### PR TITLE
clean up schemas

### DIFF
--- a/yaml/outbreak.json
+++ b/yaml/outbreak.json
@@ -1,672 +1,182 @@
 {
   "@context": {
-    "outbreak": "https://discovery.biothings.io/view/outbreak/",
-    "owl": "http://www.w3.org/2002/07/owl/",
-    "rdf": "http://www.w3.org/1999/02/22/-rdf-syntax-ns/",
-    "rdfs": "http://www.w3.org/2000/01/rdf/-schema/",
-    "schema": "http://schema.org/"
+    "schema": "http://schema.org/",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "outbreak": "http://discovery.biothings.io/view/"
   },
-  "@id": "https://discovery.biothings.io/view/outbreak/",
   "@graph": [
-    {
-      "@id": "outbreak:Product",
-      "@type": "rdfs:Class",
-      "rdfs:label": "Product",
-      "rdfs:comment": "This is the schema for describing the Product schema used for outbreak.info.",
-      "rdfs:subClassOf": {
-        "@id": "schema:Product"
-      },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
-      }
-    },
-    {"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"The name of the material or reagent","rdfs:label":"name","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":{"@id":"outbreak:Product"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:manufacturer","@type":"rdf:Property","rdfs:comment":"The name of the manufacturer of the material, biosample, or reagent","rdfs:label":"manufacturer","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:manufacturer"},"schema:domainIncludes":{"@id":"outbreak:Product"},"schema:rangeIncludes":{"@id":"outbreak:Organization"}},{"@id":"outbreak:brand","@type":"rdf:Property","rdfs:comment":"The name of the brand of the reagent, material, or biological sample (if different from the manufacturer)","rdfs:label":"brand","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:brand"},"schema:domainIncludes":{"@id":"outbreak:Product"},"schema:rangeIncludes":[{"@id":"schema:Text"},{"@id":"outbreak:Organization"}]},{"@id":"outbreak:identifier","@type":"rdf:Property","rdfs:comment":"The catalog number or identifier of the material or reagent","rdfs:label":"identifier","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":{"@id":"outbreak:Product"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:type","@type":"rdf:Property","rdfs:comment":"The type of material. Reagent, PPE, biological samples, etc.","rdfs:label":"type","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":{"@id":"outbreak:Product"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {
-      "@id": "outbreak:Instrument",
-      "@type": "rdfs:Class",
-      "rdfs:label": "Instrument",
-      "rdfs:comment": "This is the schema for describing the Instrument schema used for outbreak.info.",
-      "rdfs:subClassOf": {
-        "@id": "schema:Product"
-      },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
-      }
-    },  
-    {"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"The name of the instrument","rdfs:label":"name","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":{"@id":"outbreak:Instrument"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:manufacturer","@type":"rdf:Property","rdfs:comment":"The name of the manufacturer of the instrument","rdfs:label":"manufacturer","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:manufacturer"},"schema:domainIncludes":{"@id":"outbreak:Instrument"},"schema:rangeIncludes":{"@id":"outbreak:Organization"}},{"@id":"outbreak:brand","@type":"rdf:Property","rdfs:comment":"The brand of the instrument","rdfs:label":"brand","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:brand"},"schema:domainIncludes":{"@id":"outbreak:Instrument"},"schema:rangeIncludes":[{"@id":"schema:Text"},{"@id":"outbreak:Organization"}]},{"@id":"outbreak:model","@type":"rdf:Property","rdfs:comment":"The model number of the instrument","rdfs:label":"model","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:model"},"schema:domainIncludes":{"@id":"outbreak:Instrument"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {
-      "@id": "outbreak:Organization",
-      "@type": "rdfs:Class",
-      "rdfs:label": "Organization",
-      "rdfs:comment": "This is the schema for describing the Organization schema used for outbreak.info.",
-      "rdfs:subClassOf": {
-        "@id": "schema:Organization"
-      },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
-      }
-    },
-    {"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"The name of the organization, team or group","rdfs:label":"name","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":{"@id":"outbreak:Organization"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:alternateName","@type":"rdf:Property","rdfs:comment":"Alternative names or commonly used abbreviations for the organization, team or group","rdfs:label":"alternateName","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:alternateName"},"schema:domainIncludes":{"@id":"outbreak:Organization"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:affiliation","@type":"rdf:Property","rdfs:comment":"An overarching consortia, multi-institutional team or group in which the organization\/team\/group is a member or affiliate","rdfs:label":"affiliation","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:affiliation"},"schema:domainIncludes":{"@id":"outbreak:Organization"},"schema:rangeIncludes":{"@id":"outbreak:Organization"}},{"@id":"outbreak:affiliationStatus","@type":"rdf:Property","rdfs:comment":"The status of the organization's membership or affiliation in the overarching consortial, multi-institutional team or group (current, past)","rdfs:label":"affiliationStatus","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:additionalType"},"schema:domainIncludes":{"@id":"outbreak:Organization"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:members","@type":"rdf:Property","rdfs:comment":"Members of this organization, team, or group","rdfs:label":"members","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:members"},"schema:domainIncludes":{"@id":"outbreak:Organization"},"schema:rangeIncludes":[{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"}]},{"@id":"outbreak:membershipStatus","@type":"rdf:Property","rdfs:comment":"Status of the members of this organization","rdfs:label":"membershipStatus","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:additionalType"},"schema:domainIncludes":{"@id":"outbreak:Organization"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:isRelatedTo","@type":"rdf:Property","rdfs:comment":"A resource which a person played a role","rdfs:label":"isRelatedTo","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:isRelatedTo"},"schema:domainIncludes":{"@id":"outbreak:Organization"},"schema:rangeIncludes":[{"@id":"schema:CreativeWork"},{"@id":"schema:HowTo"}]},{"@id":"outbreak:class","@type":"rdf:Property","rdfs:comment":"A classification of the organization by a resource. Eg- for ClinicalTrials funders, it's [\"U.S. National Institutes of Health\", \"Other U.S. Federal agencies\", \"Industry\", \"All others\"]","rdfs:label":"class","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":[{"@id":"schema:CreativeWork"},{"@id":"schema:HowTo"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:role","@type":"rdf:Property","rdfs:comment":"The role of an organization in its involvement with a resource","rdfs:label":"role","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:additionalType"},"schema:domainIncludes":[{"@id":"schema:CreativeWork"},{"@id":"schema:HowTo"}],"schema:rangeIncludes":{"@id":"schema:Text"}},
     {
       "@id": "outbreak:Person",
       "@type": "rdfs:Class",
+      "rdfs:comment": "This is the Person schema for describing authors and people for outbreak.info resources",
       "rdfs:label": "Person",
-      "rdfs:comment": "This is the schema for describing the Person schema used for outbreak.info.",
       "rdfs:subClassOf": {
         "@id": "schema:Person"
       },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
+      "$validation": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "The name of the person.",
+            "type": "string"
+          },
+          "alternateName": {
+            "description": "An alias for the person.",
+            "type": "string"
+          },
+          "familyName": {
+            "description": "Family name. In the U.S., the last name of an Person. This can be used along with givenName instead of the name property.",
+            "type": "string"
+          },
+          "givenName": {
+            "description": "Given name. In the U.S., the first name of a Person. This can be used along with familyName instead of the name property.",
+            "type": "string"
+          },
+          "affiliation": {
+            "description": "An organization that this person is affiliated with. For example, a school/university, a club, or a team.",
+            "oneOf": [
+              {
+                "$ref": "#/definitions/baseOrgObject"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/baseOrgObject"
+                }
+              }
+            ]
+          },
+          "orcid": {
+            "description": "the ORCID ID of the person",
+            "type": "string"
+          },
+          "role": {
+            "description": "authorship, sponsorship, or other contribution role played by the person or organization in the creation of this resource",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            ]
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "definitions":{
+            "baseOrgObject": {
+                "@type": "outbreak:Organization",
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "alternateName": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ]   
+            }
+        }
       }
     },
-    {"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"The name of the person","rdfs:label":"name","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":{"@id":"outbreak:Person"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:alternateName","@type":"rdf:Property","rdfs:comment":"Alternative ways in which the person's name is included in a record","rdfs:label":"alternateName","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:alternateName"},"schema:domainIncludes":{"@id":"outbreak:Person"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:givenName","@type":"rdf:Property","rdfs:comment":"The given name of the person","rdfs:label":"givenName","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:givenName"},"schema:domainIncludes":{"@id":"outbreak:Person"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:familyName","@type":"rdf:Property","rdfs:comment":"The family name of the person","rdfs:label":"familyName","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:familyName"},"schema:domainIncludes":{"@id":"outbreak:Person"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:affiliation","@type":"rdf:Property","rdfs:comment":"The organization with which the person is affiliated or has membership in","rdfs:label":"affiliation","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:affiliation"},"schema:domainIncludes":{"@id":"outbreak:Person"},"schema:rangeIncludes":{"@id":"outbreak:Organization"}},{"@id":"outbreak:affiliationStatus","@type":"rdf:Property","rdfs:comment":"The status of the person's membership or affiliation in an organization, team or group (current, past)","rdfs:label":"affiliationStatus","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":{"@id":"outbreak:Person"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:orcid","@type":"rdf:Property","rdfs:comment":"The ORCID ID of the person","rdfs:label":"orcid","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":{"@id":"outbreak:Person"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:isRelatedTo","@type":"rdf:Property","rdfs:comment":"A resource which a person played a role","rdfs:label":"isRelatedTo","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:isRelatedTo"},"schema:domainIncludes":{"@id":"outbreak:Person"},"schema:rangeIncludes":[{"@id":"schema:CreativeWork"},{"@id":"schema:HowTo"}]},{"@id":"outbreak:role","@type":"rdf:Property","rdfs:comment":"The role a person played in the creation of a resource","rdfs:label":"role","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":[{"@id":"schema:CreativeWork"},{"@id":"schema:HowTo"}],"schema:rangeIncludes":{"@id":"schema:Text"}},
     {
-      "@id": "outbreak:DataDownload",
-      "@type": "rdfs:Class",
-      "rdfs:label": "DataDownload",
-      "rdfs:comment": "This is the schema for describing the DataDownload schema used for outbreak.info.",
-      "rdfs:subClassOf": {
-        "@id": "schema:DataDownload"
+      "@id": "outbreak:orcid",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "the ORCID ID of the person",
+      "rdfs:label": "orcid",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Person"
       },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
-      }
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
     },
-    {"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"The name of the download if available","rdfs:label":"name","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":{"@id":"outbreak:DataDownload"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:contentUrl","@type":"rdf:Property","rdfs:comment":"Link to the location where the dataset can be found, ideally a permanent URL","rdfs:label":"contentUrl","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:distribution"},"schema:domainIncludes":{"@id":"outbreak:DataDownload"},"schema:rangeIncludes":{"@id":"schema:URL"}},{"@id":"outbreak:dateModified","@type":"rdf:Property","rdfs:comment":"Date which the particular DataDownload (file) has been changed","rdfs:label":"dateModified","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:dateModified"},"schema:domainIncludes":{"@id":"outbreak:DataDownload"},"schema:rangeIncludes":{"@id":"schema:Date"}},
     {
-      "@id": "outbreak:MonetaryGrant",
+      "@id": "outbreak:Organization",
       "@type": "rdfs:Class",
-      "rdfs:label": "MonetaryGrant",
-      "rdfs:comment": "This is the schema for describing the MonetaryGrant schema used for outbreak.info.",
+      "rdfs:comment": "This is the organization schema for describing authors, funders and other organizations referenced by outbreak.info resources",
+      "rdfs:label": "Organization",
       "rdfs:subClassOf": {
-        "@id": "schema:MonetaryGrant"
-      },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
-      }
-    },
-    {"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"The name of the monetary grant","rdfs:label":"name","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":{"@id":"outbreak:MonetaryGrant"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:identifier","@type":"rdf:Property","rdfs:comment":"The grant ID or an identifier associated with the grant","rdfs:label":"identifier","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":{"@id":"outbreak:MonetaryGrant"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:url","@type":"rdf:Property","rdfs:comment":"The url for the grant (if available)","rdfs:label":"url","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:url"},"schema:domainIncludes":{"@id":"outbreak:MonetaryGrant"},"schema:rangeIncludes":{"@id":"schema:URL"}},{"@id":"outbreak:funder","@type":"rdf:Property","rdfs:comment":"The funding organization of the grant","rdfs:label":"funder","owl:cardinality":"many","marginality":"required","rdfs:sameAs":{"@id":"schema:funder"},"schema:domainIncludes":{"@id":"outbreak:MonetaryGrant"},"schema:rangeIncludes":{"@id":"outbreak:Organization"}},{"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"The name of the funding organization","rdfs:label":"name","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":{"@id":"outbreak:Organization"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:recipient","@type":"rdf:Property","rdfs:comment":"The person or organization to whom or to which the grant was awarded","rdfs:label":"recipient","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:recipient"},"schema:domainIncludes":{"@id":"outbreak:MonetaryGrant"},"schema:rangeIncludes":[{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"}]},{"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"The name of the recipient of the grant","rdfs:label":"name","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":[{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:affiliation","@type":"rdf:Property","rdfs:comment":"The affiliation of the recipient of the grant","rdfs:label":"affiliation","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:affiliation"},"schema:domainIncludes":[{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"}],"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {
-      "@id": "outbreak:Correction",
-      "@type": "rdfs:Class",
-      "rdfs:label": "Correction",
-      "rdfs:comment": "This is the schema for describing the Correction schema used for outbreak.info.",
-      "rdfs:subClassOf": {
-        "@id": "schema:Thing"
-      },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
-      }
-    },
-    {"@id":"outbreak:correctionType","@type":"rdf:Property","rdfs:comment":"Type of notice: (correction, retraction, expression of convern, withdrawal, erratum, update, correction\/republication, preprint, peer reviewed version)","rdfs:label":"correctionType","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":{"@id":"outbreak:Correction"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:url","@type":"rdf:Property","rdfs:comment":"The url to the notice if available","rdfs:label":"url","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:url"},"schema:domainIncludes":{"@id":"outbreak:Correction"},"schema:rangeIncludes":{"@id":"schema:URL"}},{"@id":"outbreak:identifier","@type":"rdf:Property","rdfs:comment":"DOI (preferred) or PMID (e.g., 10.1126\/sciimmunol.aaw6329, PMID:31471352)","rdfs:label":"identifier","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":{"@id":"outbreak:Correction"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:doi","@type":"rdf:Property","rdfs:comment":"DOI","rdfs:label":"doi","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":{"@id":"outbreak:Correction"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:pmid","@type":"rdf:Property","rdfs:comment":"PMID","rdfs:label":"pmid","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":{"@id":"outbreak:Correction"},"schema:rangeIncludes":{"@id":"schema:Number"}},{"@id":"outbreak:datePublished","@type":"rdf:Property","rdfs:comment":"PublicationDate online if available","rdfs:label":"datePublished","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:datePublished"},"schema:domainIncludes":{"@id":"outbreak:Correction"},"schema:rangeIncludes":{"@id":"schema:Date"}},
-    {
-      "@id": "outbreak:StudyEvent",
-      "@type": "rdfs:Class",
-      "rdfs:label": "StudyEvent",
-      "rdfs:comment": "This is the schema for describing the StudyEvent schema used for outbreak.info.",
-      "rdfs:subClassOf": {
-        "@id": "schema:Thing"
-      },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
-      }
-    },
-    {"@id":"outbreak:studyEventType","@type":"rdf:Property","rdfs:comment":"Type of the event status such as StudyStart, PrimaryCompletion, Completion, StudyFirstSubmit, StudyFirstSubmitQC, LastUpdateSubmit","rdfs:label":"studyEventType","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:additionalType"},"schema:domainIncludes":{"@id":"outbreak:StudyEvent"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:studyEventDate","@type":"rdf:Property","rdfs:comment":"StartDate, Primary CompletionDate, CompletionDate, StudyFirstSubmitDate, StudyFirstSubmitQCDate, LastUpdateSubmitDate","rdfs:label":"studyEventDate","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:temporal"},"schema:domainIncludes":{"@id":"outbreak:StudyEvent"},"schema:rangeIncludes":{"@id":"schema:Date"}},{"@id":"outbreak:studyEventDateType","@type":"rdf:Property","rdfs:comment":"the type of date provided (actual, anticipated, or estimated)","rdfs:label":"studyEventDateType","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":{"@id":"outbreak:StudyEvent"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {
-      "@id": "outbreak:StudyStatus",
-      "@type": "rdfs:Class",
-      "rdfs:label": "StudyStatus",
-      "rdfs:comment": "This is the schema for describing the StudyStatus schema used for outbreak.info.",
-      "rdfs:subClassOf": {
-        "@id": "schema:Thing"
-      },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
-      }
-    },
-    {"@id":"outbreak:status","@type":"rdf:Property","rdfs:comment":"The recruitment status of the study","rdfs:label":"status","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:status"},"schema:domainIncludes":{"@id":"outbreak:StudyStatus"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:statusExpandedAccess","@type":"rdf:Property","rdfs:comment":"Flag for whether or not the study has expanded Access status","rdfs:label":"statusExpandedAccess","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:additionalType"},"schema:domainIncludes":{"@id":"outbreak:StudyStatus"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:statusDate","@type":"rdf:Property","rdfs:comment":"The date that the status was verified. Equivalent to NCT's StatusVerifiedDate","rdfs:label":"statusDate","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:temporal"},"schema:domainIncludes":{"@id":"outbreak:StudyStatus"},"schema:rangeIncludes":{"@id":"schema:Date"}},{"@id":"outbreak:enrollmentCount","@type":"rdf:Property","rdfs:comment":"The number of participants enrolled in the study","rdfs:label":"enrollmentCount","owl:cardinality":"one","marginality":"recommended","schema:domainIncludes":{"@id":"outbreak:StudyStatus"},"schema:rangeIncludes":{"@id":"schema:Number"}},{"@id":"outbreak:enrollmentType","@type":"rdf:Property","rdfs:comment":"The type of estimation used to determine the enrollmentCount (actual counts, target size, etc.)","rdfs:label":"enrollmentType","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:additionalType"},"schema:domainIncludes":{"@id":"outbreak:StudyStatus"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:whyStopped","@type":"rdf:Property","rdfs:comment":"A brief explanation of the reason(s) why such clinical study was stopped (for a clinical study that is \"Suspended,\" \"Terminated,\" or \"Withdrawn\" prior to its planned completion as anticipated by the protocol)","rdfs:label":"whyStopped","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:description"},"schema:domainIncludes":{"@id":"outbreak:StudyStatus"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {
-      "@id": "outbreak:StudyDesign",
-      "@type": "rdfs:Class",
-      "rdfs:label": "StudyDesign",
-      "rdfs:comment": "This is the schema for describing the StudyDesign schema used for outbreak.info.",
-      "rdfs:subClassOf": {
-        "@id": "schema:Thing"
-      },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
-      }
-    },
-    {"@id":"outbreak:studyType","@type":"rdf:Property","rdfs:comment":"Type of human study, can be subtypes of observational study or interventional studies and may include the temporal relationship of observation period to time of participant enrollment.","rdfs:label":"studyType","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:additionalType"},"schema:domainIncludes":{"@id":"outbreak:StudyDesign"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:phase","@type":"rdf:Property","rdfs:comment":"Stage or phase of the study in the U.S.","rdfs:label":"phase","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:additionalType"},"schema:domainIncludes":{"@id":"outbreak:StudyDesign"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:phaseNumber","@type":"rdf:Property","rdfs:comment":"The number of the phase or stage of the study","rdfs:label":"phaseNumber","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:additionalType"},"schema:domainIncludes":{"@id":"outbreak:StudyDesign"},"schema:rangeIncludes":{"@id":"schema:Number"}},{"@id":"outbreak:designAllocation","@type":"rdf:Property","rdfs:comment":"The method by which the study participants were allocated into groups","rdfs:label":"designAllocation","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:additionalType"},"schema:domainIncludes":{"@id":"outbreak:StudyDesign"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:designModel","@type":"rdf:Property","rdfs:comment":"The general design of the strategy for assigning interventions to participants in a clinical intervention study OR the general design of the strategy for identifying and following up with participants during an observational study.","rdfs:label":"designModel","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:additionalType"},"schema:domainIncludes":{"@id":"outbreak:StudyDesign"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:designPrimaryPurpose","@type":"rdf:Property","rdfs:comment":"The primary purpose of the study","rdfs:label":"designPrimaryPurpose","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:additionalType"},"schema:domainIncludes":{"@id":"outbreak:StudyDesign"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:designWhoMasked","@type":"rdf:Property","rdfs:comment":"The people who not know which participants have been assigned to which interventions.","rdfs:label":"designWhoMasked","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:additionalType"},"schema:domainIncludes":{"@id":"outbreak:StudyDesign"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:designStudyText","@type":"rdf:Property","rdfs:comment":"String description of the study design if structured information not available","rdfs:label":"designStudyText","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:description"},"schema:domainIncludes":{"@id":"outbreak:StudyDesign"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {
-      "@id": "outbreak:StudyLocation",
-      "@type": "rdfs:Class",
-      "rdfs:label": "StudyLocation",
-      "rdfs:comment": "This is the schema for describing the StudyLocation schema used for outbreak.info.",
-      "rdfs:subClassOf": {
-        "@id": "schema:Place"
-      },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
-      }
-    },
-    {"@id":"outbreak:studyLocation","@type":"rdf:Property","rdfs:comment":"The location of the study","rdfs:label":"studyLocation","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:studyLocation"},"schema:domainIncludes":{"@id":"outbreak:ClinicalTrial"},"schema:rangeIncludes":{"@id":"schema:Place"}},{"@id":"outbreak:studyLocationCity","@type":"rdf:Property","rdfs:comment":"The city in which the facility used for the study is located","rdfs:label":"studyLocationCity","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:studyLocation"},"schema:domainIncludes":{"@id":"outbreak:ClinicalTrial"},"schema:rangeIncludes":{"@id":"schema:City"}},{"@id":"outbreak:studyLocationState","@type":"rdf:Property","rdfs:comment":"The state or province in which the facility used for the study is located","rdfs:label":"studyLocationState","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:studyLocation"},"schema:domainIncludes":{"@id":"outbreak:ClinicalTrial"},"schema:rangeIncludes":{"@id":"schema:State"}},{"@id":"outbreak:studyLocationCountry","@type":"rdf:Property","rdfs:comment":"The country in which the facility used for the study is located","rdfs:label":"studyLocationCountry","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:studyLocation"},"schema:domainIncludes":{"@id":"outbreak:ClinicalTrial"},"schema:rangeIncludes":{"@id":"schema:Country"}},{"@id":"outbreak:studyLocationStatus","@type":"rdf:Property","rdfs:comment":"The recruitment status of the study at the specific study site","rdfs:label":"studyLocationStatus","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:additionalType"},"schema:domainIncludes":{"@id":"outbreak:ClinicalTrial"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {
-      "@id": "outbreak:Intervention",
-      "@type": "rdfs:Class",
-      "rdfs:label": "Intervention",
-      "rdfs:comment": "This is the schema for describing the Intervention schema used for outbreak.info.",
-      "rdfs:subClassOf": {
-        "@id": "schema:Thing"
-      },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
-      }
-    },
-    {"@id":"outbreak:category","@type":"rdf:Property","rdfs:comment":"The category of an intervention in the study","rdfs:label":"category","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:additionalType"},"schema:domainIncludes":{"@id":"outbreak:Intervention"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"The name of the intervention in the study","rdfs:label":"name","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":{"@id":"outbreak:Intervention"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:description","@type":"rdf:Property","rdfs:comment":"A description of the intervention in the study","rdfs:label":"description","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:description"},"schema:domainIncludes":{"@id":"outbreak:Intervention"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {
-      "@id": "outbreak:ArmGroup",
-      "@type": "rdfs:Class",
-      "rdfs:label": "ArmGroup",
-      "rdfs:comment": "This is the schema for describing the ArmGroup schema used for outbreak.info.",
-      "rdfs:subClassOf": {
-        "@id": "schema:Thing"
-      },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
-      }
-    },
-    {"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"The name of the arm or factor (can include a specific intervention, a placebo or even a lack of intervention, ie- 'no intervention' group)","rdfs:label":"name","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":{"@id":"outbreak:ArmGroup"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:role","@type":"rdf:Property","rdfs:comment":"The role of the arm or factor in the study this is equivalent to the ArmType in ClinicalTrials.gov","rdfs:label":"role","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:additionalType"},"schema:domainIncludes":{"@id":"outbreak:ArmGroup"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:description","@type":"rdf:Property","rdfs:comment":"A description of the arm or factor","rdfs:label":"description","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:description"},"schema:domainIncludes":{"@id":"outbreak:ArmGroup"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:intervention","@type":"rdf:Property","rdfs:comment":"The interventions (if any) in this ArmGroup","rdfs:label":"intervention","owl:cardinality":"many","marginality":"optional","schema:domainIncludes":{"@id":"outbreak:ArmGroup"},"schema:rangeIncludes":{"@id":"outbreak:Intervention"}},{"@id":"outbreak:category","@type":"rdf:Property","rdfs:comment":"The category of the arm or factor in the study","rdfs:label":"category","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:additionalType"},"schema:domainIncludes":{"@id":"outbreak:Intervention"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"The name of the intervention in the study","rdfs:label":"name","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":{"@id":"outbreak:Intervention"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:description","@type":"rdf:Property","rdfs:comment":"A description of the intervention in the study","rdfs:label":"description","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:description"},"schema:domainIncludes":{"@id":"outbreak:Intervention"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {
-      "@id": "outbreak:Eligibility",
-      "@type": "rdfs:Class",
-      "rdfs:label": "Eligibility",
-      "rdfs:comment": "This is the schema for describing the Eligibility schema used for outbreak.info.",
-      "rdfs:subClassOf": {
-        "@id": "schema:Thing"
-      },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
-      }
-    },
-    {"@id":"outbreak:inclusionCriteria","@type":"rdf:Property","rdfs:comment":"criteria for inclusion in the study","rdfs:label":"inclusionCriteria","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:qualifications"},"schema:domainIncludes":{"@id":"outbreak:Eligibility"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:minimumAge","@type":"rdf:Property","rdfs:comment":"the minimum age for a participant to be included in the study","rdfs:label":"minimumAge","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:requiredMinAge"},"schema:domainIncludes":{"@id":"outbreak:Eligibility"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:maximumAge","@type":"rdf:Property","rdfs:comment":"the maximum age for a participant to be included in the study","rdfs:label":"maximumAge","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:requiredMaxAge"},"schema:domainIncludes":{"@id":"outbreak:Eligibility"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:gender","@type":"rdf:Property","rdfs:comment":"the sex requirement to be included in the study","rdfs:label":"gender","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:requiredGender"},"schema:domainIncludes":{"@id":"outbreak:Eligibility"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:genderBased","@type":"rdf:Property","rdfs:comment":"Boolean for whether or not participation is based on gender","rdfs:label":"genderBased","owl:cardinality":"one","marginality":"recommended","schema:domainIncludes":{"@id":"outbreak:Eligibility"},"schema:rangeIncludes":{"@id":"schema:Boolean"}},{"@id":"outbreak:healthyVolunteers","@type":"rdf:Property","rdfs:comment":"Boolean to indicate whether or not healthy volunteers may be included in the study","rdfs:label":"healthyVolunteers","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:additionalType"},"schema:domainIncludes":{"@id":"outbreak:Eligibility"},"schema:rangeIncludes":{"@id":"schema:Boolean"}},{"@id":"outbreak:stdAge","@type":"rdf:Property","rdfs:comment":"the age category of a participant to be included in the study if a minimum and maximum age is not specified","rdfs:label":"stdAge","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:additionalType"},"schema:domainIncludes":{"@id":"outbreak:Eligibility"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:exclusionCriteria","@type":"rdf:Property","rdfs:comment":"criteria for exclusion from the study","rdfs:label":"exclusionCriteria","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:qualifications"},"schema:domainIncludes":{"@id":"outbreak:Eligibility"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:criteriaText","@type":"rdf:Property","rdfs:comment":"The descriptive criteria as published for the Clinical Trial","rdfs:label":"criteriaText","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:description"},"schema:domainIncludes":{"@id":"outbreak:Eligibility"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {
-      "@id": "outbreak:Outcome",
-      "@type": "rdfs:Class",
-      "rdfs:label": "Outcome",
-      "rdfs:comment": "This is the schema for describing the Outcome schema used for outbreak.info.",
-      "rdfs:subClassOf": {
-        "@id": "schema:Thing"
-      },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
-      }
-    },
-    {"@id":"outbreak:outcomeMeasure","@type":"rdf:Property","rdfs:comment":"The outcome measure for the study","rdfs:label":"outcomeMeasure","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:description"},"schema:domainIncludes":{"@id":"outbreak:Outcome"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:outcomeTimeFrame","@type":"rdf:Property","rdfs:comment":"The specific time point(s) and overall duration of evaluation must be specified in this section. ","rdfs:label":"outcomeTimeFrame","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:duration"},"schema:domainIncludes":{"@id":"outbreak:Outcome"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:outcomeType","@type":"rdf:Property","rdfs:comment":"The classification of the outcome measure as either primary, secondary, or exploratory","rdfs:label":"outcomeType","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:additionalType"},"schema:domainIncludes":{"@id":"outbreak:Outcome"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {
-      "@id": "outbreak:Analysis",
-      "@type": "rdfs:Class",
-      "rdfs:label": "Analysis",
-      "rdfs:comment": "This is the schema for describing the Analysis schema used for outbreak.info.",
-      "rdfs:subClassOf": {
-        "@id": "schema:CreativeWork"
-      },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
+        "@id": "schema:Organization"
       },
       "$validation": {
-          "$schema": "http://json-schema.org/draft-07/schema#",
-          "type": "object",
-          "properties": {
-            "name": {
-              "description": "The name of the item.",
-              "type": "string"
-            },
-            "description": {
-              "description": "A description of the item.",
-              "type": "string"
-            },
-            "url": {
-              "description": "The url of the item",
-              "format": "uri",
-              "type": "string"
-            },
-            "identifier": {
-              "description": "An identifier associated with the analysis if available",
-              "type": "string"
-            },
-            "doi": {
-              "description": "A DOI associated with the analysis if available",
-              "type": "string"
-            },
-            "hasDownloadableContent": {
-              "description": "Indicates the site has content that can be downloaded (raw data, data sheets, charts, etc)",
-              "type": "boolean"
-            },
-            "license": {
-              "description": "A license document that applies to this content, typically indicated by URL",
-              "type": "string"
-            },
-            "domainUrl": {
-              "description": "The domain name or main site on which webpage or specific url can be found",
-              "format": "uri",
-              "type": "string"
-            },
-            "datePublished": {
-              "description": "PublicationDate of the analysis online if available",
-              "format": "date",
-              "type": "string"
-            },
-            "dateModified": {
-              "description": "Most recent date for which the analysis model itself was updated",
-              "format": "date",
-              "type": "string"
-            },
-            "assumption": {
-              "description": "Statement of assumptions / limitations of the model",
-              "oneOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                }
-              ]
-            },
-            "keywords": {
-              "description": "keywords",
-              "oneOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                }
-              ]
-            },
-            "topicCategory": {
-              "description": "Applicable outbreak.info category",
-              "oneOf": [
-                {
-                  "enum": [
-                    "Clinical",
-                    "Case Descriptions",
-                    "Risk Factors",
-                    "Diagnosis",
-                    "Symptoms",
-                    "Rapid Diagnostics",
-                    "Antibody Detection",
-                    "Virus Detection",
-                    "Testing Prevalence",
-                    "Pathology/Radiology",
-                    "Forecasting",
-                    "Mechanism",
-                    "Virus Factors",
-                    "Host Factors",
-                    "Immunological Response",
-                    "Mechanism of Infection",
-                    "Mechanism of Transmission",
-                    "Prevention",
-                    "Public Health Interventions",
-                    "Individual Prevention",
-                    "Transmission",
-                    "Host/Intermediate Reservoirs",
-                    "Viral Shedding / Persistence",
-                    "Treatment",
-                    "Vaccines",
-                    "Pharmaceutical Treatments",
-                    "Medical Care",
-                    "Repurposing",
-                    "Biologics",
-                    "Behavioral Research",
-                    "Epidemiology",
-                    "Classical Epidemiology",
-                    "Molecular Epidemiology"
-                  ]
-                },
-                {
-                  "type": "array",
-                  "items": {
-                      "enum": [
-                        "Clinical",
-                        "Case Descriptions",
-                        "Risk Factors",
-                        "Diagnosis",
-                        "Symptoms",
-                        "Rapid Diagnostics",
-                        "Antibody Detection",
-                        "Virus Detection",
-                        "Testing Prevalence",
-                        "Pathology/Radiology",
-                        "Forecasting",
-                        "Mechanism",
-                        "Virus Factors",
-                        "Host Factors",
-                        "Immunological Response",
-                        "Mechanism of Infection",
-                        "Mechanism of Transmission",
-                        "Prevention",
-                        "Public Health Interventions",
-                        "Individual Prevention",
-                        "Transmission",
-                        "Host/Intermediate Reservoirs",
-                        "Viral Shedding / Persistence",
-                        "Treatment",
-                        "Vaccines",
-                        "Pharmaceutical Treatments",
-                        "Medical Care",
-                        "Repurposing",
-                        "Biologics",
-                        "Behavioral Research",
-                        "Epidemiology",
-                        "Classical Epidemiology",
-                        "Molecular Epidemiology"
-                      ]
-                  }
-                }
-              ]
-
-            },
-            "analysisTechnique": {
-                "description": "A technique or technology used in a analysis.",
-                "oneOf": [
-                  {
-                    "$ref": "#/definitions/moreControlledVocabulary"
-                  },
-                  {
-                    "enum": [
-                        "predictive/forecasting models",
-                        "observation/visualization models"
-                    ]
-                  },
-                  {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/definitions/moreControlledVocabulary"
-                    }
-                  },  
-                  {
-                    "type": "array",
-                    "enum": [
-                        "predictive/forecasting models",
-                        "observation/visualization models"
-                    ]
-                  }
-                ]
-              },
-            "infectiousAgent": {
-            "description": "infectious agents(s) which are the focus of the dataset",
-            "oneOf": [{
-                "$ref": "#/definitions/miscControlledVocabulary"
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "The name of the organization.",
+            "type": "string"
+          },
+          "alternateName": {
+            "description": "An alias or acronym for the organization.",
+            "type": "string"
+          },
+          "affiliation": {
+            "description": "consortia or other organizations with which this organization is affiliated",
+            "oneOf": [
+              {
+                "$ref": "#/definitions/baseOrgObject"
               },
               {
                 "type": "array",
                 "items": {
-                  "$ref": "#/definitions/miscControlledVocabulary"
+                    "$ref": "#/definitions/baseOrgObject"
                 }
               }
             ]
           },
-            "infectiousDisease": {
-              "description": "The disease or medical conditions caused by the infectious agent. Important as some agents may cause multiple diseases",
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/diseaseVocabulary"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/diseaseVocabulary"
-                  }
-                }
-              ]
-            },
-            "analysisTopic": {
-              "description": "The underlying question, goal, or aim of the analysis",
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/controlledVocabulary"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                        "$ref": "#/definitions/controlledVocabulary"
-                  }
-                }
-              ]
-            },
-            "author": {
-              "description": "The author of this content or rating.",
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/person"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/person"
-                  }
-                },
-                {
-                  "$ref": "#/definitions/organization"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/organization"
-                  }
-                }
-              ]
-            },
-            "contributor": {
-              "description": "A secondary contributor to the CreativeWork or Event.",
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/person"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/person"
-                  }
-                },
-                {
-                  "$ref": "#/definitions/organization"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/organization"
-                  }
-                }
-              ]
-            },
-            "maintainer": {
-              "description": "A maintainer of a Dataset, software package (SoftwareApplication), or other Project.",
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/person"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/person"
-                  }
-                },
-                {
-                  "$ref": "#/definitions/organization"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/organization"
-                  }
-                }
-              ]
-            },
-            "funding": {
-              "description": "A person or organization that supports (sponsors) something through some kind of financial contribution.",
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/funding"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/funding"
-                  }
-                }
-              ]
-            },
-            "citedBy": {
-              "description": "A resource (publication, protocol, dataset, etc.) which was derived from this protocol",
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/citation"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/citation"
-                  }
-                }
-              ]
-            },
-            "isBasedOn": {
-              "description": "A resource (publication, protocol, dataset, etc) from which this analysis was derived",
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/citation"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/citation"
-                  }
-                }
-              ]
-            },
-            "isRelatedTo": {
-              "description": "Other resources related to, but not a derivative of nor derived from this analysis",
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/citation"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/citation"
-                  }
-                }
-              ]
-            },
-            "curatedBy": {
-            "description": "The source from which this Dataset was identified for inclusion into Outbreak.info. Provides provenance for a resource which was curated by another.",
-            "anyOf": [{
-                "$ref": "#/definitions/citation"
-              },
+          "class": {
+            "description": "A classification of the organization by a resource. Eg- for ClinicalTrials funders, it's [U.S. National Institutes of Health, Other U.S. Federal agencies, Industry, All others]",
+            "type": "string"
+          },
+          "role": {
+            "description": "The role of an organization in its involvement with a resource",
+            "oneOf": [
               {
-                "$ref": "#/definitions/person"
-              },
-              {
-                "$ref": "#/definitions/organization"
+                "type": "string"
               },
               {
                 "type": "array",
                 "items": {
-                  "$ref": "#/definitions/person"
-                }
-              },
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/definitions/organization"
-                }
-              },
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/definitions/citation"
+                    "type": "string"
                 }
               }
             ]
           },
-            "curationDate":{
-            "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
-            "type": "string",
-            "format": "date"
+          "members": {
+            "description": "Members of this organization, team, or group",
+            "oneOf": [
+              {
+                "$ref": "#/definitions/basePersonObject"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/basePersonObject"
+                }
+              }
+            ]
           }
-          },
-          "required": [
-            "url",
-            "identifier",
-            "name",
-            "description",
-            "author"
-          ],
-          "definitions": {
-            "controlledVocabulary": {
-              "definition": "collection of vocabulary terms defined in ontologies",
-              "@type": "CreativeWork",
-              "type": "string",
-              "strict": false,
-              "vocabulary": {
-                  "ontology": [
-                    "covid19",
-                    "cido",
-                    "epo"
-                  ],
-                  "children_of": [
-                  "https://bioportal.bioontology.org/ontologies/COVID19",
-                  "http://purl.obolibrary.org/obo/cido.owl",
-                  "http://purl.obolibrary.org/obo/epo"
-                ]
-                }
-            },
-            "miscControlledVocabulary": {
-              "description": "collection of vocabulary terms defined in ontologies",
-              "@type": "CreativeWork",
-              "type": "string",
-              "strict": false,
-              "vocabulary": {
-                  "ontology": ["ncbitaxon"],
-                  "children_of": ["http://purl.obolibrary.org/obo/NCBITaxon_10239"]
-                }
-            },
-            "moreControlledVocabulary": {
-              "definition": "collection of vocabulary terms defined in ontologies",
-              "@type": "CreativeWork",
-              "type": "string",
-              "strict": false,
-              "vocabulary": {
-                  "ontology": [
-                    "mamo"
-                  ],
-                  "children_of": [
-                    "http://identifiers.org/mamo/MAMO_0000037"
-                  ]
-                }
-            },
-            "diseaseVocabulary": {
-              "description": "collection of vocabulary terms defined in ontologies",
-              "@type": "CreativeWork",
-              "type": "string",
-              "strict": false,
-              "vocabulary": {
-                "ontology": ["mondo"],
-                "children_of": ["http://purl.obolibrary.org/obo/MONDO_0000001"]              
-              }
-            },
+        },
+        "required": [
+          "name"
+        ],
+        "definitions": {
             "baseOrgObject":{
-                "description": "A barebones Organization object to work around recursion issues in DDE",
-                "@type": "Organization",
+                "description": "Affiliated Organization",
+                "@type": "outbreak:Organization",
                 "type": "object",
                 "properties": {
                   "name": {
@@ -681,243 +191,453 @@
                 "required": [
                   "name"
                 ]              
-              }, 
-            "person": {
-                  "description": "Reusable person definition",
-                  "@type": "Person",
-                  "type": "object",
-                  "properties": {
+            },
+            "basePersonObject":{
+                "@type": "outbreak:Person",
+                "type": "object",
+                "properties": {
                     "name": {
-                      "type": "string"
+                        "type": "string"
+                    },
+                    "alternateName": {
+                        "type": "string"
                     },
                     "givenName": {
-                      "type": "string"
+                        "type": "string"
                     },
                     "familyName": {
-                      "type": "string"
+                        "type": "string"
                     },
                     "orcid": {
-                      "type": "string"
+                        "type": "string"
                     },
                     "affiliation": {
-                      "oneOf": [
-                        {
-                          "$ref": "#/definitions/baseOrgObject"
-                        },
-                        {
-                          "type": "array",
-                          "items": {
+                        "description": "consortia or other organizations with which this person is affiliated",
+                        "oneOf": [
+                          {
                             "$ref": "#/definitions/baseOrgObject"
+                          },
+                          {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/baseOrgObject"
+                            }
                           }
-                        }
-                      ]
-                    }
-                  },
-                  "required": [
+                        ]
+                      }
+                },
+                "required": [
                     "name"
-                  ]
-                },
-            "memberObject": {
-                  "description": "Reusable person definition accounting for recursion issues in DDE",
-                  "@type": "Person",
-                  "type": "object",
-                  "properties": {
-                    "name": {
-                      "type": "string"
-                    },
-                    "givenName": {
-                      "type": "string"
-                    },
-                    "familyName": {
-                      "type": "string"
-                    },
-                    "orcid": {
-                      "type": "string"
-                    },
-                    "affiliation": {
-                      "oneOf": [
-                        {
-                          "$ref": "#/definitions/baseOrgObject"
-                        },
-                        {
-                          "type": "array",
-                          "items": {
-                            "$ref": "#/definitions/baseOrgObject"
-                          }
-                        }
-                      ]
-                    }
-                  },
-                  "required": [
-                    "name"
-                  ]
-                },
-            "organization": {
-                "description": "Reusable organization definition",
-                "@type": "Organization",
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": "string"
-                  },
-                  "alternateName": {
-                    "type": "string"
-                  },
-                  "affiliation": {
-                    "$ref": "#/definitions/baseOrgObject"
-                  },
-                  "members": {
-                     "oneOf": [
-                        {
-                          "$ref": "#/definitions/memberObject"
-                        },
-                        {
-                          "type": "array",
-                          "items": {
-                            "$ref": "#/definitions/memberObject"
-                          }
-                        }
-                      ]
-                  }
-                },
-                "required": [
-                  "name"
-                ]
-              },
-            "citation": {
-                "description": "A citation object for a resource which is cited by the Analysis (ie- is a derivative of the Analysis) , related to the Analysis, or from which the Analysis was based on (ie- is derived from).",
-                "@type": "Thing",
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "description": "Name of or title of the citation",
-                    "type": "string"
-                  },
-                  "identifier": {
-                    "description": "An identifier associated with the citation",
-                    "type": "string"
-                  },
-                  "pmid": {
-                    "description": "A pubmed identifier if available",
-                    "type": "string"
-                  },
-                  "doi": {
-                    "description": "A doi if available",
-                    "type": "string"
-                  },
-                  "type": {
-                    "description": "The type of resource",
-                    "enum": [
-                      "Dataset",
-                      "Publication",
-                      "ClinicalTrial", 
-                      "Analysis",
-                      "Protocol", 
-                      "SoftwareApplication",
-                      "Other"
-                      ]
-                  },
-                  "url": {
-                    "description": "The url of the resource cited.",
-                    "type": "string",
-                    "format": "uri"
-                  },
-                  "versionDate": {
-                    "description": "The version date of the resource used at the time of the creation of the citation as certain resources (protocols, datasets) may change frequently over time.",
-                    "type": "string",
-                    "format": "date"
-                  },
-                  "citeText": {
-                    "description": "The bibliographic citation for the referenced resource as is provided",
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "name",
-                  "type"
-                ]
-          },
-            "funding": {
-                "type": "object",
-                "@type": "MonetaryGrant",
-                "description": "Information about funding support",
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "description": "The name of the monetary grant that funded/funds the analysis"
-                  },
-                  "identifier": {
-                    "type": "string",
-                    "description": "Unique identifier(s) for the grant(s) used to fund the analysis"
-                  },
-                  "funder": {
-                    "description": "name of the funding organization",
-                    "oneOf": [
-                  {
-                    "$ref": "#/definitions/baseOrgObject"
-                  },
-                  {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/definitions/baseOrgObject"
-                    }
-                  }
-                ]
-                  },
-                  "url": {
-                    "type": "string",
-                    "format": "uri",
-                    "description": "award URL"
-                  }
-                },
-                "required": [
-                  "funder"
-                ]
-          }
-          }
+                ]                
+            }
+        }
       }
     },
-    {"@id":"outbreak:url","@type":"rdf:Property","rdfs:comment":"The url of the item","rdfs:label":"url","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:url"},"schema:domainIncludes":{"@id":"outbreak:Analysis"},"schema:rangeIncludes":{"@id":"schema:URL"}},{"@id":"outbreak:domainUrl","@type":"rdf:Property","rdfs:comment":"The domain name or main site on which webpage or specific url can be found","rdfs:label":"domainUrl","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:url"},"schema:domainIncludes":{"@id":"outbreak:Analysis"},"schema:rangeIncludes":{"@id":"schema:URL"}},{"@id":"outbreak:identifier","@type":"rdf:Property","rdfs:comment":"An identifier associated with the analysis if available, otherwise one should be assigned","rdfs:label":"identifier","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":{"@id":"outbreak:Analysis"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:doi","@type":"rdf:Property","rdfs:comment":"A DOI associated with the analysis if available","rdfs:label":"doi","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":{"@id":"outbreak:Analysis"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"The name of the item.","rdfs:label":"name","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":{"@id":"outbreak:Analysis"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:description","@type":"rdf:Property","rdfs:comment":"A description of the item.","rdfs:label":"description","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:description"},"schema:domainIncludes":{"@id":"outbreak:Analysis"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:author","@type":"rdf:Property","rdfs:comment":"The author of this content or rating.","rdfs:label":"author","owl:cardinality":"many","marginality":"required","rdfs:sameAs":{"@id":"schema:author"},"schema:domainIncludes":{"@id":"outbreak:Analysis"},"schema:rangeIncludes":[{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"}]},{"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"The name of the author as provided by the resource","rdfs:label":"name","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":[{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:affiliation","@type":"rdf:Property","rdfs:comment":"The affiliation of the author","rdfs:label":"affiliation","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:affiliation"},"schema:domainIncludes":[{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"}],"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:funding","@type":"rdf:Property","rdfs:comment":"Funding for the generation of the analysis","rdfs:label":"funding","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"outbreak:MonetaryGrant"},"schema:domainIncludes":{"@id":"outbreak:Analysis"},"schema:rangeIncludes":{"@id":"outbreak:MonetaryGrant"}},{"@id":"outbreak:funder","@type":"rdf:Property","rdfs:comment":"The funder of the analysis","rdfs:label":"funder","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:funder"},"schema:domainIncludes":{"@id":"outbreak:MonetaryGrant"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:identifier","@type":"rdf:Property","rdfs:comment":"The identifier of the grant (if available)","rdfs:label":"identifier","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":{"@id":"outbreak:MonetaryGrant"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:hasDownloadableContent","@type":"rdf:Property","rdfs:comment":"Indicates the site has content that can be downloaded (raw data, data sheets, charts, etc)","rdfs:label":"hasDownloadableContent","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:isAccessibleForFree"},"schema:domainIncludes":{"@id":"outbreak:Analysis"},"schema:rangeIncludes":{"@id":"schema:Boolean"}},{"@id":"outbreak:infectiousAgent","@type":"rdf:Property","rdfs:comment":"The actual infectious agent, such as a specific bacterium","rdfs:label":"infectiousAgent","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:infectiousAgent"},"schema:domainIncludes":{"@id":"outbreak:Analysis"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:infectiousDisease","@type":"rdf:Property","rdfs:comment":"The disease caused by the infectious agent. Important as some agents may cause multiple diseases","rdfs:label":"infectiousDisease","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:infectousDisease"},"schema:domainIncludes":{"@id":"outbreak:Analysis"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:license","@type":"rdf:Property","rdfs:comment":"A license document that applies to this content, typically indicated by URL","rdfs:label":"license","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:license"},"schema:domainIncludes":{"@id":"outbreak:Analysis"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:datePublished","@type":"rdf:Property","rdfs:comment":"PublicationDate of the analysis online if available","rdfs:label":"datePublished","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:datePublished"},"schema:domainIncludes":{"@id":"outbreak:Analysis"},"schema:rangeIncludes":{"@id":"schema:Date"}},{"@id":"outbreak:dateModified","@type":"rdf:Property","rdfs:comment":"Most recent date for which the analysis model itself was updated","rdfs:label":"dateModified","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:dateModified"},"schema:domainIncludes":{"@id":"outbreak:Analysis"},"schema:rangeIncludes":{"@id":"schema:Date"}},{"@id":"outbreak:analysisTechnique","@type":"rdf:Property","rdfs:comment":"This is the analysis type, analytical technique or mathematical model used in this analysis","rdfs:label":"analysisTechnique","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":{"@id":"outbreak:Analysis"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:analysisTopic","@type":"rdf:Property","rdfs:comment":"The underlying question, goal, or aim of the analysis","rdfs:label":"analysisTopic","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:purpose"},"schema:domainIncludes":{"@id":"outbreak:Analysis"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:assumption","@type":"rdf:Property","rdfs:comment":"Statement of assumptions \/ limitations of the model","rdfs:label":"assumption","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:text"},"schema:domainIncludes":{"@id":"outbreak:Analysis"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:citedBy","@type":"rdf:Property","rdfs:comment":"A resource (publication, protocol, dataset, etc.) which was derived from this protocol","rdfs:label":"citedBy","owl:cardinality":"many","marginality":"optional","owl:inverseOf":{"@id":"schema:isBasedOn"},"schema:domainIncludes":{"@id":"outbreak:Analysis"},"schema:rangeIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}]},{"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"name of the citedBy resource","rdfs:label":"name","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:type","@type":"rdf:Property","rdfs:comment":"type (publication, protocol, dataset, code, etc.) of the citedBy resource","rdfs:label":"type","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:additionalType"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:identifier","@type":"rdf:Property","rdfs:comment":"identifier (pmid, WHO protocol id, etc.) of the citedby resource","rdfs:label":"identifier","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:isBasedOn","@type":"rdf:Property","rdfs:comment":"A resource (publication, protocol, dataset, etc) from which this analysis was derived","rdfs:label":"isBasedOn","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:isBasedOn"},"schema:domainIncludes":{"@id":"outbreak:Analysis"},"schema:rangeIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}]},
-    {"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"name of the isBasedOn resource","rdfs:label":"name","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:type","@type":"rdf:Property","rdfs:comment":"type (publication, protocol, dataset, code, etc.) of the isBasedOn resource","rdfs:label":"type","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:additionalType"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:identifier","@type":"rdf:Property","rdfs:comment":"identifier (pmid, WHO protocol id, etc.) of the isBasedOn resource","rdfs:label":"identifier","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:versionDate","@type":"rdf:Property","rdfs:comment":"date of the version of the resource from which this analysis was derived. Note this is NOT the same as dateModified, as the protocol may be based on an earlier 'dateModified' than is what is available from the resource","rdfs:label":"versionDate","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:releaseDate"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Date"}},{"@id":"outbreak:isRelatedTo","@type":"rdf:Property","rdfs:comment":"Other resources related to, but not a derivative of nor derived from this analysis","rdfs:label":"isRelatedTo","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:isRelatedTo"},"schema:domainIncludes":{"@id":"outbreak:Analysis"},"schema:rangeIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}]},{"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"name of related resource","rdfs:label":"name","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:type","@type":"rdf:Property","rdfs:comment":"type of related resource","rdfs:label":"type","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:additionalType"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:identifier","@type":"rdf:Property","rdfs:comment":"identifier (if available) of related resource","rdfs:label":"identifier","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:contributor","@type":"rdf:Property","rdfs:comment":"A secondary contributor to the CreativeWork or Event.","rdfs:label":"contributor","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:contributor"},"schema:domainIncludes":{"@id":"outbreak:Analysis"},"schema:rangeIncludes":{"@id":"outbreak:author"}},{"@id":"outbreak:maintainer","@type":"rdf:Property","rdfs:comment":"A maintainer of a Dataset, software package (SoftwareApplication), or other Project.","rdfs:label":"maintainer","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:maintainer"},"schema:domainIncludes":{"@id":"outbreak:Analysis"},"schema:rangeIncludes":{"@id":"outbreak:author"}},{"@id":"outbreak:keywords","@type":"rdf:Property","rdfs:comment":"keywords","rdfs:label":"keywords","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:keywords"},"schema:domainIncludes":{"@id":"outbreak:Analysis"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:topicCategory","@type":"rdf:Property","rdfs:comment":"Applicable outbreak.info category","rdfs:label":"topicCategory","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:about"},"schema:domainIncludes":{"@id":"outbreak:Analysis"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:curatedBy","@type":"rdf:Property","rdfs:comment":"The source from which this analysis was identified for inclusion into Outbreak.info. Provides provenance for a resource which was curated by another","rdfs:label":"curatedBy","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:citation"},"schema:domainIncludes":{"@id":"outbreak:Analysis"},"schema:rangeIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"},{"@id":"schema:Thing"}]},
-    {"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"name of the source from which this analysis was identified for inclusion","rdfs:label":"name","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:curationDate","@type":"rdf:Property","rdfs:comment":"The date this resource was added to outbreak.info, or the date when this resource was updated in outbreak.info","rdfs:label":"curationDate","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:releaseDate"},"schema:domainIncludes":{"@id":"outbreak:Analysis"},"schema:rangeIncludes":{"@id":"schema:Date"}},
     {
-      "@id": "outbreak:Dataset",
-      "@type": "rdfs:Class",
-      "rdfs:label": "Dataset",
-      "rdfs:comment": "This is the schema for describing the Dataset schema used for outbreak.info.",
-      "rdfs:subClassOf": {
-        "@id": "schema:Dataset"
+      "@id": "outbreak:affiliation",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "consortia or other organizations with which this organization is affiliated",
+      "rdfs:label": "affiliation",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Organization"
       },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
+      "schema:rangeIncludes": [
+        {
+          "@id": "outbreak:Organization"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:members",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Members of this organization, team, or group",
+      "rdfs:label": "members",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Organization"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "outbreak:Person"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:class",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "A classification of the organization by a resource. Eg- for ClinicalTrials funders, it's [U.S. National Institutes of Health, Other U.S. Federal agencies, Industry, All others]",
+      "rdfs:label": "class",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Organization"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:role",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "authorship, sponsorship, or other contribution role played by the person or organization in the creation of this resource. In a Clinical Study/Trial ArmGroup, it's equivalent to the ArmType in ClinicalTrials.gov",
+      "rdfs:label": "role",
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Person"},
+        {"@id": "outbreak:Organization"},
+        {"@id": "outbreak:ArmGroup"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:MonetaryGrant",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing the MonetaryGrant schema used for outbreak.info",
+      "rdfs:label": "MonetaryGrant",
+      "rdfs:subClassOf": {
+        "@id": "schema:MonetaryGrant"
       },
       "$validation": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
         "properties": {
           "name": {
-            "description": "Descriptive name of the dataset",
+            "description": "The name of the grant or funding.",
+            "type": "string"
+          },
+          "identifier": {
+            "description": "The funding or grant id",
+            "type": "string"
+          },
+          "url": {
+            "description": "URL of the grant or funding award.",
+            "type": "string",
+            "format": "uri"
+          },
+          "funder": {
+            "description": "The organization(s) that supported (sponsored) the grant through some kind of financial contribution.",
+            "oneOf": [
+              {
+                "$ref": "#/definitions/baseOrgObject"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/baseOrgObject"
+                }
+              }
+            ]
+          },
+          "recipient": {
+            "description": "The person or organization to whom or to which the grant was awarded",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/basePersonObject"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/basePersonObject"
+                }
+              },
+              {
+                "$ref": "#/definitions/baseOrgObject"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/baseOrgObject"
+                }
+              }
+            ]
+          }   
+        },
+        "required": [
+          "funder"
+        ],
+        "definitions": {
+            "baseOrgObject":{
+                "description": "Affiliated Organization",
+                "@type": "outbreak:Organization",
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "description": "name of the organization",
+                    "type": "string"
+                  },
+                  "alternateName": {
+                    "description": "Alternate name or Acronym for the organization.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ]              
+            },
+            "basePersonObject":{
+                "@type": "outbreak:Person",
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "alternateName": {
+                        "type": "string"
+                    },
+                    "givenName": {
+                        "type": "string"
+                    },
+                    "familyName": {
+                        "type": "string"
+                    },
+                    "orcid": {
+                        "type": "string"
+                    },
+                    "affiliation": {
+                        "description": "consortia or other organizations with which this person is affiliated",
+                        "oneOf": [
+                          {
+                            "$ref": "#/definitions/baseOrgObject"
+                          },
+                          {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/baseOrgObject"
+                            }
+                          }
+                        ]
+                      }
+                },
+                "required": [
+                    "name"
+                ]                
+            }
+        }
+      }
+    },
+    {
+      "@id": "outbreak:recipient",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The person or organization to whom or to which the grant was awarded",
+      "rdfs:label": "recipient",
+      "schema:domainIncludes": {
+        "@id": "outbreak:MonetaryGrant"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Person"
+        },
+        {
+          "@id": "schema:Organization"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:DataDownload",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing the DataDownload schema used for outbreak.info.",
+      "rdfs:label": "DataDownload",
+      "rdfs:subClassOf": {
+        "@id": "schema:DataDownload"
+      },
+      "$validation": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "The name of the distribution.",
+            "type": "string"
+          },
+          "contentUrl": {
+            "description": "Actual url of the data file.",
+            "type": "string",
+            "format": "uri"
+          },
+          "dateModified": {
+            "description": "The date on which the distribution was most recently modified or when the item's entry was modified within a DataFeed.",
+            "format": "date",
+            "type": "string"
+          }
+        },
+        "required": [
+          "contentUrl",
+          "dateModified"
+        ]
+      }
+    },
+    {
+      "@id": "outbreak:CitationObject",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "A citation object for a resource which is cited by the subject (ie- is a derivative of the subject), related to the subject, or from which the subject was based on (ie- is derived from).",
+      "rdfs:label": "CitationObject",
+      "rdfs:subClassOf": {
+        "@id": "schema:CreativeWork"
+      },
+      "$validation": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "The name or title of the cited resource.",
+            "type": "string"
+          },
+          "url": {
+            "description": "URL of the cited resource.",
+            "type": "string",
+            "format": "uri"
+          },
+          "identifier": {
+            "description": "An identifier associated with the citation",
+            "type": "string"
+          },
+          "citeText": {
+            "description": "The bibliographic citation for the referenced resource as is provided",
+            "type": "string"
+          },
+          "versionDate": {
+            "description": "The version date of the resource used at the time of the creation of the citation as certain resources (protocols, datasets) may change frequently over time.",
+            "format": "date",
+            "type": "string"
+          },
+          "pmid": {
+            "description": "A pubmed identifier if available",
+            "type": "string"
+          },
+          "doi": {
+            "description": "A doi if available",
+            "type": "string"
+          },
+          "sourceType": {
+            "description": "The @type of resource",
+            "enum": [
+              "Dataset",
+              "Publication",
+              "ClinicalTrial",
+              "Analysis",
+              "Protocol",
+              "SoftwareApplication",
+              "CreativeWork"
+            ]
+          }
+        },
+        "required": [
+          "name",
+          "sourceType"
+        ]
+      }
+    },
+    {
+      "@id": "outbreak:citeText",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The bibliographic citation for the referenced resource as is provided",
+      "rdfs:label": "citeText",
+      "schema:domainIncludes": {
+        "@id": "outbreak:CitationObject"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:versionDate",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The version date of the resource used at the time of the creation of the citation as certain resources (protocols, datasets) may change frequently over time.",
+      "rdfs:label": "versionDate",
+      "schema:domainIncludes": {
+        "@id": "outbreak:CitationObject"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Date"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:sourceType",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The type of resource",
+      "rdfs:label": "sourceType",
+      "schema:domainIncludes": {
+        "@id": "outbreak:CitationObject"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:Dataset",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing the Dataset schema used for outbreak.info.",
+      "rdfs:label": "Dataset",
+      "rdfs:subClassOf": {
+        "@id": "schema:Dataset"
+      },
+      "$validation": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "Descriptive name of the dataset.",
             "type": "string"
           },
           "description": {
-            "description": "Longer description of what is contained in the dataset",
+            "description": "Longer description of what is contained in the dataset.",
             "type": "string"
           },
-          "datePublished": {
-              "description": "PublicationDate of the analysis online if available",
-              "format": "date",
-              "type": "string"
-            },
-          "dateModified": {
-              "description": "Most recent date for which the analysis model itself was updated",
-              "format": "date",
-              "type": "string"
+          "doi": {
+            "description": "The DOI for the dataset if available",
+            "type": "string"
           },
+          "identifier": {
+            "description": "An identifier for the dataset, preferably a doi",
+            "type": "string"
+          },
+          "species": {
+            "description": "Species(es) from which dataset has been collected",
+            "oneOf": [{
+                "$ref": "#/definitions/speciesControlledVocabulary"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/speciesControlledVocabulary"
+                }
+              }
+            ]
+          },
+          "infectiousAgent": {
+            "description": "infectious agents(s) which are the focus of the dataset",
+            "oneOf": [{
+                "$ref": "#/definitions/miscControlledVocabulary"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/miscControlledVocabulary"
+                }
+              }
+            ]
+          },
+          "infectiousDisease": {
+              "description": "The disease or medical conditions caused by the infectious agent. Important as some agents may cause multiple diseases",
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/diseaseVocabulary"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/diseaseVocabulary"
+                  }
+                }
+              ]
+            },
           "measurementTechnique": {
             "description": "A technique or technology used in a Dataset, corresponding to the method used for measuring the corresponding variable(s).",
             "oneOf": [{
@@ -943,14 +663,6 @@
                 }
               }
             ]
-          },
-          "identifier": {
-            "description": "identifier for the dataset",
-            "type": "string"
-          },
-          "doi": {
-            "description": "The DOI for the dataset if available",
-            "type": "string"
           },
           "author": {
             "description": "Name of the author or organization that created the dataset.  Note: schema.org/author and schema.org/organization have additional fields that can provide more information about the author/organization, if desired.",
@@ -1001,26 +713,1839 @@
               }
             ]
           },
-          "license": {
-            "description": "A license document that applies to this content, typically indicated by URL.",
-            "type": "string",
-            "format": "uri"
+          "dateModified": {
+            "description": "The date on which the CreativeWork was most recently modified or when the item's entry was modified within a DataFeed.",
+            "format": "date",
+            "type": "string"
           },
-          "species": {
-            "description": "Species(es) from which dataset has been collected",
-            "oneOf": [{
-                "$ref": "#/definitions/speciesControlledVocabulary"
+          "datePublished": {
+            "description": "Date of first broadcast/publication.",
+            "format": "date",
+            "type": "string"
+          },
+          "topicCategory": {
+            "description": "Applicable outbreak.info category",
+            "oneOf": [
+              {
+                "enum": [
+                  "Clinical",
+                  "Case Descriptions",
+                  "Risk Factors",
+                  "Diagnosis",
+                  "Symptoms",
+                  "Rapid Diagnostics",
+                  "Antibody Detection",
+                  "Virus Detection",
+                  "Testing Prevalence",
+                  "Pathology/Radiology",
+                  "Forecasting",
+                  "Mechanism",
+                  "Virus Factors",
+                  "Host Factors",
+                  "Immunological Response",
+                  "Mechanism of Infection",
+                  "Mechanism of Transmission",
+                  "Prevention",
+                  "Public Health Interventions",
+                  "Individual Prevention",
+                  "Transmission",
+                  "Host/Intermediate Reservoirs",
+                  "Viral Shedding / Persistence",
+                  "Treatment",
+                  "Vaccines",
+                  "Pharmaceutical Treatments",
+                  "Medical Care",
+                  "Repurposing",
+                  "Biologics",
+                  "Behavioral Research",
+                  "Epidemiology",
+                  "Classical Epidemiology",
+                  "Molecular Epidemiology",
+                  "Information Sciences"
+                ]
               },
               {
                 "type": "array",
                 "items": {
-                  "$ref": "#/definitions/speciesControlledVocabulary"
+                  "enum": [
+                    "Clinical",
+                    "Case Descriptions",
+                    "Risk Factors",
+                    "Diagnosis",
+                    "Symptoms",
+                    "Rapid Diagnostics",
+                    "Antibody Detection",
+                    "Virus Detection",
+                    "Testing Prevalence",
+                    "Pathology/Radiology",
+                    "Forecasting",
+                    "Mechanism",
+                    "Virus Factors",
+                    "Host Factors",
+                    "Immunological Response",
+                    "Mechanism of Infection",
+                    "Mechanism of Transmission",
+                    "Prevention",
+                    "Public Health Interventions",
+                    "Individual Prevention",
+                    "Transmission",
+                    "Host/Intermediate Reservoirs",
+                    "Viral Shedding / Persistence",
+                    "Treatment",
+                    "Vaccines",
+                    "Pharmaceutical Treatments",
+                    "Medical Care",
+                    "Repurposing",
+                    "Biologics",
+                    "Behavioral Research",
+                    "Epidemiology",
+                    "Classical Epidemiology",
+                    "Molecular Epidemiology",
+                    "Information Sciences"
+                  ]
                 }
               }
             ]
           },
+          "keywords": {
+            "description": "Keywords or tags used to describe this content. Multiple entries in a keywords list are typically delimited by commas.",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            ]
+          },
+          "isBasedOn": {
+            "description": "A citation to a resource (eg- publication, protocol, etc.) on which this dataset was derived (stored as an object, not a string)",
+            "oneOf": [{
+                "$ref": "#/definitions/citation"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/citation"
+                }
+              }
+            ]
+          },
+          "citedBy": {
+            "description": "A citation to a resource (eg- publication, protocol, etc.) which is derived from this dataset (stored as an object, not a string)",
+            "oneOf": [{
+                "$ref": "#/definitions/citation"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/citation"
+                }
+              }
+            ]
+          },
+          "isRelatedTo": {
+            "description": "A citation to a resource (eg- publication, protocol, etc.) which is related to the dataset but is not a derivative nor was derived from the dataset (stored as an object, not a string)",
+            "oneOf": [{
+                "$ref": "#/definitions/citation"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/citation"
+                }
+              }
+            ]
+          },
+          "curatedBy": {
+            "description": "The source from which this Dataset was identified for inclusion into Outbreak.info. Provides provenance for a resource which was curated by another.",
+            "anyOf": [{
+                "$ref": "#/definitions/citation"
+              },
+              {
+                "$ref": "#/definitions/person"
+              },
+              {
+                "$ref": "#/definitions/organization"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/person"
+                }
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/organization"
+                }
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/citation"
+                }
+              }
+            ]
+          },
+          "curationDate":{
+            "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
+            "type": "string",
+            "format": "date"
+          },
+          "license": {
+            "description": "A license document that applies to this content, typically indicated by URL.",
+            "type": "string"
+          },
+          "evaluations":{
+              "description": "Reviews, Ratings, or other types of evaluations on this resource",
+              "anyOf":[
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/reviewObject"
+                }
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/ratingObject"
+                }
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/aggregateRatingObject"
+                }
+              }
+            ]
+            }
+        },
+        "required": [
+          "author",
+          "description",
+          "identifier",
+          "name"
+        ],
+        "definitions": {
+          "controlledVocabulary": {
+            "description": "collection of vocabulary terms defined in ontologies",
+            "@type": "DefinedTerm",
+            "type": "string",
+            "vocabulary": {
+              "ontology": ["efo", "ncit","obi"],
+              "children_of": ["https://www.ebi.ac.uk/efo/EFO_0002694", "http://purl.obolibrary.org/obo/NCIT_C20368",
+                             "http://purl.obolibrary.org/obo/OBI_0000011"]
+            },
+            "strict": false
+          },
+          "miscControlledVocabulary": {
+            "description": "collection of vocabulary terms defined in ontologies",
+            "@type": "DefinedTerm",
+            "type": "string",
+            "vocabulary": {
+              "ontology": ["ncbitaxon"],
+              "children_of": ["http://purl.obolibrary.org/obo/NCBITaxon_10239"]
+            },
+            "strict": false
+          },
+          "speciesControlledVocabulary": {
+            "description": "collection of vocabulary terms defined in ontologies",
+            "@type": "DefinedTerm",
+            "type": "string",
+            "vocabulary": {
+              "ontology": ["ncbitaxon"],
+              "children_of": ["http://purl.obolibrary.org/obo/NCBITaxon_131567"]
+            },
+              "strict": false
+          },
+          "diseaseVocabulary": {
+            "description": "collection of vocabulary terms defined in ontologies",
+            "@type": "DefinedTerm",
+            "type": "string",
+            "vocabulary": {
+              "ontology": ["mondo"],
+              "children_of": ["http://purl.obolibrary.org/obo/MONDO_0000001"]
+            },
+            "strict": false
+          },
+          "moreControlledVocabulary": {
+              "definition": "collection of vocabulary terms defined in ontologies",
+              "@type": "DefinedTerm",
+              "type": "string",
+              "strict": false,
+              "vocabulary": {
+                "ontology": [
+                  "efo",
+                  "cido",
+                  "epo",
+                  "covid19"
+                ],
+                "children_of": [
+                  "https://www.ebi.ac.uk/efo/EFO_0001444",
+                  "http://purl.obolibrary.org/obo/cido.owl",
+                  "http://purl.obolibrary.org/obo/epo",
+                  "https://bioportal.bioontology.org/ontologies/COVID19"
+                ]
+              }
+          },
+          "datadownload": {
+            "description": "A dataset in downloadable form.",
+            "@type": "outbreak:DataDownload",
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "dateModified": {
+                "type": "string",
+                "format": "date"
+              },
+              "contentUrl": {
+                "type": "string",
+                "format": "uri"
+              }
+            },
+            "required": [
+              "dateModified",
+              "contentUrl"
+            ]
+          },
+          "baseOrgObject": {
+            "description": "A barebones Organization object to work around recursion issues in DDE",
+            "@type": "outbreak:Organization",
+            "type": "object",
+            "properties": {
+              "name": {
+                "description": "name of the organization",
+                "type": "string"
+              },
+              "alternateName": {
+                "description": "Alternate name or Acronym for the organization.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ]              
+          }, 
+          "person": {
+              "description": "Reusable person definition",
+              "@type": "outbreak:Person",
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "givenName": {
+                  "type": "string"
+                },
+                "familyName": {
+                  "type": "string"
+                },
+                "orcid": {
+                  "type": "string"
+                },
+                "affiliation": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/definitions/baseOrgObject"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/baseOrgObject"
+                      }
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "name"
+              ]
+            },
+          "memberObject": {
+              "description": "Reusable person definition accounting for recursion issues in DDE",
+              "@type": "outbreak:Person",
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "givenName": {
+                  "type": "string"
+                },
+                "familyName": {
+                  "type": "string"
+                },
+                "orcid": {
+                  "type": "string"
+                },
+                "affiliation": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/definitions/baseOrgObject"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/baseOrgObject"
+                      }
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "name"
+              ]
+            },
+          "organization": {
+            "description": "Reusable organization definition",
+            "@type": "outbreak:Organization",
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "alternateName": {
+                "type": "string"
+              },
+              "affiliation": {
+                "$ref": "#/definitions/baseOrgObject"
+              },
+              "members": {
+                 "oneOf": [
+                    {
+                      "$ref": "#/definitions/memberObject"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/memberObject"
+                      }
+                    }
+                  ]
+              }
+            },
+            "required": [
+              "name"
+            ]
+          },
+          "funding": {
+            "type": "object",
+            "@type": "outbreak:MonetaryGrant",
+            "description": "Information about funding support",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "The name of the monetary grant that funded/funds the Dataset"
+              },
+              "identifier": {
+                "type": "string",
+                "description": "Unique identifier(s) for the grant(s) used to fund the Dataset"
+              },
+              "funder": {
+                "description": "name of the funding organization",
+                "oneOf": [
+              {
+                "$ref": "#/definitions/baseOrgObject"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/baseOrgObject"
+                }
+              }
+            ]
+              },
+              "url": {
+                "type": "string",
+                "format": "uri",
+                "description": "award URL"
+              }
+            },
+            "required": [
+              "funder"
+            ]
+          },
+          "citation": {
+            "description": "A citation object for a resource which is cited by the dataset (ie- is a derivative of the dataset) , related to the dataset, or from which the dataset was based on (ie- is derived from).",
+            "@type": "outbreak:CitationObject",
+            "type": "object",
+            "properties": {
+              "name": {
+                "description": "Name of or title of the citation",
+                "type": "string"
+              },
+              "identifier": {
+                "description": "An identifier associated with the citation",
+                "type": "string"
+              },
+              "pmid": {
+                "description": "A pubmed identifier if available",
+                "type": "string"
+              },
+              "doi": {
+                "description": "A doi if available",
+                "type": "string"
+              },
+              "sourceType": {
+                "description": "The type of resource",
+                "enum": [
+                  "Dataset",
+                  "Publication",
+                  "ClinicalTrial", 
+                  "Analysis",
+                  "Protocol", 
+                  "SoftwareApplication",
+                  "CreativeWork"
+                  ]
+              },
+              "url": {
+                "description": "The url of the resource cited.",
+                "type": "string",
+                "format": "uri"
+              },
+              "versionDate": {
+                "description": "The version date of the resource used at the time of the creation of the citation as certain resources (protocols, datasets) may change frequently over time.",
+                "type": "string",
+                "format": "date"
+              },
+              "citeText": {
+                "description": "The bibliographic citation for the referenced resource as is provided",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "sourceType"
+            ]
+          },
+          "reviewObject": {
+            "description": "A review or descriptive evaluation of the resource",
+            "@type": "Review",
+            "type": "object",
+            "properties": {
+              "name": {
+                    "type": "string",
+                    "description": "The name of the review"
+                  },
+              "reviewAspect":{
+                    "description": "This Review or Rating is relevant to this part or facet of the itemReviewed",
+                    "type": "string"
+                  },
+              "reviewBody": {
+                      "description": "The actual body of the review.",
+                      "type": "string"
+                  },
+              "reviewRating": {
+                "description": "The rating given in this review",
+                    "$ref": "#/definitions/ratingObject"      
+                },
+              "author": {
+                    "description": "The author of this content or rating.",
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/person"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/person"
+                      }
+                      },
+                      {
+                        "$ref": "#/definitions/organization"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/organization"
+                      }
+                }
+              ]
+            },
+              "curationDate":{
+                    "description": "The date this evaluation was added into outbreak.info, or was updated in outbreak.info.",
+                    "type": "string",
+                    "format": "date"
+                  }
+                },
+              "required": [
+              ]
+            },
+          "ratingObject": {
+                "description": "A rating or categorical evaluation of the resource",
+                "@type": "Rating",
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "The name of the rating"
+                  },
+                  "ratingExplanation": {
+                    "type": "string",
+                    "description": "An explanation of the rating"    
+                  },
+                  "ratingValue": {
+                    "type": "string",
+                    "description": "The rating for the content."
+                  },
+                  "reviewAspect": {
+                    "type": "string",
+                    "description": "This Review or Rating is relevant to this part or facet of the itemReviewed"
+                  },
+                  "author": {
+                    "description": "The author of this content or rating.",
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/person"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/person"
+                      }
+                      },
+                      {
+                        "$ref": "#/definitions/organization"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/organization"
+                      }
+                }
+              ]
+            },
+                  "curationDate":{
+                    "description": "The date this evaluation was added into outbreak.info, or was updated in outbreak.info.",
+                    "type": "string",
+                    "format": "date"
+                  }
+                },
+                "required": [
+                ]
+            },
+          "aggregateRatingObject": {
+              "description": "A cumulative evaluation of the resource",
+              "@type": "AggregateRating",
+              "type": "object",
+              "properties": {
+                "name": {
+                "type": "string",
+                "description": "The name of the aggregate rating"
+                },
+                "ratingValue": {
+                    "type": "string",
+                    "description": "The rating for the content."
+                },
+                "reviewAspect":{
+                  "description": "This Review or Rating is relevant to this part or facet of the itemReviewed",
+                  "type": "string"
+                },
+                "author": {
+                    "description": "The author of this content or rating.",
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/person"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/person"
+                      }
+                      },
+                      {
+                        "$ref": "#/definitions/organization"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/organization"
+                      }
+                }
+              ]
+            },
+                "curationDate": {
+                    "description": "The date this evaluation was added into outbreak.info, or was updated in outbreak.info.",
+                    "type": "string",
+                    "format": "date"
+                  },
+                "reviews": {
+                  "anyOf": [
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/reviewObject"
+                        }
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/ratingObject"
+                        }
+                      }
+                      
+                  ]
+                }
+                },
+            "required": [
+            ]
+          }
+        }
+      }
+    },
+    {
+      "@id": "outbreak:Correction",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing a Correction used for outbreak.info. A Correction is a specialized subclass of the CitationObject",
+      "rdfs:label": "Correction",
+      "rdfs:subClassOf": {
+        "@id": "schema:CreativeWork"
+      },
+      "$validation": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "doi": {
+            "description": "The DOI of the published correction or correction notice",
+            "type": "string"
+          },
+          "pmid": {
+            "description": "The PMID of the published correction or correction notice (if available)",
+            "type": "integer"
+          },
+          "correctionType": {
+            "description": "Type of notice or correction: (correction, retraction, expression of convern, withdrawal, erratum, update, correction/republication, preprint, peer reviewed version)",
+            "oneOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "correction",
+                  "retraction",
+                  "expression of concern",
+                  "withdrawal",
+                  "erratum",
+                  "update",
+                  "correction and re-publication",
+                  "peer reviewed version",
+                  "preprint"
+                ]
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "correction",
+                    "retraction",
+                    "expression of concern",
+                    "withdrawal",
+                    "erratum",
+                    "update",
+                    "correction and re-publication",
+                    "peer reviewed version",
+                    "preprint"
+                  ]
+                }
+              }
+            ]
+          },
+          "datePublished": {
+            "description": "Publication date of the correction or correction notice",
+            "format": "date",
+            "type": "string"
+          },
+          "identifier": {
+            "description": "An identifier for the published correction or correction notice. DOI (preferred) or PMID (e.g., 10.1126\/sciimmunol.aaw6329, PMID:31471352)",
+            "type": "string"
+          },
+          "url": {
+            "description": "URL of the item.",
+            "type": "string",
+            "format": "uri"
+          }
+        },
+        "required": []
+      }
+    },
+    {
+      "@id": "outbreak:correctionType",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Type of notice or correction: (correction, retraction, expression of convern, withdrawal, erratum, update, correction/republication, preprint, peer reviewed version)",
+      "rdfs:label": "correctionType",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Correction"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:Publication",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing the Publication used for outbreak.info",
+      "rdfs:label": "Publication",
+      "rdfs:subClassOf": {
+        "@id": "schema:MedicalScholarlyArticle"
+      },
+      "$validation": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "Title of the article or publication",
+            "type": "string"
+          },
+          "abstract": {
+            "description": "A short descriptive summary of the resource",
+            "type": "string"
+          },
+          "identifier": {
+            "description": "An identifier for the publication. DOI (preferred) or PMID (e.g., 10.1126/sciimmunol.aaw6329, PMID:31471352)",
+            "type": "string"
+          },
+          "pmid": {
+            "description": "The Pubmed identifier or PMID of the publication if available",
+            "type": "string"
+          },
+          "doi": {
+            "description": "The DOI of the publication if available",
+            "type": "string"
+          },
+          "url": {
+              "description": "url where the publication or article can be found",
+              "oneOf": [
+                {
+                  "type": "string",
+                  "format": "uri"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "format": "uri"
+                  }
+                }
+              ]
+            },
+          "journalName": {
+            "description": "The name of the journal (or publisher or preprint server if journal name not available)",
+            "type": "string"
+          },
+          "journalNameAbbrevation": {
+            "description": "abbreviated Journal Title (note, this should be autopopulated)",
+            "type": "string"
+          },
+          "volumeNumber": {
+            "description": "Volume number of journal in which the article was published",
+            "type": "string"
+          },
+          "issueNumber": {
+            "description": "Issue of journal in which the article was published",
+            "type": "string"
+          },
+          "pagination": {
+            "description": "Any description of pages for the article or publication",
+            "type": "string"
+          },
+          "datePublished": {
+              "description": "PublicationDate online if available",
+              "format": "date",
+              "type": "string"
+            },
+          "dateModified": {
+              "description": "Date of Version update",
+              "oneOf": [
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "format": "date"
+                  }
+                }
+              ]
+            },
+          "publicationType": {
+              "description": "Type of publication such as preprint, research article, case report, etc",
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              ]
+            },
+          "correction": {
+              "description": "Related corrections or correction notices for this resource (eg- retraction notice, etc.)",
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/correctionObject"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/correctionObject"
+                  }
+                }
+              ]
+            },
+          "author": {
+              "description": "Name of the author or organization that created the dataset.  Note: schema.org/creator and schema.org/organization have additional fields that can provide more information about the author/organization, if desired",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/person"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/person"
+                  }
+                },
+                {
+                  "$ref": "#/definitions/organization"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/organization"
+                  }
+                }
+              ]
+            },
+          "funding": {
+            "description": "Funding that supports (sponsors) the collection of this dataset through some kind of financial contribution",
+            "oneOf": [{
+                "$ref": "#/definitions/funding"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/funding"
+                }
+              }
+            ]
+          },
+          "topicCategory": {
+            "description": "Applicable outbreak.info category",
+            "oneOf": [
+              {
+                "enum": [
+                  "Clinical",
+                  "Case Descriptions",
+                  "Risk Factors",
+                  "Diagnosis",
+                  "Symptoms",
+                  "Rapid Diagnostics",
+                  "Antibody Detection",
+                  "Virus Detection",
+                  "Testing Prevalence",
+                  "Pathology/Radiology",
+                  "Forecasting",
+                  "Mechanism",
+                  "Virus Factors",
+                  "Host Factors",
+                  "Immunological Response",
+                  "Mechanism of Infection",
+                  "Mechanism of Transmission",
+                  "Prevention",
+                  "Public Health Interventions",
+                  "Individual Prevention",
+                  "Transmission",
+                  "Host/Intermediate Reservoirs",
+                  "Viral Shedding / Persistence",
+                  "Treatment",
+                  "Vaccines",
+                  "Pharmaceutical Treatments",
+                  "Medical Care",
+                  "Repurposing",
+                  "Biologics",
+                  "Behavioral Research",
+                  "Epidemiology",
+                  "Classical Epidemiology",
+                  "Molecular Epidemiology",
+                  "Information Sciences"
+                ]
+              },
+              {
+                "type": "array",
+                "items": {
+                  "enum": [
+                    "Clinical",
+                    "Case Descriptions",
+                    "Risk Factors",
+                    "Diagnosis",
+                    "Symptoms",
+                    "Rapid Diagnostics",
+                    "Antibody Detection",
+                    "Virus Detection",
+                    "Testing Prevalence",
+                    "Pathology/Radiology",
+                    "Forecasting",
+                    "Mechanism",
+                    "Virus Factors",
+                    "Host Factors",
+                    "Immunological Response",
+                    "Mechanism of Infection",
+                    "Mechanism of Transmission",
+                    "Prevention",
+                    "Public Health Interventions",
+                    "Individual Prevention",
+                    "Transmission",
+                    "Host/Intermediate Reservoirs",
+                    "Viral Shedding / Persistence",
+                    "Treatment",
+                    "Vaccines",
+                    "Pharmaceutical Treatments",
+                    "Medical Care",
+                    "Repurposing",
+                    "Biologics",
+                    "Behavioral Research",
+                    "Epidemiology",
+                    "Classical Epidemiology",
+                    "Molecular Epidemiology",
+                    "Information Sciences"
+                  ]
+                }
+              }
+            ]
+          },
+          "keywords": {
+            "description": "Keywords or tags used to describe this content. Multiple entries in a keywords list are typically delimited by commas.",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            ]
+          },
+          "isBasedOn": {
+              "description": "Associated datasets, software, protocols, etc. used by the work described in this publication, including reference publications",
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/citation"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/citation"
+                  }
+                }
+              ]
+            },
+          "citedBy": {
+            "description": "A citation to a resource (eg- publication, protocol, etc.) which is derived from this publication (stored as an object, not a string)",
+            "oneOf": [{
+                "$ref": "#/definitions/citation"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/citation"
+                }
+              }
+            ]
+          },
+          "isRelatedTo": {
+            "description": "A citation to a resource (eg- publication, protocol, etc.) which is related to the publication but is not a derivative nor was derived from the publication (stored as an object, not a string)",
+            "oneOf": [{
+                "$ref": "#/definitions/citation"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/citation"
+                }
+              }
+            ]
+          },
+          "curatedBy": {
+            "description": "The source from which this Publication was identified for inclusion into Outbreak.info. Provides provenance for a resource which was curated by another.",
+            "anyOf": [{
+                "$ref": "#/definitions/citation"
+              },
+              {
+                "$ref": "#/definitions/person"
+              },
+              {
+                "$ref": "#/definitions/organization"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/person"
+                }
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/organization"
+                }
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/citation"
+                }
+              }
+            ]
+          },
+          "curationDate":{
+            "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
+            "type": "string",
+            "format": "date"
+          },
+          "license": {
+            "description": "Licensing that applies to this content, typically indicated by URL.",
+            "type": "string"
+          },
+          "evaluations":{
+              "description": "Reviews, Ratings, or other types of evaluations on this resource",
+              "anyOf":[
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/reviewObject"
+                }
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/ratingObject"
+                }
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/aggregateRatingObject"
+                }
+              }
+            ]
+            }
+        },
+        "required": [
+          "journalName",
+          "identifier",
+          "name",
+          "url",
+          "author",
+          "datePublished"
+        ],
+        "definitions": {
+          "baseOrgObject":{
+            "description": "A barebones Organization object to work around recursion issues in DDE",
+            "@type": "outbreak:Organization",
+            "type": "object",
+            "properties": {
+              "name": {
+                "description": "name of the organization",
+                "type": "string"
+              },
+              "alternateName": {
+                "description": "Alternate name or Acronym for the organization.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ]              
+          }, 
+          "person": {
+              "description": "Reusable person definition",
+              "@type": "outbreak:Person",
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "givenName": {
+                  "type": "string"
+                },
+                "familyName": {
+                  "type": "string"
+                },
+                "orcid": {
+                  "type": "string"
+                },
+                "affiliation": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/definitions/baseOrgObject"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/baseOrgObject"
+                      }
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "name"
+              ]
+            },
+          "memberObject": {
+              "description": "Reusable person definition accounting for recursion issues in DDE",
+              "@type": "outbreak:Person",
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "givenName": {
+                  "type": "string"
+                },
+                "familyName": {
+                  "type": "string"
+                },
+                "orcid": {
+                  "type": "string"
+                },
+                "affiliation": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/definitions/baseOrgObject"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/baseOrgObject"
+                      }
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "name"
+              ]
+            },
+          "organization": {
+            "description": "Reusable organization definition",
+            "@type": "outbreak:Organization",
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "alternateName": {
+                "type": "string"
+              },
+              "affiliation": {
+                "$ref": "#/definitions/baseOrgObject"
+              },
+              "members": {
+                 "oneOf": [
+                    {
+                      "$ref": "#/definitions/memberObject"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/memberObject"
+                      }
+                    }
+                  ]
+              }
+            },
+            "required": [
+              "name"
+            ]
+          },
+          "funding": {
+            "type": "object",
+            "@type": "outbreak:MonetaryGrant",
+            "description": "Information about funding support",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "The name of the monetary grant that funded/funds the Dataset"
+              },
+              "identifier": {
+                "type": "string",
+                "description": "Unique identifier(s) for the grant(s) used to fund the Dataset"
+              },
+              "funder": {
+                "description": "name of the funding organization",
+                "oneOf": [
+              {
+                "$ref": "#/definitions/baseOrgObject"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/baseOrgObject"
+                }
+              }
+            ]
+              },
+              "url": {
+                "type": "string",
+                "format": "uri",
+                "description": "award URL"
+              }
+            },
+            "required": [
+              "funder"
+            ]
+          },
+          "correctionObject": {
+              "@type": "outbreak:Correction",
+              "type": "object",
+              "properties": {
+                "url": {
+                  "type": "string",
+                  "format": "uri"
+                },
+                "correctionType": {
+                  "enum": [
+                    "correction",
+                    "retraction",
+                    "expression of concern",
+                    "withdrawal",
+                    "erratum",
+                    "update",
+                    "correction and re-publication",
+                    "peer reviewed version",
+                    "preprint"
+                  ]
+                },
+                "identifier": {
+                  "type": "string"
+                },
+                "doi": {
+                  "type": "string"
+                },
+                "pmid": {
+                  "type": "integer"
+                },
+                "datePublished": {
+                  "description": "publication date of the correction notice or publication",
+                  "type": "string",
+                  "format": "date"
+                }
+              },
+              "required": [
+                  "url",
+                  "correctionType"
+              ]
+            },
+          "citation": {
+            "description": "A citation object for a resource which is cited by the publication (ie- is a derivative of the publication) , related to the publication, or from which the publication was based on (ie- is derived from).",
+            "@type": "outbreak:CitationObject",
+            "type": "object",
+            "properties": {
+              "name": {
+                "description": "Name of or title of the citation",
+                "type": "string"
+              },
+              "identifier": {
+                "description": "An identifier associated with the citation",
+                "type": "string"
+              },
+              "pmid": {
+                "description": "A pubmed identifier if available",
+                "type": "string"
+              },
+              "doi": {
+                "description": "A doi if available",
+                "type": "string"
+              },
+              "sourceType": {
+                "description": "The type of resource",
+                "enum": [
+                  "Dataset",
+                  "Publication",
+                  "ClinicalTrial", 
+                  "Analysis",
+                  "Protocol", 
+                  "SoftwareApplication",
+                  "CreativeWork"
+                  ]
+              },
+              "url": {
+                "description": "The url of the resource cited.",
+                "type": "string",
+                "format": "uri"
+              },
+              "versionDate": {
+                "description": "The version date of the resource used at the time of the creation of the citation as certain resources (protocols, datasets) may change frequently over time.",
+                "type": "string",
+                "format": "date"
+              },
+              "citeText": {
+                "description": "The bibliographic citation for the referenced resource as is provided",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "sourceType"
+            ]
+          },
+          "reviewObject": {
+            "description": "A review or descriptive evaluation of the resource",
+            "@type": "Review",
+            "type": "object",
+            "properties": {
+              "name": {
+                    "type": "string",
+                    "description": "The name of the review"
+                  },
+              "reviewAspect":{
+                    "description": "This Review or Rating is relevant to this part or facet of the itemReviewed",
+                    "type": "string"
+                  },
+              "reviewBody": {
+                      "description": "The actual body of the review.",
+                      "type": "string"
+                  },
+              "reviewRating": {
+                "description": "The rating given in this review",
+                    "$ref": "#/definitions/ratingObject"      
+                },
+              "author": {
+                    "description": "The author of this content or rating.",
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/person"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/person"
+                      }
+                      },
+                      {
+                        "$ref": "#/definitions/organization"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/organization"
+                      }
+                }
+              ]
+            },
+              "curationDate":{
+                    "description": "The date this evaluation was added into outbreak.info, or was updated in outbreak.info.",
+                    "type": "string",
+                    "format": "date"
+                  }
+                },
+              "required": [
+              ]
+            },
+          "ratingObject": {
+                "description": "A rating or categorical evaluation of the resource",
+                "@type": "Rating",
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "The name of the rating"
+                  },
+                  "ratingExplanation": {
+                    "type": "string",
+                    "description": "An explanation of the rating"    
+                  },
+                  "ratingValue": {
+                    "type": "string",
+                    "description": "The rating for the content."
+                  },
+                  "reviewAspect": {
+                    "type": "string",
+                    "description": "This Review or Rating is relevant to this part or facet of the itemReviewed"
+                  },
+                  "author": {
+                    "description": "The author of this content or rating.",
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/person"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/person"
+                      }
+                      },
+                      {
+                        "$ref": "#/definitions/organization"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/organization"
+                      }
+                }
+              ]
+            },
+                  "curationDate":{
+                    "description": "The date this evaluation was added into outbreak.info, or was updated in outbreak.info.",
+                    "type": "string",
+                    "format": "date"
+                  }
+                },
+                "required": [
+                ]
+            },
+          "aggregateRatingObject": {
+              "description": "A cumulative evaluation of the resource",
+              "@type": "AggregateRating",
+              "type": "object",
+              "properties": {
+                "name": {
+                "type": "string",
+                "description": "The name of the aggregate rating"
+                },
+                "ratingValue": {
+                    "type": "string",
+                    "description": "The rating for the content."
+                },
+                "reviewAspect":{
+                  "description": "This Review or Rating is relevant to this part or facet of the itemReviewed",
+                  "type": "string"
+                },
+                "author": {
+                    "description": "The author of this content or rating.",
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/person"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/person"
+                      }
+                      },
+                      {
+                        "$ref": "#/definitions/organization"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/organization"
+                      }
+                }
+              ]
+            },
+                "curationDate": {
+                    "description": "The date this evaluation was added into outbreak.info, or was updated in outbreak.info.",
+                    "type": "string",
+                    "format": "date"
+                  },
+                "reviews": {
+                  "anyOf": [
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/reviewObject"
+                        }
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/ratingObject"
+                        }
+                      }
+                      
+                  ]
+                }
+                },
+            "required": [
+            ]
+          }
+        }
+      }
+    },
+    {
+      "@id": "outbreak:journalName",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The name of the journal (or publisher if journal name not available)",
+      "rdfs:label": "journalName",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Publication"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:journalNameAbbrevation",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "abbreviated Journal Title (note, this should be autopopulated)",
+      "rdfs:label": "journalNameAbbrevation",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Publication"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:volumeNumber",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Volume number of journal in which the article was published",
+      "rdfs:label": "volumeNumber",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Publication"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:issueNumber",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Issue of journal in which the article was published",
+      "rdfs:label": "issueNumber",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Publication"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:Analysis",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing an Analysis for inclusion in outbreak.info resources",
+      "rdfs:label": "Analysis",
+      "rdfs:subClassOf": {
+        "@id": "schema:CreativeWork"
+      },
+      "$validation": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "The name of the analysis",
+            "type": "string"
+          },
+          "description": {
+            "description": "A description of the analysis",
+            "type": "string"
+          },
+          "identifier": {
+            "description": "An identifier for the analysis, preferably a doi",
+            "type": "string"
+          },
+          "doi": {
+            "description": "The DOI of the analysis if available",
+            "type": "string"
+          },
+          "url": {
+            "description": "URL where the analysis can be found",
+            "type": "string",
+            "format": "uri"
+          },
+          "domainUrl": {
+            "description": "The domain name or main site on which webpage or specific url of the analysis can be found",
+            "type": "string",
+            "format": "uri"
+          },
+          "datePublished": {
+            "description": "Date of first broadcast/publication of the analysis",
+            "format": "date",
+            "type": "string"
+          },
+          "dateModified": {
+            "description": "The date on which the CreativeWork was most recently modified or when the item's entry was modified within a DataFeed.",
+            "format": "date",
+            "type": "string"
+          },
+          "author": {
+              "description": "The author of this content or rating.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/person"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/person"
+                  }
+                },
+                {
+                  "$ref": "#/definitions/organization"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/organization"
+                  }
+                }
+              ]
+            },
+          "assumption": {
+            "description": "Statement of assumptions / limitations of the model",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            ]
+          },
+          "keywords": {
+            "description": "Keywords or tags used to describe this content. Multiple entries in a keywords list are typically delimited by commas.",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            ]
+          },
+          "topicCategory": {
+              "description": "Applicable outbreak.info category",
+              "oneOf": [
+                {
+                  "enum": [
+                    "Clinical",
+                    "Case Descriptions",
+                    "Risk Factors",
+                    "Diagnosis",
+                    "Symptoms",
+                    "Rapid Diagnostics",
+                    "Antibody Detection",
+                    "Virus Detection",
+                    "Testing Prevalence",
+                    "Pathology/Radiology",
+                    "Forecasting",
+                    "Mechanism",
+                    "Virus Factors",
+                    "Host Factors",
+                    "Immunological Response",
+                    "Mechanism of Infection",
+                    "Mechanism of Transmission",
+                    "Prevention",
+                    "Public Health Interventions",
+                    "Individual Prevention",
+                    "Transmission",
+                    "Host/Intermediate Reservoirs",
+                    "Viral Shedding / Persistence",
+                    "Treatment",
+                    "Vaccines",
+                    "Pharmaceutical Treatments",
+                    "Medical Care",
+                    "Repurposing",
+                    "Biologics",
+                    "Behavioral Research",
+                    "Epidemiology",
+                    "Classical Epidemiology",
+                    "Molecular Epidemiology",
+                    "Information Sciences"
+                  ]
+                },
+                {
+                  "type": "array",
+                  "items": {
+                      "enum": [
+                        "Clinical",
+                        "Case Descriptions",
+                        "Risk Factors",
+                        "Diagnosis",
+                        "Symptoms",
+                        "Rapid Diagnostics",
+                        "Antibody Detection",
+                        "Virus Detection",
+                        "Testing Prevalence",
+                        "Pathology/Radiology",
+                        "Forecasting",
+                        "Mechanism",
+                        "Virus Factors",
+                        "Host Factors",
+                        "Immunological Response",
+                        "Mechanism of Infection",
+                        "Mechanism of Transmission",
+                        "Prevention",
+                        "Public Health Interventions",
+                        "Individual Prevention",
+                        "Transmission",
+                        "Host/Intermediate Reservoirs",
+                        "Viral Shedding / Persistence",
+                        "Treatment",
+                        "Vaccines",
+                        "Pharmaceutical Treatments",
+                        "Medical Care",
+                        "Repurposing",
+                        "Biologics",
+                        "Behavioral Research",
+                        "Epidemiology",
+                        "Classical Epidemiology",
+                        "Molecular Epidemiology",
+                        "Information Sciences"
+                      ]
+                  }
+                }
+              ]
+
+            },
+          "analysisTechnique": {
+            "description": "A technique or technology used in a analysis",
+            "oneOf": [
+                  {
+                    "$ref": "#/definitions/moreControlledVocabulary"
+                  },
+                  {
+                    "enum": [
+                        "predictive/forecasting models",
+                        "observation/visualization models"
+                    ]
+                  },
+                  {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/definitions/moreControlledVocabulary"
+                    }
+                  },  
+                  {
+                    "type": "array",
+                    "enum": [
+                        "predictive/forecasting models",
+                        "observation/visualization models"
+                    ]
+                  }
+                ]
+          },
           "infectiousAgent": {
-            "description": "infectious agents(s) which are the focus of the dataset",
+            "description": "infectious agents(s) which are the focus of the analysis",
             "oneOf": [{
                 "$ref": "#/definitions/miscControlledVocabulary"
               },
@@ -1033,8 +2558,8 @@
             ]
           },
           "infectiousDisease": {
-              "description": "The disease or medical conditions caused by the infectious agent. Important as some agents may cause multiple diseases",
-              "oneOf": [
+            "description": "The disease or medical conditions caused by the infectious agent. Important as some agents may cause multiple diseases",
+            "oneOf": [
                 {
                   "$ref": "#/definitions/diseaseVocabulary"
                 },
@@ -1044,8 +2569,3045 @@
                     "$ref": "#/definitions/diseaseVocabulary"
                   }
                 }
+            ]
+          },
+          "analysisTopic": {
+            "description": "The underlying question, goal, or aim of the analysis",
+            "oneOf": [
+                {
+                  "$ref": "#/definitions/controlledVocabulary"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                        "$ref": "#/definitions/controlledVocabulary"
+                  }
+                }
+            ]
+          },
+          "funding": {
+            "description": "The funding that supported the creation or maintenance of the analysis",
+            "oneOf": [
+              {
+                "$ref": "#/definitions/funding"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/funding"
+                }
+              }
+            ]
+          },          
+          "isBasedOn": {
+              "description": "Associated datasets, software, protocols, etc. used by the work described in this analysis, including reference publications",
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/citation"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/citation"
+                  }
+                }
               ]
             },
+          "citedBy": {
+            "description": "A citation to a resource (eg- publication, protocol, etc.) which is derived from this analysis (stored as an object, not a string)",
+            "oneOf": [{
+                "$ref": "#/definitions/citation"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/citation"
+                }
+              }
+            ]
+          },
+          "isRelatedTo": {
+            "description": "A citation to a resource (eg- publication, protocol, etc.) which is related to the analysis but is not a derivative nor was derived from the analysis (stored as an object, not a string)",
+            "oneOf": [{
+                "$ref": "#/definitions/citation"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/citation"
+                }
+              }
+            ]
+          },
+          "curatedBy": {
+            "description": "The source from which this analysis was identified for inclusion into Outbreak.info. Provides provenance for a resource which was curated by another.",
+            "anyOf": [{
+                "$ref": "#/definitions/citation"
+              },
+              {
+                "$ref": "#/definitions/person"
+              },
+              {
+                "$ref": "#/definitions/organization"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/person"
+                }
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/organization"
+                }
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/citation"
+                }
+              }
+            ]
+          },
+          "curationDate":{
+            "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
+            "type": "string",
+            "format": "date"
+          },
+          "license": {
+            "description": "A license document that applies to this content, typically indicated by URL.",
+            "type": "string"
+          },
+          "evaluations":{
+              "description": "Reviews, Ratings, or other types of evaluations on this resource",
+              "anyOf":[
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/reviewObject"
+                }
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/ratingObject"
+                }
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/aggregateRatingObject"
+                }
+              }
+            ]
+            }
+        },
+        "required": [
+          "author",
+          "description",
+          "identifier",
+          "name",
+          "url"
+        ],
+          "definitions": {
+            "controlledVocabulary": {
+              "definition": "collection of vocabulary terms defined in ontologies",
+              "@type": "DefinedTerm",
+              "type": "string",
+              "strict": false,
+              "vocabulary": {
+                  "ontology": [
+                    "covid19",
+                    "cido",
+                    "epo"
+                  ],
+                  "children_of": [
+                  "https://bioportal.bioontology.org/ontologies/COVID19",
+                  "http://purl.obolibrary.org/obo/cido.owl",
+                  "http://purl.obolibrary.org/obo/epo"
+                ]
+                }
+            },
+            "miscControlledVocabulary": {
+              "description": "collection of vocabulary terms defined in ontologies",
+              "@type": "DefinedTerm",
+              "type": "string",
+              "strict": false,
+              "vocabulary": {
+                  "ontology": ["ncbitaxon"],
+                  "children_of": ["http://purl.obolibrary.org/obo/NCBITaxon_10239"]
+                }
+            },
+            "moreControlledVocabulary": {
+              "definition": "collection of vocabulary terms defined in ontologies",
+              "@type": "DefinedTerm",
+              "type": "string",
+              "strict": false,
+              "vocabulary": {
+                  "ontology": [
+                    "mamo"
+                  ],
+                  "children_of": [
+                    "http://identifiers.org/mamo/MAMO_0000037"
+                  ]
+                }
+            },
+            "diseaseVocabulary": {
+              "description": "collection of vocabulary terms defined in ontologies",
+              "@type": "DefinedTerm",
+              "type": "string",
+              "strict": false,
+              "vocabulary": {
+                "ontology": ["mondo"],
+                "children_of": ["http://purl.obolibrary.org/obo/MONDO_0000001"]              
+              }
+            },
+            "baseOrgObject":{
+            "description": "A barebones Organization object to work around recursion issues in DDE",
+            "@type": "outbreak:Organization",
+            "type": "object",
+            "properties": {
+              "name": {
+                "description": "name of the organization",
+                "type": "string"
+              },
+              "alternateName": {
+                "description": "Alternate name or Acronym for the organization.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ]              
+          }, 
+            "person": {
+              "description": "Reusable person definition",
+              "@type": "outbreak:Person",
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "givenName": {
+                  "type": "string"
+                },
+                "familyName": {
+                  "type": "string"
+                },
+                "orcid": {
+                  "type": "string"
+                },
+                "affiliation": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/definitions/baseOrgObject"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/baseOrgObject"
+                      }
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "name"
+              ]
+            },
+            "memberObject": {
+              "description": "Reusable person definition accounting for recursion issues in DDE",
+              "@type": "outbreak:Person",
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "givenName": {
+                  "type": "string"
+                },
+                "familyName": {
+                  "type": "string"
+                },
+                "orcid": {
+                  "type": "string"
+                },
+                "affiliation": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/definitions/baseOrgObject"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/baseOrgObject"
+                      }
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "name"
+              ]
+            },
+            "organization": {
+                "description": "Reusable organization definition",
+                "@type": "outbreak:Organization",
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "alternateName": {
+                    "type": "string"
+                  },
+                  "affiliation": {
+                    "$ref": "#/definitions/baseOrgObject"
+                  },
+              "members": {
+                 "oneOf": [
+                    {
+                      "$ref": "#/definitions/memberObject"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/memberObject"
+                      }
+                    }
+                  ]
+              }
+            },
+            "required": [
+              "name"
+            ]
+          },
+            "funding": {
+            "type": "object",
+            "@type": "outbreak:MonetaryGrant",
+            "description": "Information about funding support",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "The name of the monetary grant that funded/funds the analysis"
+              },
+              "identifier": {
+                "type": "string",
+                "description": "Unique identifier(s) for the grant(s) used to fund the analysis"
+              },
+              "funder": {
+                "description": "name of the funding organization",
+                "oneOf": [
+              {
+                "$ref": "#/definitions/baseOrgObject"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/baseOrgObject"
+                }
+              }
+            ]
+              },
+              "url": {
+                "type": "string",
+                "format": "uri",
+                "description": "award URL"
+              }
+            },
+            "required": [
+              "funder"
+            ]
+          },
+            "citation": {
+                "description": "A citation object for a resource which is cited by the analysis (ie- is a derivative of the publication) , related to the analysis, or from which the analysis was based on (ie- is derived from).",
+                "@type": "outbreak:CitationObject",
+                "type": "object",
+                "properties": {
+                "name": {
+                    "description": "Name of or title of the citation",
+                    "type": "string"
+                },
+                "identifier": {
+                    "description": "An identifier associated with the citation",
+                    "type": "string"
+                },
+                "pmid": {
+                    "description": "A pubmed identifier if available",
+                    "type": "string"
+                },
+                "doi": {
+                    "description": "A doi if available",
+                    "type": "string"
+                },
+                "sourceType": {
+                    "description": "The type of resource",
+                    "enum": [
+                      "Dataset",
+                      "Publication",
+                      "ClinicalTrial", 
+                      "Analysis",
+                      "Protocol", 
+                      "SoftwareApplication",
+                      "CreativeWork"
+                      ]
+                },
+              "url": {
+                "description": "The url of the resource cited.",
+                "type": "string",
+                "format": "uri"
+              },
+              "versionDate": {
+                "description": "The version date of the resource used at the time of the creation of the citation as certain resources (protocols, datasets) may change frequently over time.",
+                "type": "string",
+                "format": "date"
+              },
+              "citeText": {
+                "description": "The bibliographic citation for the referenced resource as is provided",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "sourceType"
+            ]
+          },
+            "reviewObject": {
+              "description": "A review or descriptive evaluation of the resource",
+              "@type": "Review",
+              "type": "object",
+              "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "The name of the review"
+                },
+                "reviewAspect":{
+                    "description": "This Review or Rating is relevant to this part or facet of the itemReviewed",
+                    "type": "string"
+                },
+                "reviewBody": {
+                      "description": "The actual body of the review.",
+                      "type": "string"
+                },
+                "reviewRating": {
+                  "description": "The rating given in this review",
+                    "$ref": "#/definitions/ratingObject"      
+                  },
+                "author": {
+                    "description": "The author of this content or rating.",
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/person"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/person"
+                      }
+                      },
+                      {
+                        "$ref": "#/definitions/organization"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/organization"
+                      }
+                }
+              ]
+            },
+                "curationDate":{
+                    "description": "The date this evaluation was added into outbreak.info, or was updated in outbreak.info.",
+                    "type": "string",
+                    "format": "date"
+                }
+              },
+              "required": [
+              ]
+            },
+            "ratingObject": {
+                "description": "A rating or categorical evaluation of the resource",
+                "@type": "Rating",
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "The name of the rating"
+                  },
+                  "ratingExplanation": {
+                    "type": "string",
+                    "description": "An explanation of the rating"    
+                  },
+                  "ratingValue": {
+                    "type": "string",
+                    "description": "The rating for the content."
+                  },
+                  "reviewAspect": {
+                    "type": "string",
+                    "description": "This Review or Rating is relevant to this part or facet of the itemReviewed"
+                  },
+                  "author": {
+                    "description": "The author of this content or rating.",
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/person"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/person"
+                      }
+                      },
+                      {
+                        "$ref": "#/definitions/organization"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/organization"
+                      }
+                }
+              ]
+            },
+                  "curationDate":{
+                    "description": "The date this evaluation was added into outbreak.info, or was updated in outbreak.info.",
+                    "type": "string",
+                    "format": "date"
+                  }
+                },
+                "required": [
+                ]
+            },
+            "aggregateRatingObject": {
+              "description": "A cumulative evaluation of the resource",
+              "@type": "AggregateRating",
+              "type": "object",
+              "properties": {
+                "name": {
+                "type": "string",
+                "description": "The name of the aggregate rating"
+                },
+                "ratingValue": {
+                    "type": "string",
+                    "description": "The rating for the content."
+                },
+                "reviewAspect":{
+                  "description": "This Review or Rating is relevant to this part or facet of the itemReviewed",
+                  "type": "string"
+                },
+                "author": {
+                    "description": "The author of this content or rating.",
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/person"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/person"
+                      }
+                      },
+                      {
+                        "$ref": "#/definitions/organization"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/organization"
+                      }
+                }
+              ]
+            },
+                "curationDate": {
+                    "description": "The date this evaluation was added into outbreak.info, or was updated in outbreak.info.",
+                    "type": "string",
+                    "format": "date"
+                  },
+                "reviews": {
+                  "anyOf": [
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/reviewObject"
+                        }
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/ratingObject"
+                        }
+                      }
+                      
+                  ]
+                }
+                },
+            "required": [
+            ]
+          }
+            }
+          }
+        },
+    {
+      "@id": "outbreak:domainUrl",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The domain name or main site on which webpage or specific url can be found",
+      "rdfs:label": "domainUrl",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Analysis"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:URL"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:assumption",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Statement of assumptions / limitations of the model",
+      "rdfs:label": "assumption",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Analysis"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:analysisTechnique",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "A technique or technology used in a analysis",
+      "rdfs:label": "analysisTechnique",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Analysis"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:analysisTopic",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The underlying question, goal, or aim of the analysis",
+      "rdfs:label": "analysisTopic",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Analysis"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:Product",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing a reagent, material, sample, or some other product used in a protocol resource in outbreak.info",
+      "rdfs:label": "Product",
+      "rdfs:subClassOf": {
+        "@id": "schema:Product"
+      },
+      "$validation": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "manufacturer": {
+            "description": "The manufacturer of the reagent, material, sample or product.",
+            "@type": "outbreak:Organization",
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "alternatename": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ]
+          },
+          "category": {
+            "description": "The type of product (chemical/reagent, biological sample, PPE, or other.",
+            "oneOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "chemical or reagent",
+                  "biological sample",
+                  "PPE",
+                  "other"
+                ]
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "chemical or reagent",
+                    "biological sample",
+                    "PPE",
+                    "other"
+                  ]
+                }
+              }
+            ]
+          },
+          "brand": {
+            "description": "The brand(s) associated with the product",
+            "type": "string"
+          },
+          "identifier": {
+            "description": "An identifier for the product (preferably the manufacturer's identifier for the product)",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the reagent/sample/material/product",
+            "type": "string"
+          },
+          "url": {
+            "description": "URL of the product",
+            "type": "string",
+            "format": "uri"
+          }
+        },
+        "required": [
+          "name"
+        ]
+      }
+    },
+    {
+      "@id": "outbreak:Instrument",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing an instrument used in a protocol resource listed in outbreak.info",
+      "rdfs:label": "Instrument",
+      "rdfs:subClassOf": {
+        "@id": "schema:Product"
+      },
+      "$validation": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "manufacturer": {
+            "description": "The manufacturer of the instrument",
+            "@type": "outbreak:Organization",
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "alternateName": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ]
+          },
+          "model": {
+            "description": "The model of the instrument",
+            "type": "string"
+          },
+          "brand": {
+            "description": "The brand(s) associated with the instrument",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the instrument",
+            "type": "string"
+          },
+          "url": {
+            "description": "URL of the product page for the instrument",
+            "type": "string",
+            "format": "uri"
+          }
+        },
+        "required": [
+          "name"
+        ]
+      }
+    },
+    {
+      "@id": "outbreak:Protocol",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing the Protocols for outbreak.info Resources.",
+      "rdfs:label": "Protocol",
+      "rdfs:subClassOf": {
+        "@id": "schema:HowTo"
+      },
+      "$validation": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "The name of the protocol",
+            "type": "string"
+          },
+          "description": {
+            "description": "A description of the protocol",
+            "type": "string"
+          },
+          "datePublished": {
+            "description": "Publication Date of the protocol online if available",
+            "format": "date",
+            "type": "string"
+          },
+          "url": {
+            "description": "url where the protocol can be found",
+            "type": "string",
+            "format": "uri"
+          },
+          "identifier": {
+            "description": "An identifier associated with the protocol",
+            "type": "string"
+          },
+          "doi": {
+            "description": "the DOI of the protocol",
+            "type": "string"
+          },
+          "license": {
+            "description": "A license document that applies to this content, typically indicated by URL.",
+            "type": "string"
+          },
+          "warning": {
+            "description": "Precautions, warnings, and/or safety warnings associated with or highlighted by the protocol",
+            "type": "string"
+          },
+          "dateModified": {
+              "description": "Date of protocol update",
+              "oneOf": [
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "format": "date"
+                  }
+                }
+              ]
+          },
+          "correctionNote": {
+            "description": "statement of what was updated/changed since prior version",
+            "type": "string"
+          },
+          "protocolStatus": {
+            "description": "The status of the protocol",
+            "enum": [
+                "Working--In use by author",
+                "Working--not in use by author",
+                "Working--in use by others",
+                "Not working",
+                "In Development",
+                "Deprecated"
+              ]
+          },
+          "material": {
+              "description": "the reagent, biological sample, or material such as PPE source materials) used or tested in this protocol",
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/product"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/product"
+                  }
+                }
+              ]
+            },
+          "instrument": {
+              "description": "For LabProtocols it would be a laboratory equipment use by a person to follow one or more steps described in this LabProtocol.",
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/instrument"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/instrument"
+                  }
+                }
+              ]
+          },
+          "measurementTechnique": {
+                "description": "A technique or technology used in this protocol.",
+                "oneOf": [{
+                    "$ref": "#/definitions/controlledVocabulary"
+                  },
+                  {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/definitions/controlledVocabulary"
+                    }
+                  }
+                ]
+          },
+          "protocolSetting": {
+              "description": "The type of 'protocol' based on setting in which it would apply",
+              "enum": [
+                    "clinical",
+                    "experimental",
+                    "field",
+                    "computational",
+                    "public"
+              ]
+          },
+          "protocolCategory": {
+              "description": "The type of 'protocol' based on degree of specificity and purpose",
+              "enum": [
+                    "protocol",
+                    "procedure",
+                    "policy",
+                    "guideline"
+              ]
+          },
+          "usedToGenerate": {
+              "description": "Type of evidence/data generated by the protocol",
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/miscControlledVocabulary"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/miscControlledVocabulary"
+                  }
+                }
+              ]
+          },
+          "inComplianceWith": {
+              "description": "Guidelines or Standards to which these protocols adhere. ie- GMP, GCP, other EQUATOR guidelines. Useful for selecting protocols where certain standards/guidelines must be met",
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              ]
+          },
+          "keywords": {
+              "description": "keywords",
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              ]
+          },
+          "topicCategory": {
+              "description": "Applicable outbreak.info category",
+              "oneOf": [
+                {
+                  "enum": [
+                    "Clinical",
+                    "Case Descriptions",
+                    "Risk Factors",
+                    "Diagnosis",
+                    "Symptoms",
+                    "Rapid Diagnostics",
+                    "Antibody Detection",
+                    "Virus Detection",
+                    "Testing Prevalence",
+                    "Pathology/Radiology",
+                    "Forecasting",
+                    "Mechanism",
+                    "Virus Factors",
+                    "Host Factors",
+                    "Immunological Response",
+                    "Mechanism of Infection",
+                    "Mechanism of Transmission",
+                    "Prevention",
+                    "Public Health Interventions",
+                    "Individual Prevention",
+                    "Transmission",
+                    "Host/Intermediate Reservoirs",
+                    "Viral Shedding / Persistence",
+                    "Treatment",
+                    "Vaccines",
+                    "Pharmaceutical Treatments",
+                    "Medical Care",
+                    "Repurposing",
+                    "Biologics",
+                    "Behavioral Research",
+                    "Epidemiology",
+                    "Classical Epidemiology",
+                    "Molecular Epidemiology",
+                    "Information Sciences"
+                  ]
+                },
+                {
+                  "type": "array",
+                  "items": {
+                      "enum": [
+                        "Clinical",
+                        "Case Descriptions",
+                        "Risk Factors",
+                        "Diagnosis",
+                        "Symptoms",
+                        "Rapid Diagnostics",
+                        "Antibody Detection",
+                        "Virus Detection",
+                        "Testing Prevalence",
+                        "Pathology/Radiology",
+                        "Forecasting",
+                        "Mechanism",
+                        "Virus Factors",
+                        "Host Factors",
+                        "Immunological Response",
+                        "Mechanism of Infection",
+                        "Mechanism of Transmission",
+                        "Prevention",
+                        "Public Health Interventions",
+                        "Individual Prevention",
+                        "Transmission",
+                        "Host/Intermediate Reservoirs",
+                        "Viral Shedding / Persistence",
+                        "Treatment",
+                        "Vaccines",
+                        "Pharmaceutical Treatments",
+                        "Medical Care",
+                        "Repurposing",
+                        "Biologics",
+                        "Behavioral Research",
+                        "Epidemiology",
+                        "Classical Epidemiology",
+                        "Molecular Epidemiology",
+                        "Information Sciences"
+                      ]
+                  }
+                }
+              ]
+
+          },
+          "author": {
+              "description": "person, people, or organization that created the protocol",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/person"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/person"
+                  }
+                },
+                {
+                  "$ref": "#/definitions/organization"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/organization"
+                  }
+                }
+              ]
+          },
+          "funding": {
+              "description": "The funder of the Protocol",
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/funding"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/funding"
+                  }
+                }
+              ]
+          },
+          "citedBy": {
+              "description": "Associated guidelines, protocols, publications, etc. that include, adapt, modify, expand, etc. this protocol.",
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/citation"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/citation"
+                  }
+                }
+              ]
+          },
+          "isBasedOn": {
+              "description": "Associated resource (guidelines, protocols, publications, etc.) from which this protocol was derived",
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/citation"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/citation"
+                  }
+                }
+              ]
+          },
+          "isRelatedTo": {
+              "description": "Other resources related to, but not a derivative of nor derived from this protocol",
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/citation"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/citation"
+                  }
+                }
+              ]
+          },
+          "curatedBy": {
+            "description": "The source from which this Protocol was identified for inclusion into Outbreak.info. Provides provenance for a resource which was curated by another.",
+            "anyOf": [{
+                "$ref": "#/definitions/citation"
+              },
+              {
+                "$ref": "#/definitions/person"
+              },
+              {
+                "$ref": "#/definitions/organization"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/person"
+                }
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/organization"
+                }
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/citation"
+                }
+              }
+            ]
+          },
+          "curationDate":{
+            "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
+            "type": "string",
+            "format": "date"
+          },
+          "evaluations":{
+              "description": "Reviews, Ratings, or other types of evaluations on this resource",
+              "anyOf":[
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/reviewObject"
+                }
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/ratingObject"
+                }
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/aggregateRatingObject"
+                }
+              }
+            ]
+            }  
+        },
+        "required": [
+          "description",
+          "identifier",
+          "name",
+          "url",
+          "author"
+        ],
+        "definitions": {
+          "controlledVocabulary": {
+              "definition": "collection of vocabulary terms defined in ontologies",
+              "@type": "DefinedTerm",
+              "type": "string",
+              "strict": false,
+              "vocabulary": {
+                "ontology": [
+                  "efo",
+                  "eco",
+                  "obi"
+                ],
+                "children_of": [
+                  "https://www.ebi.ac.uk/efo/EFO_0002694",
+                  "http://purl.obolibrary.org/obo/ECO_0000000",
+                  "http://purl.obolibrary.org/obo/OBI_0000011"
+                ]
+              }
+          },
+          "miscControlledVocabulary": {
+              "definition": "collection of vocabulary terms defined in ontologies",
+              "@type": "DefinedTerm",
+              "type": "string",
+              "strict": false,
+              "vocabulary": {
+                "ontology": [
+                  "eco"
+                ],
+                "children_of": [
+                  "http://purl.obolibrary.org/obo/ECO_0000000"
+                ]
+              }
+          },
+          "product": {
+              "type": "object",
+              "@type": "Product",
+              "description": "the reagent, biological sample, or material such as PPE source materials) used or tested in this protocol",
+              "properties": {
+                "name": {
+                  "description": "The name of the material or reagent",
+                  "type": "string"
+                },
+                "manufacturer": {
+                  "description": "The manufacturer of the material, biosample, or reagent",
+                  "$ref": "#/definitions/baseOrgObject"
+                },
+                "brand": {
+                  "description": "The brand of the reagent, material, or biological sample (if different from the manufacturer)",
+                  "type": "string"
+                },
+                "identifier": {
+                  "description": "The catalog number or identifier of the material or reagent",
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  ]
+                },
+                "category": {
+                  "description": "The type of material. Reagent, PPE, biological samples, etc.",
+                  "enum": [
+                    "chemical or reagent",
+                    "biological sample",
+                    "PPE",
+                    "other"
+                  ]
+                }
+              },
+              "required": [
+                "name"
+              ]
+            },
+          "instrument": {
+              "type": "object",
+              "@type": "Product",
+              "description": "A laboratory equipment use by a person to follow one or more steps described in this protocol.",
+              "properties": {
+                "name": {
+                  "description": "The name of the instrument",
+                  "type": "string"
+                },
+                "manufacturer": {
+                  "description": "The name of the manufacturer of the material, biosample, or reagent",
+                  "$ref": "#/definitions/baseOrgObject"
+                },
+                "brand": {
+                  "description": "The brand of the instrument",
+                  "type": "string"
+                },
+                "model": {
+                  "description": "The model number of the instrument",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ]
+            },
+          "baseOrgObject":{
+            "description": "A barebones Organization object to work around recursion issues in DDE",
+            "@type": "outbreak:Organization",
+            "type": "object",
+            "properties": {
+              "name": {
+                "description": "name of the organization",
+                "type": "string"
+              },
+              "alternateName": {
+                "description": "Alternate name or Acronym for the organization.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ]              
+          }, 
+          "person": {
+              "description": "Reusable person definition",
+              "@type": "outbreak:Person",
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "givenName": {
+                  "type": "string"
+                },
+                "familyName": {
+                  "type": "string"
+                },
+                "orcid": {
+                  "type": "string"
+                },
+                "affiliation": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/definitions/baseOrgObject"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/baseOrgObject"
+                      }
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "name"
+              ]
+            },
+          "memberObject": {
+              "description": "Reusable person definition accounting for recursion issues in DDE",
+              "@type": "outbreak:Person",
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "givenName": {
+                  "type": "string"
+                },
+                "familyName": {
+                  "type": "string"
+                },
+                "orcid": {
+                  "type": "string"
+                },
+                "affiliation": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/definitions/baseOrgObject"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/baseOrgObject"
+                      }
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "name"
+              ]
+            },
+          "organization": {
+            "description": "Reusable organization definition",
+            "@type": "outbreak:Organization",
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "alternateName": {
+                "type": "string"
+              },
+              "affiliation": {
+                "$ref": "#/definitions/baseOrgObject"
+              },
+              "members": {
+                 "oneOf": [
+                    {
+                      "$ref": "#/definitions/memberObject"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/memberObject"
+                      }
+                    }
+                  ]
+              }
+            },
+            "required": [
+              "name"
+            ]
+          },
+          "funding": {
+            "type": "object",
+            "@type": "outbreak:MonetaryGrant",
+            "description": "Information about funding support",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "The name of the monetary grant that funded/funds the Dataset"
+              },
+              "identifier": {
+                "type": "string",
+                "description": "Unique identifier(s) for the grant(s) used to fund the Dataset"
+              },
+              "funder": {
+                "description": "name of the funding organization",
+                "oneOf": [
+              {
+                "$ref": "#/definitions/baseOrgObject"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/baseOrgObject"
+                }
+              }
+            ]
+              },
+              "url": {
+                "type": "string",
+                "format": "uri",
+                "description": "award URL"
+              }
+            },
+            "required": [
+              "funder"
+            ]
+          },
+          "citation": {
+            "description": "A citation object for a resource which is cited by the protocol (ie- is a derivative of the protocol), related to the protocol, or from which the protocol was based on (ie- is derived from).",
+            "@type": "outbreak:CitationObject",
+            "type": "object",
+            "properties": {
+              "name": {
+                "description": "Name of or title of the citation",
+                "type": "string"
+              },
+              "identifier": {
+                "description": "An identifier associated with the citation",
+                "type": "string"
+              },
+              "pmid": {
+                "description": "A pubmed identifier if available",
+                "type": "string"
+              },
+              "doi": {
+                "description": "A doi if available",
+                "type": "string"
+              },
+              "sourceType": {
+                "description": "The type of resource",
+                "enum": [
+                  "Dataset",
+                  "Publication",
+                  "ClinicalTrial", 
+                  "Analysis",
+                  "Protocol", 
+                  "SoftwareApplication",
+                  "CreativeWork"
+                  ]
+              },
+              "url": {
+                "description": "The url of the resource cited.",
+                "type": "string",
+                "format": "uri"
+              },
+              "versionDate": {
+                "description": "The version date of the resource used at the time of the creation of the citation as certain resources (protocols, datasets) may change frequently over time.",
+                "type": "string",
+                "format": "date"
+              },
+              "citeText": {
+                "description": "The bibliographic citation for the referenced resource as is provided",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "sourceType"
+            ]
+          },
+          "reviewObject": {
+            "description": "A review or descriptive evaluation of the resource",
+            "@type": "Review",
+            "type": "object",
+            "properties": {
+              "name": {
+                    "type": "string",
+                    "description": "The name of the review"
+                  },
+              "reviewAspect":{
+                    "description": "This Review or Rating is relevant to this part or facet of the itemReviewed",
+                    "type": "string"
+                  },
+              "reviewBody": {
+                      "description": "The actual body of the review.",
+                      "type": "string"
+                  },
+              "reviewRating": {
+                "description": "The rating given in this review",
+                    "$ref": "#/definitions/ratingObject"      
+                },
+              "author": {
+                    "description": "The author of this content or rating.",
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/person"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/person"
+                      }
+                      },
+                      {
+                        "$ref": "#/definitions/organization"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/organization"
+                      }
+                }
+              ]
+            },
+              "curationDate":{
+                    "description": "The date this evaluation was added into outbreak.info, or was updated in outbreak.info.",
+                    "type": "string",
+                    "format": "date"
+                  }
+                },
+              "required": [
+              ]
+            },
+          "ratingObject": {
+            "description": "A rating or categorical evaluation of the resource",
+            "@type": "Rating",
+            "type": "object",
+            "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "The name of the rating"
+                  },
+                  "ratingExplanation": {
+                    "type": "string",
+                    "description": "An explanation of the rating"    
+                  },
+                  "ratingValue": {
+                    "type": "string",
+                    "description": "The rating for the content."
+                  },
+                  "reviewAspect": {
+                    "type": "string",
+                    "description": "This Review or Rating is relevant to this part or facet of the itemReviewed"
+                  },
+                  "author": {
+                    "description": "The author of this content or rating.",
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/person"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/person"
+                      }
+                      },
+                      {
+                        "$ref": "#/definitions/organization"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/organization"
+                      }
+                }
+              ]
+            },
+                  "curationDate":{
+                    "description": "The date this evaluation was added into outbreak.info, or was updated in outbreak.info.",
+                    "type": "string",
+                    "format": "date"
+                  }
+                },
+            "required": [
+            ]
+          },
+          "aggregateRatingObject": {
+            "description": "A cumulative evaluation of the resource",
+            "@type": "AggregateRating",
+            "type": "object",
+            "properties": {
+                "name": {
+                "type": "string",
+                "description": "The name of the aggregate rating"
+                },
+                "ratingValue": {
+                    "type": "string",
+                    "description": "The rating for the content."
+                },
+                "reviewAspect":{
+                  "description": "This Review or Rating is relevant to this part or facet of the itemReviewed",
+                  "type": "string"
+                },
+                "author": {
+                    "description": "The author of this content or rating.",
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/person"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/person"
+                      }
+                      },
+                      {
+                        "$ref": "#/definitions/organization"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/organization"
+                      }
+                }
+              ]
+            },
+                "curationDate": {
+                    "description": "The date this evaluation was added into outbreak.info, or was updated in outbreak.info.",
+                    "type": "string",
+                    "format": "date"
+                  },
+                "reviews": {
+                  "anyOf": [
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/reviewObject"
+                        }
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/ratingObject"
+                        }
+                      }
+                      
+                  ]
+                }
+            }
+          }
+        }
+      }
+    },
+    {
+      "@id": "outbreak:warning",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Precautions, warnings, and/or safety warnings associated with or highlighted by the protocol",
+      "rdfs:label": "warning",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Protocol"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:correctionNote",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "statement of what was updated/changed since prior version",
+      "rdfs:label": "correctionNote",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Protocol"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:protocolStatus",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The status of the protocol",
+      "rdfs:label": "protocolStatus",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Protocol"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:instrument",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "A laboratory equipment use by a person to follow one or more steps described in this Protocol",
+      "rdfs:label": "instrument",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Protocol"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "outbreak:Instrument"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:protocolSetting",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The type of 'protocol' based on setting in which it would apply",
+      "rdfs:label": "protocolSetting",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Protocol"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:protocolCategory",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The type of 'protocol' based on degree of specificity and purpose",
+      "rdfs:label": "protocolCategory",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Protocol"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:usedToGenerate",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Type of evidence/data generated by the protocol",
+      "rdfs:label": "usedToGenerate",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Protocol"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:inComplianceWith",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Guidelines or Standards to which these protocols adhere. ie- GMP, GCP, other EQUATOR guidelines. Useful for selecting protocols where certain standards/guidelines must be met",
+      "rdfs:label": "inComplianceWith",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Protocol"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    }, 
+    {
+      "@id": "outbreak:StudyEvent",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing StudyEvents, a class that describes categorical events in Clinical Trials added to outbreak.info",
+      "rdfs:label": "StudyEvent",
+      "rdfs:subClassOf": {
+        "@id": "schema:Thing"
+      },
+      "$validation": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "studyEventType": {
+            "description": "Type of the event status such as StudyStart, PrimaryCompletion, Completion, StudyFirstSubmit, StudyFirstSubmitQC, LastUpdateSubmit",
+            "oneOf": [
+              {
+                "enum": [
+                  "StudyStart",
+                  "PrimaryCompletion",
+                  "Completion",
+                  "StudyFirstSubmit",
+                  "StudyFirstSubmitQC",
+                  "LastUpdateSubmit"
+                ]
+              },
+              {
+                "type": "string"
+              }
+            ]
+          },
+          "studyEventDate": {
+            "description": "The corresponding/actual date of the study event (ie- the StartDate, Primary CompletionDate, CompletionDate, StudyFirstSubmitDate, StudyFirstSubmitQCDate, LastUpdateSubmitDate)",
+            "format": "date",
+            "type": "string"
+          },
+          "studyEventDateType": {
+            "description": "the type of date provided (actual, anticipated, or estimated)",
+            "oneOf": [
+              {
+                "enum": [
+                  "actual",
+                  "anticipated",
+                  "estimated"
+                ]
+              },
+              {
+                "type": "string"
+              }
+            ]
+          }
+        },
+        "required": []
+      }
+    },
+    {
+      "@id": "outbreak:studyEventType",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Type of the event status such as StudyStart, PrimaryCompletion, Completion, StudyFirstSubmit, StudyFirstSubmitQC, LastUpdateSubmit",
+      "rdfs:label": "studyEventType",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyEvent"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:studyEventDate",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The corresponding/actual date of the study event (ie- the StartDate, Primary CompletionDate, CompletionDate, StudyFirstSubmitDate, StudyFirstSubmitQCDate, LastUpdateSubmitDate)",
+      "rdfs:label": "studyEventDate",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyEvent"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Date"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:studyEventDateType",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "the type of date provided (actual, anticipated, or estimated)",
+      "rdfs:label": "studyEventDateType",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyEvent"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },  
+    {
+      "@id": "outbreak:StudyStatus",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing the status of a ClinicalTrial resource in outbreak.info",
+      "rdfs:label": "StudyStatus",
+      "rdfs:subClassOf": {
+        "@id": "schema:Thing"
+      },
+      "$validation": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "statusExpandedAccess": {
+            "description": "Flag for whether or not the study has expanded Access status",
+            "oneOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "enum": [
+                        "yes",
+                        "no",
+                        "unknown"
+                      ]
+                    }
+                  ]
+          },
+          "statusDate": {
+            "description": "The date that the status was verified. Equivalent to NCT's StatusVerifiedDate",
+            "format": "date",
+            "type": "string"
+          },
+          "enrollmentCount": {
+            "description": "The number of participants enrolled in the study",
+            "type": "integer"
+          },
+          "enrollmentType": {
+            "description": "The type of estimation used to determine the enrollmentCount (actual counts, target size, etc.)",
+            "oneOf": [
+              {
+                "enum": [
+                  "actual counts",
+                  "target size"
+                ]
+              },
+              {
+                "type": "string"
+              }
+            ]
+          },
+          "whyStopped": {
+            "description": "A brief explanation of the reason(s) why such clinical study was stopped (for a clinical study that is Suspended, Terminated, or Withdrawn prior to its planned completion as anticipated by the protocol)",
+            "type": "string"
+          },
+          "status": {
+            "description": "The recruitment status of the study",
+            "enum": [
+                "not yet recruiting",
+                "recruiting",
+                "enrolling by invitation",
+                "active",
+                "not recruiting",
+                "suspended",
+                "terminated",
+                "completed",
+                "withdrawn",
+                "unknown status"
+            ]
+          }
+        },
+        "required": [
+            "status"
+        ]
+      }
+    },
+    {
+      "@id": "outbreak:status",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The recruitment status of the study",
+      "rdfs:label": "status",
+      "rdfs:sameAs":{"@id":"schema:status"},
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyStatus"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:statusExpandedAccess",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Flag for whether or not the study has expanded Access status",
+      "rdfs:label": "statusExpandedAccess",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyStatus"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Boolean"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:statusDate",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The date that the status was verified. Equivalent to NCT's StatusVerifiedDate",
+      "rdfs:label": "statusDate",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyStatus"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Date"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:enrollmentCount",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The number of participants enrolled in the study",
+      "rdfs:label": "enrollmentCount",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyStatus"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Number"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:enrollmentType",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The type of estimation used to determine the enrollmentCount (actual counts, target size, etc.)",
+      "rdfs:label": "enrollmentType",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyStatus"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:whyStopped",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "A brief explanation of the reason(s) why such clinical study was stopped (for a clinical study that is Suspended, Terminated, or Withdrawn prior to its planned completion as anticipated by the protocol)",
+      "rdfs:label": "whyStopped",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyStatus"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:StudyDesign",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing the study design of a clinical trial/study for inclusion into outbreak.info resources",
+      "rdfs:label": "StudyDesign",
+      "rdfs:subClassOf": {
+        "@id": "schema:Thing"
+      },
+      "$validation": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "studyType": {
+            "description": "Type of human study, can be subtypes of observational study or interventional studies and may include the temporal relationship of observation period to time of participant enrollment.",
+            "enum": [
+                "interventional",
+                "observational"
+            ]
+          },
+          "phase": {
+            "description": "Stage or phase of the study in the U.S. if applicable",
+            "oneOf": [
+                    {
+                      "enum": [
+                        "Early Phase 1",
+                        "Phase 1",
+                        "Phase 2",
+                        "Phase 3",
+                        "Phase 4",
+                        "Not Applicable"
+                      ]
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "enum": [
+                          "Early Phase 1",
+                          "Phase 1",
+                          "Phase 2",
+                          "Phase 3",
+                          "Phase 4",
+                          "Not Applicable"
+                        ]
+                      }
+                    }
+                  ]
+          },
+          "phaseNumber": {
+            "description": "The number of the phase or stage of the study",
+            "oneOf": [
+                    {
+                      "enum": [
+                        "0",
+                        "1",
+                        "2",
+                        "3",
+                        "4",
+                        "Not Applicable"
+                      ]
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "enum": [
+                          "0",
+                          "1",
+                          "2",
+                          "3",
+                          "4",
+                          "Not Applicable"
+                        ]
+                      }
+                    }
+                  ]
+          },
+          "designAllocation": {
+            "description": "The method by which the study participants were allocated into groups",
+            "enum": [
+                "randomized",
+                "nonrandomized",
+                "other"
+            ]
+          },
+          "designModel": {
+            "description": "The general design of the strategy for assigning interventions to participants in a clinical intervention study OR the general design of the strategy for identifying and following up with participants during an observational study.",
+            "oneOf": [
+                {
+                    "enum": [
+                        "single group assignment",
+                        "parallel assignment",
+                        "cross-over assignment",
+                        "factorial assignment",
+                        "cohort",
+                        "case-control",
+                        "case-only",
+                        "case-cross-over",
+                        "ecologic or community studies",
+                        "family-based",
+                        "other",
+                        "retrospective",
+                        "prospective",
+                        "cross-sectional"
+                    ]
+                },
+                {
+                    "type": "array",
+                    "items": {
+                        "enum": [
+                          "single group assignment",
+                          "parallel assignment",
+                          "cross-over assignment",
+                          "factorial assignment",
+                          "cohort",
+                          "case-control",
+                          "case-only",
+                          "case-cross-over",
+                          "ecologic or community studies",
+                          "family-based",
+                          "other",
+                          "retrospective",
+                          "prospective",
+                          "cross-sectional"
+                        ]
+                    }
+                }
+            ]
+          },
+          "designPrimaryPurpose": {
+            "description": "The primary purpose of the study",
+            "enum": [
+                "treatment",
+                "prevention",
+                "diagnostic",
+                "supportive care",
+                "screening",
+                "health services research",
+                "basic science",
+                "other"
+            ]
+          },
+          "designWhoMasked": {
+            "description": "The people who do not know which participants have been assigned to which interventions",
+            "oneOf": [
+                {
+                    "enum": [
+                        "Participant",
+                        "Investigator",
+                        "Outcomes Assessor",
+                        "Care Provider"
+                    ]
+                },
+                {
+                    "type": "array",
+                    "items": {
+                        "enum": [
+                          "Participant",
+                          "Investigator",
+                          "Outcomes Assessor",
+                          "Care Provider"
+                        ]
+                    }
+                }
+            ]
+          },
+          "designStudyText": {
+            "description": "String description of the study design if structured information not available",
+            "type": "string"
+          }
+        },
+        "required": []
+      }
+    },
+    {
+      "@id": "outbreak:studyType",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Type of human study, can be subtypes of observational study or interventional studies and may include the temporal relationship of observation period to time of participant enrollment.",
+      "rdfs:label": "studyType",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyDesign"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:phase",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Stage or phase of the study in the U.S. if applicable",
+      "rdfs:label": "phase",
+      "rdfs:sameAs":{"@id":"schema:phase"},
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyDesign"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:phaseNumber",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The number of the phase or stage of the study",
+      "rdfs:label": "phaseNumber",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyDesign"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Number"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:designAllocation",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The method by which the study participants were allocated into groups",
+      "rdfs:label": "designAllocation",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyDesign"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:designModel",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The general design of the strategy for assigning interventions to participants in a clinical intervention study OR the general design of the strategy for identifying and following up with participants during an observational study",
+      "rdfs:label": "designModel",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyDesign"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:designPrimaryPurpose",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The primary purpose of the study",
+      "rdfs:label": "designPrimaryPurpose",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyDesign"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:designWhoMasked",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The people who do not know which participants have been assigned to which interventions",
+      "rdfs:label": "designWhoMasked",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyDesign"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:designStudyText",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "String description of the study design if structured information not available",
+      "rdfs:label": "designStudyText",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyDesign"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:Intervention",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "a schema to describe Interventions discussed in Clinical Studies/Trials for inclusion in outbreak.info Resources",
+      "rdfs:label": "Intervention",
+      "rdfs:subClassOf": {
+        "@id": "schema:Thing"
+      },
+      "$validation": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+            "name": {
+              "description": "The name of the intervention in the study",
+              "type": "string"
+            },
+            "description": {
+              "description": "A description of the intervention in the study",
+              "type": "string"
+            },
+            "category": {
+              "description": "The category of an intervention in the study",
+              "enum": [
+                "drugs",
+                "medical devices",
+                "procedures",
+                "vaccines",
+                "education",
+                "behavioral modification",
+                "diet",
+                "exercise",
+                "counseling",
+                "placebo",
+                "other"
+              ]
+            }
+        },
+        "required": []
+      }
+    },
+    {
+      "@id": "outbreak:category",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The category of an intervention in the study",
+      "rdfs:label": "category",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Intervention"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:ArmGroup",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing arm groups in clinical studies/trials for inclusion in outbreak.info Resources",
+      "rdfs:label": "ArmGroup",
+      "rdfs:subClassOf": {
+        "@id": "schema:Thing"
+      },
+      "$validation": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "role": {
+            "description": "The role of the arm or factor in the study this is equivalent to the ArmType in ClinicalTrials.gov",
+            "enum": [
+                "experimental arm",
+                "active comparator arm",
+                "placebo comparator arm",
+                "sham comparator arm",
+                "no intervention arm"
+            ]
+          },
+          "intervention": {
+            "description": "The interventions (if any) in this ArmGroup",
+            "type": "array",
+            "oneOf": [
+                {
+                  "$ref": "#/definitions/intervention"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/intervention"
+                  }
+                }
+            ]
+          },
+          "name": {
+            "description": "The name of the arm or factor (can include a specific intervention, a placebo or even a lack of intervention, ie- 'no intervention' group)",
+            "type": "string"
+          },
+          "description": {
+            "description": "A description of the arm or factor",
+            "type": "string"
+          }
+        },
+        "required": [],
+        "definitions":{
+          "intervention": {
+              "type": "object",
+              "@type": "outbreak:Intervention",
+              "properties": {
+                "name": {
+                  "description": "The name of the intervention in the study",
+                  "type": "string"
+                },
+                "description": {
+                  "description": "A description of the intervention in the study",
+                  "type": "string"
+                },
+                "category": {
+                  "description": "The category of an intervention in the study",
+                  "enum": [
+                    "drugs",
+                    "medical devices",
+                    "procedures",
+                    "vaccines",
+                    "education",
+                    "behavioral modification",
+                    "diet",
+                    "exercise",
+                    "counseling",
+                    "placebo",
+                    "other"
+                  ]
+                }
+              }
+            }  
+        }
+      }
+    },
+    {
+      "@id": "outbreak:intervention",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The interventions (if any) in this ArmGroup",
+      "rdfs:label": "intervention",
+      "schema:domainIncludes": {
+        "@id": "outbreak:ArmGroup"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "outbreak:Intervention"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:Outcome",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing a Clinical Trial/Study Outcome for inclusion in  outbreak.info Resources",
+      "rdfs:label": "Outcome",
+      "rdfs:subClassOf": {
+        "@id": "schema:Thing"
+      },
+      "$validation": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+            "outcomeTimeFrame": {
+                "description": "The specific time point(s) and overall duration of evaluation must be specified in this section. ",
+                "type": "string"
+            },
+            "outcomeMeasure": {
+                "description": "The outcome measure for the study",
+                "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                ]
+            },
+            "outcomeType": {
+                "description": "The classification of the outcome measure as either primary, secondary, or exploratory",
+                "enum": [
+                    "primary",
+                    "secondary",
+                    "other"
+                  ]
+            }
+        },
+        "required": []
+      }
+    },
+    {
+      "@id": "outbreak:outcomeMeasure",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The outcome measure for the study",
+      "rdfs:label": "outcomeMeasure",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Outcome"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:outcomeTimeFrame",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The specific time point(s) and overall duration of evaluation must be specified in this section",
+      "rdfs:label": "outcomeTimeFrame",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Outcome"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Duration"
+        },
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:outcomeType",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The classification of the outcome measure as either primary, secondary, or exploratory",
+      "rdfs:label": "outcomeType",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Outcome"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:Eligibility",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing information about Clinical Trials/Studies eligibility criteria for inclusion in outbreak.info Resources",
+      "rdfs:label": "Eligibility",
+      "rdfs:subClassOf": {
+        "@id": "schema:Thing"
+      },
+      "$validation": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "minimumAge": {
+            "description": "the minimum age for a participant to be included in the study",
+            "type": "string"
+          },
+          "maximumAge": {
+            "description": "the maximum age for a participant to be included in the study",
+            "type": "string"
+          },
+          "criteriaText": {
+            "description": "The descriptive criteria as published for the Clinical Trial",
+            "type": "string"
+          },
+          "inclusionCriteria": {
+            "description": "criteria for inclusion in the study",
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            ]
+          },
+          "exclusionCriteria": {
+            "description": "criteria for exclusion from the study",
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            ]
+          },
+          "gender": {
+            "description": "the sex requirement to be included in the study",
+            "enum": [
+                    "male",
+                    "female",
+                    "all"
+                ]
+          },
+          "genderBased": {
+            "description": "Boolean for whether or not participation is based on gender",
+                  "type": "boolean"
+          },
+          "healthyVolunteers": {
+            "description": "Boolean to indicate whether or not healthy volunteers may be included in the study",
+            "type": "boolean"
+          },
+          "stdAge": {
+            "description": "the age category of a participant to be included in the study if a minimum and maximum age is not specified",
+            "oneOf": [
+                {
+                    "enum": [
+                        "Child (birth-17)",
+                        "Adult (18-64)",
+                        "Older Adult (65+)"
+                      ]
+                },
+                {
+                    "items": {
+                        "enum": [
+                          "Child (birth-17)",
+                          "Adult (18-64)",
+                          "Older Adult (65+)"
+                        ]
+                    }
+                }
+            ]
+          }
+        },
+        "required": []
+      }
+    },
+    {
+      "@id": "outbreak:inclusionCriteria",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "\"criteria for inclusion in the study",
+      "rdfs:label": "inclusionCriteria",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Eligibility"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:minimumAge",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "the minimum age for a participant to be included in the study",
+      "rdfs:label": "minimumAge",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Eligibility"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:maximumAge",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "the maximum age for a participant to be included in the study",
+      "rdfs:label": "maximumAge",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Eligibility"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:gender",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "the sex requirement to be included in the study",
+      "rdfs:label": "gender",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Eligibility"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:genderBased",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Boolean for whether or not participation is based on gender",
+      "rdfs:label": "genderBased",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Eligibility"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Boolean"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:healthyVolunteers",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Boolean to indicate whether or not healthy volunteers may be included in the study",
+      "rdfs:label": "healthyVolunteers",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Eligibility"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Boolean"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:stdAge",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "the age category of a participant to be included in the study if a minimum and maximum age is not specified",
+      "rdfs:label": "stdAge",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Eligibility"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:exclusionCriteria",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "criteria for exclusion from the study",
+      "rdfs:label": "exclusionCriteria",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Eligibility"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:criteriaText",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The descriptive criteria as published for the Clinical Trial",
+      "rdfs:label": "criteriaText",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Eligibility"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:StudyLocation",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing Clinical Trial/Study locations for inclusion in outbreak.info Resources",
+      "rdfs:label": "StudyLocation",
+      "rdfs:subClassOf": {
+        "@id": "schema:Place"
+      },
+      "$validation": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "studyLocation": {
+            "description": "The location of the study as listed in the resouce.",
+            "type": "string"
+          },
+          "studyLocationCity": {
+            "description": "The city in which the facility used for the study is located",
+            "type": "string"
+          },
+          "studyLocationState": {
+            "description": "The state or province in which the facility used for the study is located",
+            "type": "string"
+          },
+          "studyLocationCountry": {
+            "description": "The country in which the facility used for the study is located",
+            "type": "string"
+          },
+          "studyLocationStatus": {
+            "description": "The recruitment status of the study at the specific study site",
+            "enum": [
+                "not yet recruiting",
+                "recruiting",
+                "enrolling by invitation",
+                "active",
+                "not recruiting",
+                "suspended",
+                "terminated",
+                "completed",
+                "withdrawn",
+                "unknown status"
+            ]
+          }
+        },
+        "required": []
+      }
+    },
+    {
+      "@id": "outbreak:studyLocation",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The location of the study",
+      "rdfs:label": "studyLocation",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyLocation"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Place"
+        },
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:studyLocationCity",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The city in which the facility used for the study is located",
+      "rdfs:label": "studyLocationCity",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyLocation"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:City"
+        },
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:studyLocationState",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The state or province in which the facility used for the study is located",
+      "rdfs:label": "studyLocationState",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyLocation"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:State"
+        },
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:studyLocationCountry",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The country in which the facility used for the study is located",
+      "rdfs:label": "studyLocationCountry",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyLocation"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Country"
+        },
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:studyLocationStatus",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The recruitment status of the study at the specific study site",
+      "rdfs:label": "studyLocationStatus",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyLocation"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+{
+      "@id": "outbreak:ClinicalTrial",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing the Clinical Trials and other medical studies used for outbreak.info Resources",
+      "rdfs:label": "ClinicalTrial",
+      "rdfs:subClassOf": {
+        "@id": "schema:MedicalStudy"
+      },
+      "$validation": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "Official or scientific title of the study",
+            "type": "string"
+          },
+          "alternateName": {
+            "description": "Brief title, acronyms, or public titles for the study",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            ]
+          },
+          "identifier": {
+              "description": "Registration number or identifier assigned to the study",
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              ]
+          },
+          "identifierSource": {
+              "description": "Source of identifier assignment or type of identifier (NCTid, China CTRid, EudraCT Number, etc.)",
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              ]
+          },
+          "abstract": {
+            "description": "A brief summary of the study",
+            "type": "string"
+          },            
+          "description": {
+            "description": "A description of the study or the stated purpose of the study",
+            "type": "string"
+          },
+          "dateCreated": {
+            "description": "Date the record was created",
+            "format": "date",
+            "type": "string"
+          },
+          "datePublished": {
+            "description": "Date the record was published",
+            "format": "date",
+            "type": "string"
+          },
+          "dateModified": {
+              "description": "LastUpdatePostDate",
+              "oneOf": [
+                {
+                  "type": "string",
+                  "format": "date"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "format": "date"
+                  }
+                }
+              ]
+          },
+          "dateModifiedType": {
+              "description": "LastUpdatePostDateType",
+              "enum": [
+                "actual",
+                "anticipated",
+                "estimated"
+              ]
+          },
+          "healthCondition": {
+              "description": "The health condition or disease being studied",
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              ]
+          },
+          "healthConditionIdentifier": {
+              "description": "Ontological or controlled vocabulary identifier for the health condition or disease",
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              ]
+          },
+          "keywords": {
+              "description": "keywords",
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              ]
+          },
           "topicCategory": {
               "description": "Applicable outbreak.info category",
               "oneOf": [
@@ -1127,59 +5689,187 @@
                   }
                 }
               ]
-            },
-          "keywords": {
-            "description": "A list of keywords associated with this dataset",
-            "oneOf": [
-                {"type":"string"},
-                {"type":"array",
-                 "items":{
-                     "type":"string"
-                 }
-                }
-            ]
+
           },
-          "isBasedOn": {
-            "description": "A citation to a resource (eg- publication, protocol, etc.) on which this dataset was derived (stored as an object, not a string)",
-            "oneOf": [{
-                "$ref": "#/definitions/citation"
+          "hasResults": {
+            "description": "Boolean for if the clinical trial has published any results",
+            "type": "boolean"
+          },
+          "url": {
+            "description": "url where the study can be found",
+            "type": "string",
+            "format": "uri"
+          },
+          "author": {
+            "description": "The study's author, this includes ResponsiblePartyInvestigator, Contacts, and OverallOfficials",
+            "oneOf": [
+              {
+                "$ref": "#/definitions/person"
               },
               {
                 "type": "array",
                 "items": {
-                  "$ref": "#/definitions/citation"
+                  "$ref": "#/definitions/person"
+                }
+              }
+            ]
+          },
+          "funding": {
+            "description": "Funding, sponsorship, and collaborations for the study.",
+            "oneOf": [
+              {
+                "$ref": "#/definitions/funding"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/funding"
+                }
+              }
+            ]
+          },
+          "studyEvent": {
+            "description": "an event status such as StudyStart, PrimaryCompletion, Completion, StudyFirstSubmit, StudyFirstSubmitQC, LastUpdateSubmit",
+            "oneOf": [
+              {
+                "$ref": "#/definitions/studyevent"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/studyevent"
+                }
+              }
+            ]
+          },
+          "studyStatus": {
+            "description": "The status of the study",
+            "oneOf": [
+              {
+                "$ref": "#/definitions/studystatus"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/studystatus"
+                }
+              }
+            ]
+          },
+          "studyDesign": {
+            "description": "The general design of the study",
+            "oneOf": [
+              {
+                "$ref": "#/definitions/studydesign"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/studydesign"
+                }
+              }
+            ]
+          },
+          "armGroup": {
+            "description": "The arm or factor of an interventional study",
+            "oneOf": [
+              {
+                "$ref": "#/definitions/armgroup"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/armgroup"
+                }
+              }
+            ]
+          },
+          "eligibilityCriteria": {
+            "description": "eligibility criteria",
+            "oneOf": [
+              {
+                "$ref": "#/definitions/eligibility"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/eligibility"
+                }
+              }
+            ]
+          },
+          "studyLocation": {
+            "description": "The location in which the study is taking/took place.",
+            "oneOf": [
+              {
+                "$ref": "#/definitions/studylocation"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/studylocation"
+                }
+              }
+            ]
+          },
+          "outcome": {
+            "description": "Expected or actual outcomes of the study.",
+            "oneOf": [
+              {
+                "$ref": "#/definitions/outcomeObject"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/outcomeObject"
                 }
               }
             ]
           },
           "citedBy": {
-            "description": "A citation to a resource (eg- publication, protocol, etc.) which is derived from this dataset (stored as an object, not a string)",
-            "oneOf": [{
-                "$ref": "#/definitions/citation"
-              },
-              {
-                "type": "array",
-                "items": {
+              "description": "Associated guidelines, protocols, publications, etc. that include, adapt, modify, expand, etc. this clinical trial/study",
+              "oneOf": [
+                {
                   "$ref": "#/definitions/citation"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/citation"
+                  }
                 }
-              }
-            ]
+              ]
+          },
+          "isBasedOn": {
+              "description": "Associated resource (guidelines, protocols, publications, etc.) from which this clinical trial/study was derived",
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/citation"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/citation"
+                  }
+                }
+              ]
           },
           "isRelatedTo": {
-            "description": "A citation to a resource (eg- publication, protocol, etc.) which is related to the dataset but is not a derivative nor was derived from the dataset (stored as an object, not a string)",
-            "oneOf": [{
-                "$ref": "#/definitions/citation"
-              },
-              {
-                "type": "array",
-                "items": {
+              "description": "Other resources related to, but not a derivative of nor derived from this clinical trial/study",
+              "oneOf": [
+                {
                   "$ref": "#/definitions/citation"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/citation"
+                  }
                 }
-              }
-            ]
+              ]
           },
           "curatedBy": {
-            "description": "The source from which this Dataset was identified for inclusion into Outbreak.info. Provides provenance for a resource which was curated by another.",
+            "description": "The source from which this clinical trial/study was identified for inclusion into Outbreak.info. Provides provenance for a resource which was curated by another.",
             "anyOf": [{
                 "$ref": "#/definitions/citation"
               },
@@ -1213,1410 +5903,9 @@
             "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
             "type": "string",
             "format": "date"
-          }
-        },
-        "required": [
-          "name",
-          "description",
-          "author",
-          "identifier"
-        ],
-        "definitions": {
-          "controlledVocabulary": {
-            "description": "collection of vocabulary terms defined in ontologies",
-            "@type": "CreativeWork",
-            "type": "string",
-            "vocabulary": {
-              "ontology": ["efo", "ncit","obi"],
-              "children_of": ["https://www.ebi.ac.uk/efo/EFO_0002694", "http://purl.obolibrary.org/obo/NCIT_C20368",
-                             "http://purl.obolibrary.org/obo/OBI_0000011"]
-            },
-            "strict": false
           },
-          "miscControlledVocabulary": {
-            "description": "collection of vocabulary terms defined in ontologies",
-            "@type": "CreativeWork",
-            "type": "string",
-            "vocabulary": {
-              "ontology": ["ncbitaxon"],
-              "children_of": ["http://purl.obolibrary.org/obo/NCBITaxon_10239"]
-            },
-            "strict": false
-          },
-          "speciesControlledVocabulary": {
-            "description": "collection of vocabulary terms defined in ontologies",
-            "@type": "CreativeWork",
-            "type": "string",
-            "vocabulary": {
-              "ontology": ["ncbitaxon"],
-              "children_of": ["http://purl.obolibrary.org/obo/NCBITaxon_131567"]
-            },
-              "strict": false
-          },
-          "diseaseVocabulary": {
-            "description": "collection of vocabulary terms defined in ontologies",
-            "@type": "CreativeWork",
-            "type": "string",
-            "vocabulary": {
-              "ontology": ["mondo"],
-              "children_of": ["http://purl.obolibrary.org/obo/MONDO_0000001"]
-            },
-            "strict": false
-          },
-          "moreControlledVocabulary": {
-              "definition": "collection of vocabulary terms defined in ontologies",
-              "@type": "CreativeWork",
-              "type": "string",
-              "strict": false,
-              "vocabulary": {
-                "ontology": [
-                  "efo",
-                  "cido",
-                  "epo",
-                  "covid19"
-                ],
-                "children_of": [
-                  "https://www.ebi.ac.uk/efo/EFO_0001444",
-                  "http://purl.obolibrary.org/obo/cido.owl",
-                  "http://purl.obolibrary.org/obo/epo",
-                  "https://bioportal.bioontology.org/ontologies/COVID19"
-                ]
-              }
-          },
-          "datadownload": {
-            "description": "A dataset in downloadable form.",
-            "@type": "DataDownload",
-            "type": "object",
-            "properties": {
-              "name": {
-                "type": "string"
-              },
-              "dateModified": {
-                "type": "string",
-                "format": "date"
-              },
-              "contentUrl": {
-                "type": "string",
-                "format": "uri"
-              }
-            },
-            "required": [
-              "dateModified",
-              "contentUrl"
-            ]
-          },
-          "baseOrgObject":{
-            "description": "A barebones Organization object to work around recursion issues in DDE",
-            "@type": "Organization",
-            "type": "object",
-            "properties": {
-              "name": {
-                "description": "name of the organization",
-                "type": "string"
-              },
-              "alternateName": {
-                "description": "Alternate name or Acronym for the organization.",
-                "type": "string"
-              }
-            },
-            "required": [
-              "name"
-            ]              
-          }, 
-          "person": {
-              "description": "Reusable person definition",
-              "@type": "Person",
-              "type": "object",
-              "properties": {
-                "name": {
-                  "type": "string"
-                },
-                "givenName": {
-                  "type": "string"
-                },
-                "familyName": {
-                  "type": "string"
-                },
-                "orcid": {
-                  "type": "string"
-                },
-                "affiliation": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/definitions/baseOrgObject"
-                    },
-                    {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/definitions/baseOrgObject"
-                      }
-                    }
-                  ]
-                }
-              },
-              "required": [
-                "name"
-              ]
-            },
-          "memberObject": {
-              "description": "Reusable person definition accounting for recursion issues in DDE",
-              "@type": "Person",
-              "type": "object",
-              "properties": {
-                "name": {
-                  "type": "string"
-                },
-                "givenName": {
-                  "type": "string"
-                },
-                "familyName": {
-                  "type": "string"
-                },
-                "orcid": {
-                  "type": "string"
-                },
-                "affiliation": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/definitions/baseOrgObject"
-                    },
-                    {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/definitions/baseOrgObject"
-                      }
-                    }
-                  ]
-                }
-              },
-              "required": [
-                "name"
-              ]
-            },
-          "organization": {
-            "description": "Reusable organization definition",
-            "@type": "Organization",
-            "type": "object",
-            "properties": {
-              "name": {
-                "type": "string"
-              },
-              "alternateName": {
-                "type": "string"
-              },
-              "affiliation": {
-                "$ref": "#/definitions/baseOrgObject"
-              },
-              "members": {
-                 "oneOf": [
-                    {
-                      "$ref": "#/definitions/memberObject"
-                    },
-                    {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/definitions/memberObject"
-                      }
-                    }
-                  ]
-              }
-            },
-            "required": [
-              "name"
-            ]
-          },
-          "funding": {
-            "type": "object",
-            "@type": "MonetaryGrant",
-            "description": "Information about funding support",
-            "properties": {
-              "name": {
-                "type": "string",
-                "description": "The name of the monetary grant that funded/funds the Dataset"
-              },
-              "identifier": {
-                "type": "string",
-                "description": "Unique identifier(s) for the grant(s) used to fund the Dataset"
-              },
-              "funder": {
-                "description": "name of the funding organization",
-                "oneOf": [
-              {
-                "$ref": "#/definitions/baseOrgObject"
-              },
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/definitions/baseOrgObject"
-                }
-              }
-            ]
-              },
-              "url": {
-                "type": "string",
-                "format": "uri",
-                "description": "award URL"
-              }
-            },
-            "required": [
-              "funder"
-            ]
-          },
-          "citation": {
-            "description": "A citation object for a resource which is cited by the dataset (ie- is a derivative of the dataset) , related to the dataset, or from which the dataset was based on (ie- is derived from).",
-            "@type": "Thing",
-            "type": "object",
-            "properties": {
-              "name": {
-                "description": "Name of or title of the citation",
-                "type": "string"
-              },
-              "identifier": {
-                "description": "An identifier associated with the citation",
-                "type": "string"
-              },
-              "pmid": {
-                "description": "A pubmed identifier if available",
-                "type": "string"
-              },
-              "doi": {
-                "description": "A doi if available",
-                "type": "string"
-              },
-              "type": {
-                "description": "The type of resource",
-                "enum": [
-                  "Dataset",
-                  "Publication",
-                  "ClinicalTrial", 
-                  "Analysis",
-                  "Protocol", 
-                  "SoftwareApplication",
-                  "Other"
-                  ]
-              },
-              "url": {
-                "description": "The url of the resource cited.",
-                "type": "string",
-                "format": "uri"
-              },
-              "versionDate": {
-                "description": "The version date of the resource used at the time of the creation of the citation as certain resources (protocols, datasets) may change frequently over time.",
-                "type": "string",
-                "format": "date"
-              },
-              "citeText": {
-                "description": "The bibliographic citation for the referenced resource as is provided",
-                "type": "string"
-              }
-            },
-            "required": [
-              "name",
-              "type"
-            ]
-          }
-        }
-      }
-    },
-    {"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"Short, descriptive title for the dataset","rdfs:label":"name","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":{"@id":"outbreak:Dataset"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:description","@type":"rdf:Property","rdfs:comment":"Longer description of what was contained in the dataset. For example, dataset fields, ...","rdfs:label":"description","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:description"},"schema:domainIncludes":{"@id":"outbreak:Dataset"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:datePublished","@type":"rdf:Property","rdfs:comment":"PublicationDate of the dataset online if available","rdfs:label":"datePublished","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:datePublished"},"schema:domainIncludes":{"@id":"outbreak:Analysis"},"schema:rangeIncludes":{"@id":"schema:Date"}},{"@id":"outbreak:dateModified","@type":"rdf:Property","rdfs:comment":"Most recent date for which the dataset was updated","rdfs:label":"dateModified","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:dateModified"},"schema:domainIncludes":{"@id":"outbreak:Analysis"},"schema:rangeIncludes":{"@id":"schema:Date"}},
-    {"@id":"outbreak:measurementTechnique","@type":"rdf:Property","rdfs:comment":"Measurement technique(s) used in collecting the dataset, e.g. RNA sequencing","rdfs:label":"measurementTechnique","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:measurementTechnique"},"schema:domainIncludes":{"@id":"outbreak:Dataset"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:variableMeasured","@type":"rdf:Property","rdfs:comment":"The factors or variables measured in the dataset","rdfs:label":"variableMeasured","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:variableMeasured"},"schema:domainIncludes":{"@id":"outbreak:Dataset"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:author","@type":"rdf:Property","rdfs:comment":"person, people, or organization that created the dataset","rdfs:label":"author","owl:cardinality":"many","marginality":"required","rdfs:sameAs":{"@id":"schema:author"},"schema:domainIncludes":{"@id":"outbreak:Dataset"},"schema:rangeIncludes":[{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"}]},{"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"The name of the author as provided by the resource","rdfs:label":"name","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":[{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:affiliation","@type":"rdf:Property","rdfs:comment":"The author's affiliation(s)","rdfs:label":"affiliation","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:affiliation"},"schema:domainIncludes":[{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"}],"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:distribution","@type":"rdf:Property","rdfs:comment":"Available downloads of the dataset","rdfs:label":"distribution","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:DataDownload"},"schema:domainIncludes":{"@id":"outbreak:Dataset"},"schema:rangeIncludes":{"@id":"outbreak:DataDownload"}},
-    {"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"The name of the download if available","rdfs:label":"name","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":{"@id":"outbreak:DataDownload"},"schema:rangeIncludes":{"@id":"schema:Text"}},  
-    {"@id":"outbreak:contentUrl","@type":"rdf:Property","rdfs:comment":"Link to the location where the dataset can be found, ideally a permanent URL","rdfs:label":"contentUrl","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:contentUrl"},"schema:domainIncludes":{"@id":"outbreak:DataDownload"},"schema:rangeIncludes":{"@id":"schema:URL"}},{"@id":"outbreak:dateModified","@type":"rdf:Property","rdfs:comment":"Date which the particular DataDownload (file) has been changed","rdfs:label":"dateModified","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:dateModified"},"schema:domainIncludes":{"@id":"outbreak:DataDownload"},"schema:rangeIncludes":{"@id":"schema:Date"}},
-    {"@id":"outbreak:funding","@type":"rdf:Property","rdfs:comment":"Funding for the generation of the dataset","rdfs:label":"funding","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"outbreak:MonetaryGrant"},"schema:domainIncludes":{"@id":"outbreak:Dataset"},"schema:rangeIncludes":{"@id":"outbreak:MonetaryGrant"}},{"@id":"outbreak:funder","@type":"rdf:Property","rdfs:comment":"Name of the funding organization ofr the dataset. Note: schema.org\/funder and schema.org\/Grant have additional fields that can provide more information about the funding organization, if desired","rdfs:label":"funder","owl:cardinality":"many","marginality":"required","rdfs:sameAs":{"@id":"schema:funder"},"schema:domainIncludes":{"@id":"outbreak:MonetaryGrant"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:identifier","@type":"rdf:Property","rdfs:comment":"The identifier of the grant (if available)","rdfs:label":"identifier","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":{"@id":"outbreak:MonetaryGrant"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:species","@type":"rdf:Property","rdfs:comment":"Species(es) from which dataset has been collected","rdfs:label":"species","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":{"@id":"outbreak:Dataset"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:infectiousAgent","@type":"rdf:Property","rdfs:comment":"The actual infectious agent, such as a specific bacterium","rdfs:label":"infectiousAgent","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:infectiousAgent"},"schema:domainIncludes":{"@id":"outbreak:Dataset"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:infectiousDisease","@type":"rdf:Property","rdfs:comment":"The infectious disease or medical condition caused by the infectious agent, such as a Covid-19","rdfs:label":"infectiousDisease","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:code"},"schema:domainIncludes":{"@id":"outbreak:Dataset"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:identifier","@type":"rdf:Property","rdfs:comment":"Unique identifier for the dataset","rdfs:label":"identifier","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":{"@id":"outbreak:Dataset"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:doi","@type":"rdf:Property","rdfs:comment":"DOI for the dataset if available","rdfs:label":"doi","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":{"@id":"outbreak:Dataset"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:license","@type":"rdf:Property","rdfs:comment":"License associated with re-use of the dataset","rdfs:label":"license","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:license"},"schema:domainIncludes":{"@id":"outbreak:Dataset"},"schema:rangeIncludes":{"@id":"schema:URL"}},
-    {"@id":"outbreak:citedBy","@type":"rdf:Property","rdfs:comment":"Associated resource (protocols, publications, etc.) that utilized or was derived from this dataset.","rdfs:label":"citedBy","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"owl:inverseOf: schema:isBasedOn"},"schema:domainIncludes":{"@id":"outbreak:Dataset"},"schema:rangeIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}]},{"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"name of the resource (publication, protocol, etc.) utilize or was derived from this dataset","rdfs:label":"name","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:type","@type":"rdf:Property","rdfs:comment":"type of resource which utilized or was derived from this dataset","rdfs:label":"type","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:additionalType"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:identifier","@type":"rdf:Property","rdfs:comment":"identifier for this resource which utilized or was derived from this dataset","rdfs:label":"identifier","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:isBasedOn","@type":"rdf:Property","rdfs:comment":"Associated resource (guidelines, protocols, publications, etc.) from which this dataset was derived","rdfs:label":"isBasedOn","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:isBasedOn"},"schema:domainIncludes":{"@id":"outbreak:Dataset"},"schema:rangeIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}]},{"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"name of the associated resource from which this dataset was derived","rdfs:label":"name","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:type","@type":"rdf:Property","rdfs:comment":"Type of resource (publication, analysis, ClinicalTrial, dataset, etc.) from which this dataset was derived","rdfs:label":"type","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:additionalType"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:identifier","@type":"rdf:Property","rdfs:comment":"Identifier for the resource","rdfs:label":"identifier","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:versionDate","@type":"rdf:Property","rdfs:comment":"date of the version of the resource from which this dataset was derived. Note this is NOT the same as dateModified, as the dataset may be based on an earlier 'dateModified' than is what is available from the resource","rdfs:label":"versionDate","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:releaseDate"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Date"}},{"@id":"outbreak:isRelatedTo","@type":"rdf:Property","rdfs:comment":"Other resources related to, but not a derivative of nor derived from this dataset","rdfs:label":"isRelatedTo","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:isRelatedTo"},"schema:domainIncludes":{"@id":"outbreak:Dataset"},"schema:rangeIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}]},{"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"name of related resource","rdfs:label":"name","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:type","@type":"rdf:Property","rdfs:comment":"type of related resource","rdfs:label":"type","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:additionalType"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:identifier","@type":"rdf:Property","rdfs:comment":"identifier (if available) of related resource","rdfs:label":"identifier","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:topicCategory","@type":"rdf:Property","rdfs:comment":"Applicable outbreak.info category","rdfs:label":"topicCategory","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:about"},"schema:domainIncludes":{"@id":"outbreak:Dataset"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:keywords","@type":"rdf:Property","rdfs:comment":"keywords","rdfs:label":"keywords","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:keywords"},"schema:domainIncludes":{"@id":"outbreak:Dataset"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:curatedBy","@type":"rdf:Property","rdfs:comment":"The source from which this dataset was identified for inclusion into Outbreak.info. Provides provenance for a resource which was curated by another","rdfs:label":"curatedBy","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:citation"},"schema:domainIncludes":{"@id":"outbreak:Dataset"},"schema:rangeIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"},{"@id":"schema:Thing"}]},
-    {"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"name of the source from which this dataset was identified for inclusion","rdfs:label":"name","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:curationDate","@type":"rdf:Property","rdfs:comment":"The date this resource was added to outbreak.info, or the date when this resource was updated in outbreak.info","rdfs:label":"curationDate","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:releaseDate"},"schema:domainIncludes":{"@id":"outbreak:Dataset"},"schema:rangeIncludes":{"@id":"schema:Date"}},
-    {
-      "@id": "outbreak:Protocol",
-      "@type": "rdfs:Class",
-      "rdfs:label": "Protocol",
-      "rdfs:comment": "This is the schema for describing the Protocol schema used for outbreak.info.",
-      "rdfs:subClassOf": {
-        "@id": "schema:HowTo"
-      },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
-      },
-      "$validation": {
-          "$schema": "http://json-schema.org/draft-07/schema#",
-          "type": "object",
-          "properties": {
-            "name": {
-              "description": "name of the protocol",
-              "type": "string"
-            },
-            "description": {
-              "description": "description of the protocol",
-              "type": "string"
-            },
-            "datePublished": {
-              "description": "PublicationDate of the protocol online if available",
-              "format": "date",
-              "type": "string"
-            },
-            "url": {
-              "description": "url where the protocol can be found",
-              "oneOf": [
-                {
-                  "type": "string",
-                  "format": "uri"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "type": "string",
-                    "format": "uri"
-                  }
-                }
-              ]
-            },
-            "identifier": {
-              "description": "An identifier associated with the protocol (if available)",
-              "type": "string"
-            },
-            "doi": {
-              "description": "A DOI associated with the protocol if available",
-              "type": "string"
-            },
-            "license": {
-              "description": "License",
-              "type": "string"
-            },
-            "warning": {
-              "description": "Precautions, warnings, and/or safety warnings associated with the protocol",
-              "oneOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                }
-              ]
-            },
-            "dateModified": {
-              "description": "Date of protocol update",
-              "oneOf": [
-                {
-                  "type": "string",
-                  "format": "date"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "type": "string",
-                    "format": "date"
-                  }
-                }
-              ]
-            },
-            "correctionNote": {
-              "description": "statement of what was updated/changed since prior version",
-              "oneOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                }
-              ]
-            },
-            "status": {
-              "description": "The status of the protocol",
-              "enum": [
-                "Working--In use by author",
-                "Working--not in use by author",
-                "Working--in use by others",
-                "Not working",
-                "In Development",
-                "Deprecated"
-              ]
-            },
-            "material": {
-              "description": "the reagent, biological sample, or material such as PPE source materials) used or tested in this protocol",
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/product"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/product"
-                  }
-                }
-              ]
-            },
-            "instrument": {
-              "description": "For LabProtocols it would be a laboratory equipment use by a person to follow one or more steps described in this LabProtocol.",
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/instrument"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/instrument"
-                  }
-                }
-              ]
-            },
-            "measurementTechnique": {
-                "description": "A technique or technology used in this protocol.",
-                "oneOf": [{
-                    "$ref": "#/definitions/controlledVocabulary"
-                  },
-                  {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/definitions/controlledVocabulary"
-                    }
-                  }
-                ]
-            },
-            "protocolSetting": {
-              "description": "The type of 'protocol' based on setting in which it would apply",
-              "enum": [
-                    "clinical",
-                    "experimental",
-                    "field",
-                    "computational",
-                    "public"
-              ]
-            },
-            "protocolCategory": {
-              "description": "The type of 'protocol' based on degree of specificity and purpose",
-              "enum": [
-                    "protocol",
-                    "procedure",
-                    "policy",
-                    "guideline"
-              ]
-            },
-            "usedToGenerate": {
-              "description": "Type of evidence/data generated by the protocol",
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/miscControlledVocabulary"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/miscControlledVocabulary"
-                  }
-                }
-              ]
-            },
-            "inComplianceWith": {
-              "description": "Guidelines or Standards to which these protocols adhere. ie- GMP, GCP, other EQUATOR guidelines. Useful for selecting protocols where certain standards/guidelines must be met",
-              "oneOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                }
-              ]
-            },
-            "keywords": {
-              "description": "keywords",
-              "oneOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                }
-              ]
-            },
-            "topicCategory": {
-              "description": "Applicable outbreak.info category",
-              "oneOf": [
-                {
-                  "enum": [
-                    "Clinical",
-                    "Case Descriptions",
-                    "Risk Factors",
-                    "Diagnosis",
-                    "Symptoms",
-                    "Rapid Diagnostics",
-                    "Antibody Detection",
-                    "Virus Detection",
-                    "Testing Prevalence",
-                    "Pathology/Radiology",
-                    "Forecasting",
-                    "Mechanism",
-                    "Virus Factors",
-                    "Host Factors",
-                    "Immunological Response",
-                    "Mechanism of Infection",
-                    "Mechanism of Transmission",
-                    "Prevention",
-                    "Public Health Interventions",
-                    "Individual Prevention",
-                    "Transmission",
-                    "Host/Intermediate Reservoirs",
-                    "Viral Shedding / Persistence",
-                    "Treatment",
-                    "Vaccines",
-                    "Pharmaceutical Treatments",
-                    "Medical Care",
-                    "Repurposing",
-                    "Biologics",
-                    "Behavioral Research",
-                    "Epidemiology",
-                    "Classical Epidemiology",
-                    "Molecular Epidemiology"
-                  ]
-                },
-                {
-                  "type": "array",
-                  "items": {
-                      "enum": [
-                        "Clinical",
-                        "Case Descriptions",
-                        "Risk Factors",
-                        "Diagnosis",
-                        "Symptoms",
-                        "Rapid Diagnostics",
-                        "Antibody Detection",
-                        "Virus Detection",
-                        "Testing Prevalence",
-                        "Pathology/Radiology",
-                        "Forecasting",
-                        "Mechanism",
-                        "Virus Factors",
-                        "Host Factors",
-                        "Immunological Response",
-                        "Mechanism of Infection",
-                        "Mechanism of Transmission",
-                        "Prevention",
-                        "Public Health Interventions",
-                        "Individual Prevention",
-                        "Transmission",
-                        "Host/Intermediate Reservoirs",
-                        "Viral Shedding / Persistence",
-                        "Treatment",
-                        "Vaccines",
-                        "Pharmaceutical Treatments",
-                        "Medical Care",
-                        "Repurposing",
-                        "Biologics",
-                        "Behavioral Research",
-                        "Epidemiology",
-                        "Classical Epidemiology",
-                        "Molecular Epidemiology"
-                      ]
-                  }
-                }
-              ]
-
-            },
-            "author": {
-              "description": "person, people, or organization that created the protocol",
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/person"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/person"
-                  }
-                },
-                {
-                  "$ref": "#/definitions/organization"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/organization"
-                  }
-                }
-              ]
-            },
-            "funding": {
-              "description": "The funder of the Protocol",
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/funding"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/funding"
-                  }
-                }
-              ]
-            },
-            "citedBy": {
-              "description": "Associated guidelines, protocols, publications, etc. that include, adapt, modify, expand, etc. this protocol.",
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/citation"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/citation"
-                  }
-                }
-              ]
-            },
-            "isBasedOn": {
-              "description": "Associated resource (guidelines, protocols, publications, etc.) from which this protocol was derived",
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/citation"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/citation"
-                  }
-                }
-              ]
-            },
-            "isRelatedTo": {
-              "description": "Other resources related to, but not a derivative of nor derived from this protocol",
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/citation"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/citation"
-                  }
-                }
-              ]
-            },
-            "curatedBy": {
-            "description": "The source from which this Protocol was identified for inclusion into Outbreak.info. Provides provenance for a resource which was curated by another.",
-            "anyOf": [{
-                "$ref": "#/definitions/citation"
-              },
-              {
-                "$ref": "#/definitions/person"
-              },
-              {
-                "$ref": "#/definitions/organization"
-              },
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/definitions/person"
-                }
-              },
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/definitions/organization"
-                }
-              },
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/definitions/citation"
-                }
-              }
-            ]
-          },
-            "curationDate":{
-            "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
-            "type": "string",
-            "format": "date"
-          }
-          },
-          "required": [
-            "name",
-            "description",
-            "datePublished",
-            "url",
-            "identifier",
-            "author"
-          ],
-          "definitions": {
-            "controlledVocabulary": {
-              "definition": "collection of vocabulary terms defined in ontologies",
-              "@type": "CreativeWork",
-              "type": "string",
-              "strict": false,
-              "vocabulary": {
-                "ontology": [
-                  "efo",
-                  "eco",
-                  "obi"
-                ],
-                "children_of": [
-                  "https://www.ebi.ac.uk/efo/EFO_0002694",
-                  "http://purl.obolibrary.org/obo/ECO_0000000",
-                  "http://purl.obolibrary.org/obo/OBI_0000011"
-                ]
-              }
-            },
-            "miscControlledVocabulary": {
-              "definition": "collection of vocabulary terms defined in ontologies",
-              "@type": "CreativeWork",
-              "type": "string",
-              "strict": false,
-              "vocabulary": {
-                "ontology": [
-                  "eco"
-                ],
-                "children_of": [
-                  "http://purl.obolibrary.org/obo/ECO_0000000"
-                ]
-              }
-            },
-            "baseOrgObject":{
-            "description": "A barebones Organization object to work around recursion issues in DDE",
-            "@type": "Organization",
-            "type": "object",
-            "properties": {
-              "name": {
-                "description": "name of the organization",
-                "type": "string"
-              },
-              "alternateName": {
-                "description": "Alternate name or Acronym for the organization.",
-                "type": "string"
-              }
-            },
-            "required": [
-              "name"
-            ]              
-          }, 
-            "person": {
-              "description": "Reusable person definition",
-              "@type": "Person",
-              "type": "object",
-              "properties": {
-                "name": {
-                  "type": "string"
-                },
-                "givenName": {
-                  "type": "string"
-                },
-                "familyName": {
-                  "type": "string"
-                },
-                "orcid": {
-                  "type": "string"
-                },
-                "affiliation": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/definitions/baseOrgObject"
-                    },
-                    {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/definitions/baseOrgObject"
-                      }
-                    }
-                  ]
-                }
-              },
-              "required": [
-                "name"
-              ]
-            },
-            "memberObject": {
-              "description": "Reusable person definition accounting for recursion issues in DDE",
-              "@type": "Person",
-              "type": "object",
-              "properties": {
-                "name": {
-                  "type": "string"
-                },
-                "givenName": {
-                  "type": "string"
-                },
-                "familyName": {
-                  "type": "string"
-                },
-                "orcid": {
-                  "type": "string"
-                },
-                "affiliation": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/definitions/baseOrgObject"
-                    },
-                    {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/definitions/baseOrgObject"
-                      }
-                    }
-                  ]
-                }
-              },
-              "required": [
-                "name"
-              ]
-            },
-            "organization": {
-            "description": "Reusable organization definition",
-            "@type": "Organization",
-            "type": "object",
-            "properties": {
-              "name": {
-                "type": "string"
-              },
-              "alternateName": {
-                "type": "string"
-              },
-              "affiliation": {
-                "$ref": "#/definitions/baseOrgObject"
-              },
-              "members": {
-                 "oneOf": [
-                    {
-                      "$ref": "#/definitions/memberObject"
-                    },
-                    {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/definitions/memberObject"
-                      }
-                    }
-                  ]
-              }
-            },
-            "required": [
-              "name"
-            ]
-          },
-            "funding": {
-                "type": "object",
-                "@type": "MonetaryGrant",
-                "description": "Information about funding support",
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "description": "The name of the monetary grant that funded/funds the protocol"
-                  },
-                  "identifier": {
-                    "type": "string",
-                    "description": "Unique identifier(s) for the grant(s) used to fund the protocol"
-                  },
-                  "funder": {
-                    "description": "name of the funding organization",
-                    "oneOf": [
-                  {
-                    "$ref": "#/definitions/baseOrgObject"
-                  },
-                  {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/definitions/baseOrgObject"
-                    }
-                  }
-                ]
-                  },
-                  "url": {
-                    "type": "string",
-                    "format": "uri",
-                    "description": "award URL"
-                  }
-                },
-                "required": [
-                  "funder"
-                ]
-          },
-            "product": {
-              "type": "object",
-              "@type": "Product",
-              "description": "the reagent, biological sample, or material such as PPE source materials) used or tested in this protocol",
-              "properties": {
-                "name": {
-                  "description": "The name of the material or reagent",
-                  "type": "string"
-                },
-                "manufacturer": {
-                  "description": "The manufacturer of the material, biosample, or reagent",
-                  "$ref": "#/definitions/baseOrgObject"
-                },
-                "brand": {
-                  "description": "The brand of the reagent, material, or biological sample (if different from the manufacturer)",
-                  "type": "string"
-                },
-                "identifier": {
-                  "description": "The catalog number or identifier of the material or reagent",
-                  "oneOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
-                    }
-                  ]
-                },
-                "type": {
-                  "description": "The type of material. Reagent, PPE, biological samples, etc.",
-                  "enum": [
-                    "chemical or reagent",
-                    "biological sample",
-                    "PPE",
-                    "other"
-                  ]
-                }
-              },
-              "required": [
-                "name"
-              ]
-            },
-            "instrument": {
-              "type": "object",
-              "@type": "Product",
-              "description": "A laboratory equipment use by a person to follow one or more steps described in this protocol.",
-              "properties": {
-                "name": {
-                  "description": "The name of the instrument",
-                  "type": "string"
-                },
-                "manufacturer": {
-                  "description": "The name of the manufacturer of the material, biosample, or reagent",
-                  "$ref": "#/definitions/baseOrgObject"
-                },
-                "brand": {
-                  "description": "The brand of the instrument",
-                  "type": "string"
-                },
-                "model": {
-                  "description": "The model number of the instrument",
-                  "type": "string"
-                }
-              },
-              "required": [
-                "name"
-              ]
-            },
-            "citation": {
-                "description": "A citation object for a resource which is cited by the protocol (ie- is a derivative of the protocol) , related to the protocol, or from which the protocol was based on (ie- is derived from).",
-                "@type": "Thing",
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "description": "Name of or title of the citation",
-                    "type": "string"
-                  },
-                  "identifier": {
-                    "description": "An identifier associated with the citation",
-                    "type": "string"
-                  },
-                  "pmid": {
-                    "description": "A pubmed identifier if available",
-                    "type": "string"
-                  },
-                  "doi": {
-                    "description": "A doi if available",
-                    "type": "string"
-                  },
-                  "type": {
-                    "description": "The type of resource",
-                    "enum": [
-                      "Dataset",
-                      "Publication",
-                      "ClinicalTrial", 
-                      "Analysis",
-                      "Protocol", 
-                      "SoftwareApplication",
-                      "Other"
-                      ]
-                  },
-                  "url": {
-                    "description": "The url of the resource cited.",
-                    "type": "string",
-                    "format": "uri"
-                  },
-                  "versionDate": {
-                    "description": "The version date of the resource used at the time of the creation of the citation as certain resources (protocols, datasets) may change frequently over time.",
-                    "type": "string",
-                    "format": "date"
-                  },
-                  "citeText": {
-                      "description": "The bibliographic citation for the referenced resource as is provided",
-                      "type": "string"
-                    }
-                },
-                "required": [
-                  "name",
-                  "type"
-                ]
-              }
-          }
-      }
-    },
-    {"@id":"outbreak:url","@type":"rdf:Property","rdfs:comment":"url where the protocol can be found","rdfs:label":"url","owl:cardinality":"many","marginality":"required","rdfs:sameAs":{"@id":"schema:url"},"schema:domainIncludes":{"@id":"outbreak:Protocol"},"schema:rangeIncludes":{"@id":"schema:URL"}},{"@id":"outbreak:identifier","@type":"rdf:Property","rdfs:comment":"An identifier associated with the protocol","rdfs:label":"identifier","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":{"@id":"outbreak:Protocol"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:doi","@type":"rdf:Property","rdfs:comment":"A DOI associated with the protocol if available","rdfs:label":"doi","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":{"@id":"outbreak:Protocol"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"name of the protocol","rdfs:label":"name","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":{"@id":"outbreak:Protocol"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:description","@type":"rdf:Property","rdfs:comment":"description of the protocol","rdfs:label":"description","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:description"},"schema:domainIncludes":{"@id":"outbreak:Protocol"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:status","@type":"rdf:Property","rdfs:comment":"The status of the protocol","rdfs:label":"status","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:creativeWorkStatus"},"schema:domainIncludes":{"@id":"outbreak:Protocol"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:measurementTechnique","@type":"rdf:Property","rdfs:comment":"This is the measurement technique or assay type covered described by the protocol","rdfs:label":"measurementTechnique","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"outbreak:measurementTechnique"},"schema:domainIncludes":{"@id":"outbreak:Protocol"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:protocolSetting","@type":"rdf:Property","rdfs:comment":"The type of research setting in which a \"protocol\" is appropriate, such as 'clinical', 'experimental', 'field', 'computational'","rdfs:label":"protocolSetting","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":{"@id":"outbreak:Protocol"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:protocolCategory","@type":"rdf:Property","rdfs:comment":"The type of \"protocol\" such as guideline, procedure, policy, etc.","rdfs:label":"protocolCategory","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":{"@id":"outbreak:Protocol"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:author","@type":"rdf:Property","rdfs:comment":"person, people, or organization that created the protocol","rdfs:label":"author","owl:cardinality":"many","marginality":"required","rdfs:sameAs":{"@id":"schema:author"},"schema:domainIncludes":{"@id":"outbreak:Protocol"},"schema:rangeIncludes":[{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"}]},{"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"The name of the author as provided by the resource","rdfs:label":"name","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":[{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:affiliation","@type":"rdf:Property","rdfs:comment":"The author's affiliation(s)","rdfs:label":"affiliation","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:affiliation"},"schema:domainIncludes":[{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:material","@type":"rdf:Property","rdfs:comment":"the reagent, biological sample, or material such as PPE source materials) used or tested in this protocol","rdfs:label":"material","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:Product"},"schema:domainIncludes":{"@id":"outbreak:Protocol"},"schema:rangeIncludes":{"@id":"outbreak:Product"}},{"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"The name of the material or reagent","rdfs:label":"name","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":{"@id":"outbreak:Product"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:manufacturer","@type":"rdf:Property","rdfs:comment":"The manufacturer, brand, or vendor of the material or reagent","rdfs:label":"manufacturer","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:manufacturer"},"schema:domainIncludes":{"@id":"outbreak:Product"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:identifier","@type":"rdf:Property","rdfs:comment":"The catalog number or identifier of the material or reagent","rdfs:label":"identifier","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":{"@id":"outbreak:Product"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:type","@type":"rdf:Property","rdfs:comment":"Type of material","rdfs:label":"type","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":{"@id":"outbreak:Product"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:instrument","@type":"rdf:Property","rdfs:comment":"For LabProtocols it would be a laboratory equipment use by a person to follow one or more steps described in this LabProtocol.","rdfs:label":"instrument","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:Product"},"schema:domainIncludes":{"@id":"outbreak:Protocol"},"schema:rangeIncludes":{"@id":"outbreak:Instrument"}},{"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"The name\/model number of the instrument","rdfs:label":"name","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":{"@id":"outbreak:Instrument"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:manufacturer","@type":"rdf:Property","rdfs:comment":"The manufacturer, brand, or vendor of the instrument","rdfs:label":"manufacturer","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:manufacturer"},"schema:domainIncludes":{"@id":"outbreak:Instrument"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:warning","@type":"rdf:Property","rdfs:comment":"Precautions, warnings, and\/or safety warnings associated with the protocol","rdfs:label":"warning","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:warning"},"schema:domainIncludes":{"@id":"outbreak:Protocol"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:license","@type":"rdf:Property","rdfs:comment":"License","rdfs:label":"license","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:license"},"schema:domainIncludes":{"@id":"outbreak:Protocol"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:funding","@type":"rdf:Property","rdfs:comment":"Funding for the generation of the protocol","rdfs:label":"funding","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"outbreak:MonetaryGrant"},"schema:domainIncludes":{"@id":"outbreak:Protocol"},"schema:rangeIncludes":{"@id":"outbreak:MonetaryGrant"}},{"@id":"outbreak:funder","@type":"rdf:Property","rdfs:comment":"The funder of the study","rdfs:label":"funder","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:funder"},"schema:domainIncludes":{"@id":"outbreak:MonetaryGrant"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:identifier","@type":"rdf:Property","rdfs:comment":"The identifier of the grant (if available)","rdfs:label":"identifier","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":{"@id":"outbreak:MonetaryGrant"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:datePublished","@type":"rdf:Property","rdfs:comment":"PublicationDate of the protocol online if available","rdfs:label":"datePublished","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:datePublished"},"schema:domainIncludes":{"@id":"outbreak:Protocol"},"schema:rangeIncludes":{"@id":"schema:Date"}},{"@id":"outbreak:dateModified","@type":"rdf:Property","rdfs:comment":"Date of protocol update","rdfs:label":"dateModified","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:dateModified"},"schema:domainIncludes":{"@id":"outbreak:Protocol"},"schema:rangeIncludes":{"@id":"schema:Date"}},
-    {"@id":"outbreak:correctionNote","@type":"rdf:Property","rdfs:comment":"statement of what was updated\/changed since prior version","rdfs:label":"correctionNote","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:correction"},"schema:domainIncludes":{"@id":"outbreak:Protocol"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:citedBy","@type":"rdf:Property","rdfs:comment":"Associated guidelines, protocols, publications, etc. that include, adapt, modify, expand, etc. this protocol.","rdfs:label":"citedBy","owl:cardinality":"many","marginality":"optional","owl:inverseOf":{"@id":"schema:isBasedOn"},"schema:domainIncludes":{"@id":"outbreak:Protocol"},"schema:rangeIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}]},{"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"name of the resource (publication, protocol, etc.) which was derived from this protocol","rdfs:label":"name","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:type","@type":"rdf:Property","rdfs:comment":"type of resource which was derived from this protocol","rdfs:label":"type","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:additionalType"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:identifier","@type":"rdf:Property","rdfs:comment":"identifier for this resource which was derived from this protocol","rdfs:label":"identifier","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:isBasedOn","@type":"rdf:Property","rdfs:comment":"Associated resource (guidelines, protocols, publications, etc.) from which this protocol was derived","rdfs:label":"isBasedOn","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:isBasedOn"},"schema:domainIncludes":{"@id":"outbreak:Protocol"},"schema:rangeIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}]},{"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"name of the associated resource from which this protocol was derived","rdfs:label":"name","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:type","@type":"rdf:Property","rdfs:comment":"Type of resource (publication, analysis, ClinicalTrial, dataset, etc.) from which this protocol was derived","rdfs:label":"type","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:additionalType"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:identifier","@type":"rdf:Property","rdfs:comment":"Identifier for the resource","rdfs:label":"identifier","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:versionDate","@type":"rdf:Property","rdfs:comment":"date of the version of the resource from which this protocol was derived. Note this is NOT the same as dateModified, as the protocol may be based on an earlier 'dateModified' than is what is available from the resource","rdfs:label":"versionDate","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:releaseDate"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Date"}},{"@id":"outbreak:isRelatedTo","@type":"rdf:Property","rdfs:comment":"Other resources related to, but not a derivative of nor derived from this protocol","rdfs:label":"isRelatedTo","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:isRelatedTo"},"schema:domainIncludes":{"@id":"outbreak:Protocol"},"schema:rangeIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}]},{"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"name of related resource","rdfs:label":"name","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:type","@type":"rdf:Property","rdfs:comment":"type of related resource","rdfs:label":"type","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:additionalType"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:identifier","@type":"rdf:Property","rdfs:comment":"identifier (if available_ of related resource","rdfs:label":"identifier","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:topicCategory","@type":"rdf:Property","rdfs:comment":"Applicable outbreak.info category","rdfs:label":"topicCategory","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:about"},"schema:domainIncludes":{"@id":"outbreak:Protocol"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:keywords","@type":"rdf:Property","rdfs:comment":"keywords","rdfs:label":"keywords","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:keywords"},"schema:domainIncludes":{"@id":"outbreak:Protocol"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:usedToGenerate","@type":"rdf:Property","rdfs:comment":"Type of evidence\/data generated by the protocol","rdfs:label":"usedToGenerate","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":{"@id":"outbreak:Protocol"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:inComplianceWith","@type":"rdf:Property","rdfs:comment":"Guidelines or Standards to which these protocols adhere. ie- GMP, GCP, other EQUATOR guidelines. Useful for selecting protocols where certain standards\/guidelines must be met","rdfs:label":"inComplianceWith","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":{"@id":"outbreak:Protocol"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:duration","@type":"rdf:Property","rdfs:comment":"The time it takes to actually carry out the protocol, in ISO 8601 date format.","rdfs:label":"duration","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:performTime"},"schema:domainIncludes":{"@id":"outbreak:Protocol"},"schema:rangeIncludes":[{"@id":"schema:Duration"},{"@id":"schema:Text"}]},
-    {"@id":"outbreak:curatedBy","@type":"rdf:Property","rdfs:comment":"The source from which this protocol was identified for inclusion into Outbreak.info. Provides provenance for a resource which was curated by another","rdfs:label":"curatedBy","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:citation"},"schema:domainIncludes":{"@id":"outbreak:Protocol"},"schema:rangeIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"},{"@id":"schema:Thing"}]},
-    {"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"name of the source from which this protocol was identified for inclusion","rdfs:label":"name","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:curationDate","@type":"rdf:Property","rdfs:comment":"The date this resource was added to outbreak.info, or the date when this resource was updated in outbreak.info","rdfs:label":"curationDate","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:releaseDate"},"schema:domainIncludes":{"@id":"outbreak:Protocol"},"schema:rangeIncludes":{"@id":"schema:Date"}},
-    {
-      "@id": "outbreak:Publication",
-      "@type": "rdfs:Class",
-      "rdfs:label": "Publication",
-      "rdfs:comment": "This is the schema for describing the Publication schema used for outbreak.info.",
-      "rdfs:subClassOf": {
-        "@id": "schema:ScholarlyArticle"
-      },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
-      },
-      "$validation": {
-          "$schema": "http://json-schema.org/draft-07/schema#",
-          "type": "object",
-          "properties": {
-            "name": {
-              "description": "Title of the article",
-              "type": "string"
-            },
-            "identifier": {
-              "description": "DOI (preferred) or PMID (e.g., 10.1126/sciimmunol.aaw6329, PMID:31471352)",
-              "type": "string"
-            },
-            "doi": {
-              "description": "DOI",
-              "type": "string"
-            },
-            "pmid": {
-              "description": "PMID",
-              "type": "integer"
-            },
-            "journalName": {
-              "description": "Journal or preprint server name",
-              "type": "string"
-            },
-            "journalNameAbbrevation": {
-              "description": "Abbreviated Journal Title (note, this should be autopopulated)",
-              "type": "string"
-            },
-            "volumeNumber": {
-              "description": "Volume number of journal in which the article was published",
-              "type": "string"
-            },
-            "issueNumber": {
-              "description": "Issue of journal in which the article was published",
-              "type": "string"
-            },
-            "pagination": {
-              "description": "Any description of pages for the article",
-              "type": "string"
-            },
-            "license": {
-              "description": "License",
-              "type": "string"
-            },
-            "abstract": {
-              "description": "Article abstract ",
-              "type": "string"
-            },
-            "datePublished": {
-              "description": "PublicationDate online if available",
-              "format": "date",
-              "type": "string"
-            },
-            "url": {
-              "description": "url where the article can be found",
-              "oneOf": [
-                {
-                  "type": "string",
-                  "format": "uri"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "type": "string",
-                    "format": "uri"
-                  }
-                }
-              ]
-            },
-            "publicationType": {
-              "description": "Type of publication such as preprint, research article, case report, etc",
-              "oneOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                }
-              ]
-            },
-            "dateModified": {
-              "description": "Date of Version update",
-              "oneOf": [
-                {
-                  "type": "string",
-                  "format": "date"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "type": "string",
-                    "format": "date"
-                  }
-                }
-              ]
-            },
-            "correction": {
-              "description": "Version number or correction statement",
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/correctionObject"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/correctionObject"
-                  }
-                }
-              ]
-            },
-            "keywords": {
-              "description": "Keywords",
-              "oneOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                }
-              ]
-            },
-            "topicCategory": {
-              "description": "Applicable outbreak.info category",
-              "oneOf": [
-                {
-                  "enum": [
-                    "Clinical",
-                    "Case Descriptions",
-                    "Risk Factors",
-                    "Diagnosis",
-                    "Symptoms",
-                    "Rapid Diagnostics",
-                    "Antibody Detection",
-                    "Virus Detection",
-                    "Testing Prevalence",
-                    "Pathology/Radiology",
-                    "Forecasting",
-                    "Mechanism",
-                    "Virus Factors",
-                    "Host Factors",
-                    "Immunological Response",
-                    "Mechanism of Infection",
-                    "Mechanism of Transmission",
-                    "Prevention",
-                    "Public Health Interventions",
-                    "Individual Prevention",
-                    "Transmission",
-                    "Host/Intermediate Reservoirs",
-                    "Viral Shedding / Persistence",
-                    "Treatment",
-                    "Vaccines",
-                    "Pharmaceutical Treatments",
-                    "Medical Care",
-                    "Repurposing",
-                    "Biologics",
-                    "Behavioral Research",
-                    "Epidemiology",
-                    "Classical Epidemiology",
-                    "Molecular Epidemiology"
-                  ]
-                },
-                {
-                  "type": "array",
-                  "items": {
-                      "enum": [
-                        "Clinical",
-                        "Case Descriptions",
-                        "Risk Factors",
-                        "Diagnosis",
-                        "Symptoms",
-                        "Rapid Diagnostics",
-                        "Antibody Detection",
-                        "Virus Detection",
-                        "Testing Prevalence",
-                        "Pathology/Radiology",
-                        "Forecasting",
-                        "Mechanism",
-                        "Virus Factors",
-                        "Host Factors",
-                        "Immunological Response",
-                        "Mechanism of Infection",
-                        "Mechanism of Transmission",
-                        "Prevention",
-                        "Public Health Interventions",
-                        "Individual Prevention",
-                        "Transmission",
-                        "Host/Intermediate Reservoirs",
-                        "Viral Shedding / Persistence",
-                        "Treatment",
-                        "Vaccines",
-                        "Pharmaceutical Treatments",
-                        "Medical Care",
-                        "Repurposing",
-                        "Biologics",
-                        "Behavioral Research",
-                        "Epidemiology",
-                        "Classical Epidemiology",
-                        "Molecular Epidemiology"
-                      ]
-                  }
-                }
-              ]
-
-            },
-            "author": {
-              "description": "Name of the author or organization that created the dataset.  Note: schema.org/creator and schema.org/organization have additional fields that can provide more information about the author/organization, if desired",
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/person"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/person"
-                  }
-                },
-                {
-                  "$ref": "#/definitions/organization"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/organization"
-                  }
-                }
-              ]
-            },
-            "funding": {
-              "description": "The funder of the study",
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/funding"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/funding"
-                  }
-                }
-              ]
-            },
-            "citedBy": {
-              "description": "other articles or resources that cite this publication",
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/citation"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/citation"
-                  }
-                }
-              ]
-            },
-            "isBasedOn": {
-              "description": "Associated datasets, software, protocols, etc. used by the work described in this publication, including reference publications",
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/citation"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/citation"
-                  }
-                }
-              ]
-            },
-            "isRelatedTo": {
-              "description": "Related articles or resources such as pre-prints, comments, editorial summaries of the article, etc. Helpful for de-duplication between pre-print and peer-reviewed version",
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/citation"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/citation"
-                  }
-                }
-              ]
-            },
-            "curatedBy": {
-            "description": "The source from which this Publication was identified for inclusion into Outbreak.info. Provides provenance for a resource which was curated by another.",
-            "anyOf": [{
-                "$ref": "#/definitions/citation"
-              },
-              {
-                "$ref": "#/definitions/person"
-              },
-              {
-                "$ref": "#/definitions/organization"
-              },
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/definitions/person"
-                }
-              },
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/definitions/organization"
-                }
-              },
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/definitions/citation"
-                }
-              }
-            ]
-          },
-            "curationDate":{
-            "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
-            "type": "string",
-            "format": "date"
-          },
-            "evaluations":{
+          "evaluations":{
+              "description": "Reviews, Ratings, or other types of evaluations on this resource",
               "anyOf":[
               {
                 "type": "array",
@@ -2637,863 +5926,21 @@
                 }
               }
             ]
-            }
-          },
-          "required": [
-            "name",
-            "identifier",
-            "datePublished",
-            "journalName",
-            "url",
-            "author"
-          ],
-          "definitions": {
-            "baseOrgObject":{
-                "description": "A barebones Organization object to work around recursion issues in DDE",
-                "@type": "Organization",
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "description": "name of the organization",
-                    "type": "string"
-                  },
-                  "alternateName": {
-                    "description": "Alternate name or Acronym for the organization.",
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "name"
-                ]              
-              }, 
-            "person": {
-                  "description": "Reusable person definition",
-                  "@type": "Person",
-                  "type": "object",
-                  "properties": {
-                    "name": {
-                      "type": "string"
-                    },
-                    "givenName": {
-                      "type": "string"
-                    },
-                    "familyName": {
-                      "type": "string"
-                    },
-                    "orcid": {
-                      "type": "string"
-                    },
-                    "affiliation": {
-                      "oneOf": [
-                        {
-                          "$ref": "#/definitions/baseOrgObject"
-                        },
-                        {
-                          "type": "array",
-                          "items": {
-                            "$ref": "#/definitions/baseOrgObject"
-                          }
-                        }
-                      ]
-                    }
-                  },
-                  "required": [
-                    "name"
-                  ]
-                },
-            "memberObject": {
-                  "description": "Reusable person definition accounting for recursion issues in DDE",
-                  "@type": "Person",
-                  "type": "object",
-                  "properties": {
-                    "name": {
-                      "type": "string"
-                    },
-                    "givenName": {
-                      "type": "string"
-                    },
-                    "familyName": {
-                      "type": "string"
-                    },
-                    "orcid": {
-                      "type": "string"
-                    },
-                    "affiliation": {
-                      "oneOf": [
-                        {
-                          "$ref": "#/definitions/baseOrgObject"
-                        },
-                        {
-                          "type": "array",
-                          "items": {
-                            "$ref": "#/definitions/baseOrgObject"
-                          }
-                        }
-                      ]
-                    }
-                  },
-                  "required": [
-                    "name"
-                  ]
-                },
-            "organization": {
-                "description": "Reusable organization definition",
-                "@type": "Organization",
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": "string"
-                  },
-                  "alternateName": {
-                    "type": "string"
-                  },
-                  "affiliation": {
-                    "$ref": "#/definitions/baseOrgObject"
-                  },
-                  "members": {
-                     "oneOf": [
-                        {
-                          "$ref": "#/definitions/memberObject"
-                        },
-                        {
-                          "type": "array",
-                          "items": {
-                            "$ref": "#/definitions/memberObject"
-                          }
-                        }
-                      ]
-                  }
-                },
-                "required": [
-                  "name"
-                ]
-              },
-            "correctionObject":{
-              "@type": "Correction",
-              "type": "object",
-              "properties": {
-                "url": {
-                  "type": "string",
-                  "format": "uri"
-                },
-                "correctionType": {
-                  "enum": [
-                    "correction",
-                    "retraction",
-                    "expression of concern",
-                    "withdrawal",
-                    "erratum",
-                    "update",
-                    "correction and re-publication",
-                    "peer reviewed version",
-                    "preprint"
-                  ]
-                },
-                "identifier": {
-                  "type": "string"
-                },
-                "doi": {
-                  "type": "string"
-                },
-                "pmid": {
-                  "type": "integer"
-                },
-                "datePublished": {
-                  "description": "publication date of the correction notice or publication",
-                  "type": "string",
-                  "format": "date"
-                }
-              },
-              "required": [
-                  "url",
-                  "correctionType"
-              ]
-            },  
-            "citation": {
-              "description": "A citation object for a resource which is cited by the publication (ie- is a derivative of the publication) , related to the publication, or from which the publication was based on (ie- is derived from).",
-              "@type": "CreativeWork",
-              "type": "object",
-              "properties": {
-                "name": {
-                  "description": "name of the referenced resource",
-                  "type": "string"
-                },
-                "identifier": {
-                  "type": "string"
-                },
-                "doi": {
-                  "type": "string"
-                },
-                "pmid": {
-                  "type": "integer"
-                },
-                "type": {
-                  "enum": [
-                    "ClinicalStudy",
-                    "Analysis",
-                    "Publication",
-                    "Dataset",
-                    "Protocol",
-                    "SoftwareApplication",
-                    "Other"
-                  ]
-                },
-                "url": {
-                  "type": "string",
-                  "format": "uri"
-                },
-                "versionDate": {
-                  "description": "Date of the version of the resource that is referenced",
-                  "type": "string",
-                  "format": "date"
-                },
-                "citeText": {
-                  "description": "The bibliographic citation for the referenced resource as is provided",
-                  "type": "string"
-                }
-              },
-              "required": [
-                "name",
-                "type"
-              ]
-            },
-            "funding": {
-              "type": "object",
-              "@type": "MonetaryGrant",
-              "description": "Information about funding support",
-              "properties": {
-                "name": {
-                  "type": "string",
-                  "description": "The name of the monetary grant that funded/funds the publication"
-                },
-                "identifier": {
-                  "type": "string",
-                  "description": "Unique identifier(s) for the grant(s) used to fund the publication"
-                },
-                "funder": {
-                  "description": "name of the funding organization",
-                  "type": "array",
-                  "oneOf": [
-                    {
-                      "$ref": "#/definitions/baseOrgObject"
-                    },
-                    {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/definitions/baseOrgObject"
-                      }
-                    }
-                  ]
-                },
-                "url": {
-                  "type": "string",
-                  "description": "award URL"
-                }
-              },
-              "required": [
-                "funder"
-              ]
-            },
-            "reviewObject":{
-                "description": "A review or descriptive evaluation of the resource",
-                "@type": "schema:Review",
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "description": "The name of the review"
-                  },
-                  "author": {
-                    "description": "The author of this content or rating.",
-                    "anyOf": [
-                      {
-                        "$ref": "#/definitions/person"
-                      },
-                      {
-                        "type": "array",
-                        "items": {
-                          "$ref": "#/definitions/person"
-                      }
-                      },
-                      {
-                        "$ref": "#/definitions/organization"
-                      },
-                      {
-                        "type": "array",
-                        "items": {
-                          "$ref": "#/definitions/organization"
-                      }
-                }
-              ]
-            },
-                  "curationDate":{
-                    "description": "The date this evaluation was added into outbreak.info, or was updated in outbreak.info.",
-                    "type": "string",
-                    "format": "date"
-                  }
-                },
-                "required": [
-                  "name"
-                ]
-            },
-            "ratingObject":{
-                "description": "A rating or categorical evaluation of the resource",
-                "@type": "schema:Rating",
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "description": "The name of the rating"
-                  },
-                  "author": {
-                    "description": "The author of this content or rating.",
-                    "anyOf": [
-                      {
-                        "$ref": "#/definitions/person"
-                      },
-                      {
-                        "type": "array",
-                        "items": {
-                          "$ref": "#/definitions/person"
-                      }
-                      },
-                      {
-                        "$ref": "#/definitions/organization"
-                      },
-                      {
-                        "type": "array",
-                        "items": {
-                          "$ref": "#/definitions/organization"
-                      }
-                }
-              ]
-            },
-                  "curationDate":{
-                    "description": "The date this evaluation was added into outbreak.info, or was updated in outbreak.info.",
-                    "type": "string",
-                    "format": "date"
-                  }
-                },
-                "required": [
-                  "name"
-                ]
-            },
-            "aggregateRatingObject":{
-                "description": "A cumulative evaluation of the resource",
-                "@type": "schema:AggregateRating",
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "description": "The name of the aggregate rating"
-                  },
-                  "author": {
-                    "description": "The author of this content or rating.",
-                    "anyOf": [
-                      {
-                        "$ref": "#/definitions/person"
-                      },
-                      {
-                        "type": "array",
-                        "items": {
-                          "$ref": "#/definitions/person"
-                      }
-                      },
-                      {
-                        "$ref": "#/definitions/organization"
-                      },
-                      {
-                        "type": "array",
-                        "items": {
-                          "$ref": "#/definitions/organization"
-                      }
-                }
-              ]
-            },
-                  "curationDate":{
-                    "description": "The date this evaluation was added into outbreak.info, or was updated in outbreak.info.",
-                    "type": "string",
-                    "format": "date"
-                  }
-                },
-                "required": [
-                  "name"
-                ]
             } 
-          }
-        }
-    },
-    {"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"Title of the article","rdfs:label":"name","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":{"@id":"outbreak:Publication"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:identifier","@type":"rdf:Property","rdfs:comment":"DOI (preferred) or PMID (e.g., 10.1126\/sciimmunol.aaw6329, PMID:31471352)","rdfs:label":"identifier","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":{"@id":"outbreak:Publication"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:doi","@type":"rdf:Property","rdfs:comment":"DOI","rdfs:label":"doi","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":{"@id":"outbreak:Publication"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:pmid","@type":"rdf:Property","rdfs:comment":"PMID","rdfs:label":"pmid","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":{"@id":"outbreak:Publication"},"schema:rangeIncludes":{"@id":"schema:Number"}},{"@id":"outbreak:datePublished","@type":"rdf:Property","rdfs:comment":"PublicationDate online if available","rdfs:label":"datePublished","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:datePublished"},"schema:domainIncludes":{"@id":"outbreak:Publication"},"schema:rangeIncludes":{"@id":"schema:Date"}},{"@id":"outbreak:journalName","@type":"rdf:Property","rdfs:comment":"Journal or preprint server name","rdfs:label":"journalName","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":{"@id":"outbreak:Publication"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:journalName","@type":"rdf:Property","rdfs:comment":"Journal or preprint server name","rdfs:label":"journalName","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":{"@id":"outbreak:Publication"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:journalNameAbbrevation","@type":"rdf:Property","rdfs:comment":"Abbreviated Journal Title (note, this should be autopopulated)","rdfs:label":"journalNameAbbrevation","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":{"@id":"outbreak:Publication"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:volumeNumber","@type":"rdf:Property","rdfs:comment":"Volume number of journal in which the article was published","rdfs:label":"volumeNumber","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:volumeNumber"},"schema:domainIncludes":{"@id":"outbreak:Publication"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:issueNumber","@type":"rdf:Property","rdfs:comment":"Issue of journal in which the article was published","rdfs:label":"issueNumber","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:issueNumber"},"schema:domainIncludes":{"@id":"outbreak:Publication"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:author","@type":"rdf:Property","rdfs:comment":"Name of the author or organization that created the dataset.  Note: schema.org\/creator and schema.org\/organization have additional fields that can provide more information about the author\/organization, if desired","rdfs:label":"author","owl:cardinality":"many","marginality":"required","rdfs:sameAs":{"@id":"schema:author"},"schema:domainIncludes":{"@id":"outbreak:Publication"},"schema:rangeIncludes":[{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"}]},{"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"The author's name (as provided by the resource)","rdfs:label":"name","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":[{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:givenName","@type":"rdf:Property","rdfs:comment":"The author's given name (if available)","rdfs:label":"givenName","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:givenName"},"schema:domainIncludes":[{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:familyName","@type":"rdf:Property","rdfs:comment":"The author's family name (if available)","rdfs:label":"familyName","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:familyName"},"schema:domainIncludes":[{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:affiliation","@type":"rdf:Property","rdfs:comment":"The author's affiliation(s)","rdfs:label":"affiliation","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:affiliation"},"schema:domainIncludes":[{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:orcid","@type":"rdf:Property","rdfs:comment":"The orcid identifier for the author","rdfs:label":"orcid","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":[{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:pagination","@type":"rdf:Property","rdfs:comment":"Any description of pages for the article","rdfs:label":"pagination","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:pagination"},"schema:domainIncludes":{"@id":"outbreak:Publication"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:license","@type":"rdf:Property","rdfs:comment":"License","rdfs:label":"license","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:license"},"schema:domainIncludes":{"@id":"outbreak:Publication"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:url","@type":"rdf:Property","rdfs:comment":"url where the article can be found","rdfs:label":"url","owl:cardinality":"many","marginality":"required","rdfs:sameAs":{"@id":"schema:url"},"schema:domainIncludes":{"@id":"outbreak:Publication"},"schema:rangeIncludes":{"@id":"schema:URL"}},{"@id":"outbreak:abstract","@type":"rdf:Property","rdfs:comment":"Article abstract ","rdfs:label":"abstract","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:abstract"},"schema:domainIncludes":{"@id":"outbreak:Publication"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:publicationType","@type":"rdf:Property","rdfs:comment":"Type of publication such as preprint, research article, case report, etc","rdfs:label":"publicationType","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:publicationType"},"schema:domainIncludes":{"@id":"outbreak:Publication"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:dateModified","@type":"rdf:Property","rdfs:comment":"Date of Version update","rdfs:label":"dateModified","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:dateModified"},"schema:domainIncludes":{"@id":"outbreak:Publication"},"schema:rangeIncludes":{"@id":"schema:Date"}},
-    {"@id":"outbreak:correction","@type":"rdf:Property","rdfs:comment":"A special citation object for notices of author withdrawal, editorial retractions, errata, expressions of concerns, preprints, peer reviewed versions, etc.","rdfs:label":"correction","owl:cardinality":"many","marginality":"optional","schema:domainIncludes":{"@id":"outbreak:Publication"},"schema:rangeIncludes":{"@id":"outbreak:Correction"}},
-    {"@id":"outbreak:correctionType","@type":"rdf:Property","rdfs:comment":"Type of notice: (correction, retraction, expression of concern, withdrawal, erratum, update, correction\/republication, preprint, peer reviewed version)","rdfs:label":"correctionType","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":{"@id":"outbreak:Correction"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:url","@type":"rdf:Property","rdfs:comment":"The url to the notice if available","rdfs:label":"url","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:url"},"schema:domainIncludes":{"@id":"outbreak:Correction"},"schema:rangeIncludes":{"@id":"schema:URL"}},
-    {"@id":"outbreak:identifier","@type":"rdf:Property","rdfs:comment":"DOI (preferred) or PMID (e.g., 10.1126\/sciimmunol.aaw6329, PMID:31471352)","rdfs:label":"identifier","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":{"@id":"outbreak:Correction"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:doi","@type":"rdf:Property","rdfs:comment":"DOI","rdfs:label":"doi","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":{"@id":"outbreak:Correction"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:pmid","@type":"rdf:Property","rdfs:comment":"PMID","rdfs:label":"pmid","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":{"@id":"outbreak:Correction"},"schema:rangeIncludes":{"@id":"schema:Number"}},{"@id":"outbreak:datePublished","@type":"rdf:Property","rdfs:comment":"PublicationDate online if available","rdfs:label":"datePublished","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:datePublished"},"schema:domainIncludes":{"@id":"outbreak:Correction"},"schema:rangeIncludes":{"@id":"schema:Date"}},
-    {"@id":"outbreak:funding","@type":"rdf:Property","rdfs:comment":"The funder of the study","rdfs:label":"funding","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:funder"},"schema:domainIncludes":{"@id":"outbreak:Publication"},"schema:rangeIncludes":{"@id":"outbreak:MonetaryGrant"}},{"@id":"outbreak:identifier","@type":"rdf:Property","rdfs:comment":"The identifier of the grant (if available)","rdfs:label":"identifier","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":{"@id":"outbreak:MonetaryGrant"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:citedBy","@type":"rdf:Property","rdfs:comment":"other articles or resources that cite this publication","rdfs:label":"citedBy","owl:cardinality":"many","marginality":"optional","owl:inverseOf":{"@id":"schema:isBasedOn"},"schema:domainIncludes":{"@id":"outbreak:Publication"},"schema:rangeIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}]},{"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"name of the citedBy resource","rdfs:label":"name","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:type","@type":"rdf:Property","rdfs:comment":"type (publicatoin, protocol, dataset, code, etc.) of the citedBy resource","rdfs:label":"type","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:additionalType"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:identifier","@type":"rdf:Property","rdfs:comment":"identifier (pmid, WHO protocol id, etc.) of the citedby resource","rdfs:label":"identifier","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:isBasedOn","@type":"rdf:Property","rdfs:comment":"Associated datasets, software, protocols, etc. used by the work described in this publication, including reference publications","rdfs:label":"isBasedOn","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:isBasedOn"},"schema:domainIncludes":{"@id":"outbreak:Publication"},"schema:rangeIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}]},{"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"name of the associated dataset, software, protocols, etc used by the work described in this publication","rdfs:label":"name","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:type","@type":"rdf:Property","rdfs:comment":"type of the associated resource (dataset, protocols, analysis, etc.) used by the work described in this publication","rdfs:label":"type","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:additionalType"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:identifier","@type":"rdf:Property","rdfs:comment":"Identifier of the associated datasets, software, protocols, etc.","rdfs:label":"identifier","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:versionDate","@type":"rdf:Property","rdfs:comment":"date of the version of the resource from which this publication was derived. Note this is NOT the same as dateModified, as the protocol may be based on an earlier 'dateModified' than is what is available from the resource","rdfs:label":"versionDate","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:releaseDate"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Date"}},
-    {"@id":"outbreak:isRelatedTo","@type":"rdf:Property","rdfs:comment":"Related articles or resources such as pre-prints, comments, editorial summaries of the article, etc. Helpful for de-duplication between pre-print and peer-reviewed version","rdfs:label":"isRelatedTo","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:isRelatedTo"},"schema:domainIncludes":{"@id":"outbreak:Publication"},"schema:rangeIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}]},{"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"name of related resource","rdfs:label":"name","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:type","@type":"rdf:Property","rdfs:comment":"type of related resource","rdfs:label":"type","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:additionalType"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:identifier","@type":"rdf:Property","rdfs:comment":"Identifier of related articles or resources such as pre-prints, comments, editorial summaries","rdfs:label":"identifier","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:keywords","@type":"rdf:Property","rdfs:comment":null,"rdfs:label":"keywords","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:keywords"},"schema:domainIncludes":{"@id":"outbreak:Publication"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:topicCategory","@type":"rdf:Property","rdfs:comment":"Applicable outbreak.info category","rdfs:label":"topicCategory","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:about"},"schema:domainIncludes":{"@id":"outbreak:Publication"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:curatedBy","@type":"rdf:Property","rdfs:comment":"The source from which this publication was identified for inclusion into Outbreak.info. Provides provenance for a resource which was curated by another","rdfs:label":"curatedBy","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:citation"},"schema:domainIncludes":{"@id":"outbreak:Publication"},"schema:rangeIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"},{"@id":"schema:Thing"}]},
-    {"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"name of the source from which this publication was identified for inclusion","rdfs:label":"name","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:curationDate","@type":"rdf:Property","rdfs:comment":"The date this resource was added to outbreak.info, or the date when this resource was updated in outbreak.info","rdfs:label":"curationDate","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:releaseDate"},"schema:domainIncludes":{"@id":"outbreak:Publication"},"schema:rangeIncludes":{"@id":"schema:Date"}},
-    {"@id":"outbreak:evaluations","@type":"rdf:Property","rdfs:comment":"One or more reviews, ratings, or other evaluations of this resource","rdfs:label":"evaluations","owl:cardinality":"many","marginality":"optional","schema:domainIncludes":{"@id":"outbreak:Publication"},"schema:rangeIncludes":[{"@id":"schema:Review"},{"@id":"schema:Rating"},{"@id":"schema:AggregateRating"}]},
-    {
-      "@id": "outbreak:ClinicalTrial",
-      "@type": "rdfs:Class",
-      "rdfs:label": "ClinicalTrial",
-      "rdfs:comment": "This is the schema for describing the ClinicalTrial schema used for outbreak.info.",
-      "rdfs:subClassOf": {
-        "@id": "schema:MedicalStudy"
-      },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
-      },
-      "$validation": {
-          "$schema": "http://json-schema.org/draft-07/schema#",
-          "type": "object",
-          "properties": {
-            "name": {
-              "description": "Official or scientific title of the study",
-              "type": "string"
-            },
-            "alternateName": {
-              "description": "Brief title, acronyms, or public titles for the study",
-              "oneOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                }
-              ]
-            },
-            "identifier": {
-              "description": "Registration number or identifier assigned to the study",
-              "oneOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                }
-              ]
-            },
-            "identifierSource": {
-              "description": "Source of identifier assignment or type of identifier (NCTid, China CTRid, EudraCT Number, etc.)",
-              "oneOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                }
-              ]
-            },
-            "abstract": {
-              "description": "A brief summary of the study",
-              "type": "string"
-            },
-            "description": {
-              "description": "A description of the study or the stated purpose of the study",
-              "type": "string"
-            },
-            "dateCreated": {
-              "description": "Date the record was created",
-              "format": "date",
-              "type": "string"
-            },
-            "datePublished": {
-              "description": "Date the record was published",
-              "format": "date",
-              "type": "string"
-            },
-            "dateModified": {
-              "description": "LastUpdatePostDate",
-              "oneOf": [
-                {
-                  "type": "string",
-                  "format": "date"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "type": "string",
-                    "format": "date"
-                  }
-                }
-              ]
-            },
-            "dateModifiedType": {
-              "description": "LastUpdatePostDateType",
-              "enum": [
-                "actual",
-                "anticipated",
-                "estimated"
-              ]
-            },
-            "healthCondition": {
-              "description": "The health condition or disease being studied",
-              "oneOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                }
-              ]
-            },
-            "healthConditionIidentifier": {
-              "description": "Ontological or controlled vocabulary identifier for the health condition or disease",
-              "oneOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                }
-              ]
-            },
-            "keywords": {
-              "description": "keywords",
-              "oneOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                }
-              ]
-            },
-            "topicCategory": {
-              "description": "Applicable outbreak.info category",
-              "oneOf": [
-                {
-                  "enum": [
-                    "Clinical",
-                    "Case Descriptions",
-                    "Risk Factors",
-                    "Diagnosis",
-                    "Symptoms",
-                    "Rapid Diagnostics",
-                    "Antibody Detection",
-                    "Virus Detection",
-                    "Testing Prevalence",
-                    "Pathology/Radiology",
-                    "Forecasting",
-                    "Mechanism",
-                    "Virus Factors",
-                    "Host Factors",
-                    "Immunological Response",
-                    "Mechanism of Infection",
-                    "Mechanism of Transmission",
-                    "Prevention",
-                    "Public Health Interventions",
-                    "Individual Prevention",
-                    "Transmission",
-                    "Host/Intermediate Reservoirs",
-                    "Viral Shedding / Persistence",
-                    "Treatment",
-                    "Vaccines",
-                    "Pharmaceutical Treatments",
-                    "Medical Care",
-                    "Repurposing",
-                    "Biologics",
-                    "Behavioral Research",
-                    "Epidemiology",
-                    "Classical Epidemiology",
-                    "Molecular Epidemiology"
-                  ]
-                },
-                {
-                  "type": "array",
-                  "items": {
-                      "enum": [
-                        "Clinical",
-                        "Case Descriptions",
-                        "Risk Factors",
-                        "Diagnosis",
-                        "Symptoms",
-                        "Rapid Diagnostics",
-                        "Antibody Detection",
-                        "Virus Detection",
-                        "Testing Prevalence",
-                        "Pathology/Radiology",
-                        "Forecasting",
-                        "Mechanism",
-                        "Virus Factors",
-                        "Host Factors",
-                        "Immunological Response",
-                        "Mechanism of Infection",
-                        "Mechanism of Transmission",
-                        "Prevention",
-                        "Public Health Interventions",
-                        "Individual Prevention",
-                        "Transmission",
-                        "Host/Intermediate Reservoirs",
-                        "Viral Shedding / Persistence",
-                        "Treatment",
-                        "Vaccines",
-                        "Pharmaceutical Treatments",
-                        "Medical Care",
-                        "Repurposing",
-                        "Biologics",
-                        "Behavioral Research",
-                        "Epidemiology",
-                        "Classical Epidemiology",
-                        "Molecular Epidemiology"
-                      ]
-                  }
-                }
-              ]
-
-            },
-            "hasResults": {
-              "description": "Binary for if the clinical trial has published any results",
-              "type": "boolean"
-            },
-            "url": {
-              "description": "url where the study can be found",
-              "format": "uri",
-              "type": "string"
-            },
-            "author": {
-              "description": "The study's author, this includes ResponsiblePartyInvestigator, Contacts, and OverallOfficials",
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/person"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/person"
-                  }
-                }
-              ]
-            },
-            "funding": {
-              "description": "Funding, sponsorship, and collaborations for the study.",
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/funding"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/funding"
-                  }
-                }
-              ]
-            },
-            "studyEvent": {
-              "description": "an event status such as StudyStart, PrimaryCompletion, Completion, StudyFirstSubmit, StudyFirstSubmitQC, LastUpdateSubmit",
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/studyevent"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/studyevent"
-                  }
-                }
-              ]
-            },
-            "studyStatus": {
-              "description": "The status of the study",
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/studystatus"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/studystatus"
-                  }
-                }
-              ]
-            },
-            "studyDesign": {
-              "description": "The general design of the study",
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/studydesign"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/studydesign"
-                  }
-                }
-              ]
-            },
-            "armGroup": {
-              "description": "The arm or factor of an interventional study",
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/armgroup"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/armgroup"
-                  }
-                }
-              ]
-            },
-            "outcome": {
-              "description": "The outcome (expected or actual) of a study",
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/outcome"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/outcome"
-                  }
-                }
-              ]
-            },
-            "eligibilityCriteria": {
-              "description": "eligibility criteria",
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/eligibility"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/eligibility"
-                  }
-                }
-              ]
-            },
-            "studyLocation": {
-              "description": "The location of the study",
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/studylocation"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/studylocation"
-                  }
-                }
-              ]
-            },
-            "citedBy": {
-              "description": "other articles or resources that cite this clinical trial",
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/citation"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/citation"
-                  }
-                }
-              ]
-            },
-            "isBasedOn": {
-              "description": "Associated datasets, software, protocols, etc. used by the work described in this clinical study (includes study protocol documents, data analysis plans, reference publications. etc)",
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/citation"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/citation"
-                  }
-                }
-              ]
-            },
-            "isRelatedTo": {
-              "description": "Other resources related to, but not a derivative of nor derived from this analysis",
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/citation"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/citation"
-                  }
-                }
-              ]
-            },
-            "curatedBy": {
-            "description": "The source from which this Clinical Study was identified for inclusion into Outbreak.info. Provides provenance for a resource which was curated by another.",
-            "anyOf": [{
-                "$ref": "#/definitions/citation"
-              },
-              {
-                "$ref": "#/definitions/person"
-              },
-              {
-                "$ref": "#/definitions/organization"
-              },
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/definitions/person"
-                }
-              },
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/definitions/organization"
-                }
-              },
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/definitions/citation"
-                }
-              }
-            ]
-          },
-            "curationDate":{
-            "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
-            "type": "string",
-            "format": "date"
-          }
-          },
-          "required": [
-            "name",
-            "url",
-            "description",
-            "identifier",
-            "identifierSource",
-            "healthCondition",
-            "funding",
-            "author"
-          ],
-          "definitions": {
-            "baseOrgObject":{
+        },
+        "required": [
+          "identifierSource",
+          "funding",
+          "author",
+          "healthCondition",
+          "description",
+          "identifier",
+          "name"
+        ],
+        "definitions": {
+          "baseOrgObject":{
             "description": "A barebones Organization object to work around recursion issues in DDE",
-            "@type": "Organization",
+            "@type": "outbreak:Organization",
             "type": "object",
             "properties": {
               "name": {
@@ -3503,15 +5950,32 @@
               "alternateName": {
                 "description": "Alternate name or Acronym for the organization.",
                 "type": "string"
-              }
+              },
+              "role": {
+                  "description": "LeadSponsor, funder, collaborator",
+                  "enum": [
+                    "lead/primary Sponsor", 
+                    "funder",
+                    "collaborator"
+                  ]
+                },
+              "class": {
+                  "description": "The type of organization",
+                  "enum": [
+                    "U.S. National Institutes of Health", 
+                    "Other U.S. Federal agencies", 
+                    "Industry", 
+                    "All others"
+                  ]
+                }
             },
             "required": [
               "name"
             ]              
           }, 
-            "person": {
+          "person": {
               "description": "Reusable person definition",
-              "@type": "Person",
+              "@type": "outbreak:Person",
               "type": "object",
               "properties": {
                 "name": {
@@ -3538,15 +6002,29 @@
                       }
                     }
                   ]
+                },
+                "role": {
+                    "description": "authorship, sponsorship, or other contribution role played by the person or organization in the creation of this resource",
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    ]
                 }
               },
               "required": [
                 "name"
               ]
-            },
-            "memberObject": {
+          },
+          "memberObject": {
               "description": "Reusable person definition accounting for recursion issues in DDE",
-              "@type": "Person",
+              "@type": "outbreak:Person",
               "type": "object",
               "properties": {
                 "name": {
@@ -3573,15 +6051,29 @@
                       }
                     }
                   ]
+                },
+                "role": {
+                    "description": "authorship, sponsorship, or other contribution role played by the person or organization in the creation of this resource",
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    ]
                 }
               },
               "required": [
                 "name"
               ]
-            },
-            "organization": {
+          },
+          "organization": {
             "description": "Reusable organization definition",
-            "@type": "Organization",
+            "@type": "outbreak:Organization",
             "type": "object",
             "properties": {
               "name": {
@@ -3628,9 +6120,9 @@
               "name"
             ]
           },
-            "funding": {
+          "funding": {
                 "type": "object",
-                "@type": "MonetaryGrant",
+                "@type": "outbreak:MonetaryGrant",
                 "description": "Information about funding or sponsorship support",
                 "properties": {
                   "name": {
@@ -3660,9 +6152,9 @@
                   "funder"
                 ]
           },
-            "studyevent": {
+          "studyevent": {
               "type": "object",
-              "@type": "Thing",
+              "@type": "outbreak:StudyEvent",
               "description": "an event status such as StudyStart, PrimaryCompletion, Completion, StudyFirstSubmit, StudyFirstSubmitQC, LastUpdateSubmit",
               "properties": {
                 "studyEventDate": {
@@ -3692,10 +6184,10 @@
                   ]
                 }
               }
-            },
-            "studystatus": {
+          },
+          "studystatus": {
               "type": "object",
-              "@type": "Thing",
+              "@type": "outbreak:StudyStatus",
               "properties": {
                 "enrollmentCount": {
                   "description": "The number of participants enrolled in the study",
@@ -3751,10 +6243,10 @@
               "required": [
                 "status"
               ]
-            },
-            "studydesign": {
+          },
+          "studydesign": {
               "type": "object",
-              "@type":"Thing",
+              "@type":"outbreak:StudyDesign",
               "properties": {
                 "designStudyText": {
                   "description": "String description of the study design if structured information not available",
@@ -3913,11 +6405,11 @@
                   ]
                 }
               }
-            },
-            "studylocation": {
+          },
+          "studylocation": {
               "description": "The study sites or the location of the study",
               "type": "object",
-              "@type": "Place",
+              "@type": "outbreak:StudyLocation",
               "properties": {
                 "studyLocation": {
                   "description": "The location of the study as listed in the resouce.",
@@ -3951,10 +6443,10 @@
                   ]
                 }
               }
-            },
-            "intervention": {
+          },
+          "intervention": {
               "type": "object",
-              "@type": "Thing",
+              "@type": "outbreak:Intervention",
               "properties": {
                 "name": {
                   "description": "The name of the intervention in the study",
@@ -3981,10 +6473,10 @@
                   ]
                 }
               }
-            },
-            "armgroup": {
+          },
+          "armgroup": {
               "type": "object",
-              "@type": "Thing",
+              "@type": "outbreak:ArmGroup",
               "properties": {
                 "name": {
                   "description": "The name of the arm or factor (can include a specific intervention, a placebo or even a lack of intervention, ie- 'no intervention' group)",
@@ -4020,10 +6512,10 @@
                   ]
                 }
               }
-            },
-            "outcome": {
+          },
+          "outcomeObject": {
               "type": "object",
-              "@type": "Thing",
+              "@type": "outbreak:Outcome",
               "properties": {
                 "outcomeTimeFrame": {
                   "description": "The specific time point(s) and overall duration of evaluation must be specified in this section. ",
@@ -4052,10 +6544,10 @@
                   ]
                 }
               }
-            },
-            "eligibility": {
+          },
+          "eligibility": {
               "type": "object",
-              "@type": "Thing",
+              "@type": "outbreak:Eligibility",
               "properties": {
                 "minimumAge": {
                   "description": "the minimum age for a participant to be included in the study",
@@ -4136,9 +6628,9 @@
                 }
               }
             },
-            "citation": {
-            "description": "A citation object for a resource which is cited by the clinical trial (ie- is a derivative of the clinical trial) , related to the clinical trial, or from which the clinical trial was based on (ie- is derived from).",
-            "@type": "Thing",
+          "citation": {
+            "description": "A citation object for a resource which is cited by the clinical trial/study (ie- is a derivative of the clinical trial/study), related to the clinical trial/study, or from which the clinical trial/study was based on (ie- is derived from).",
+            "@type": "outbreak:CitationObject",
             "type": "object",
             "properties": {
               "name": {
@@ -4157,7 +6649,7 @@
                 "description": "A doi if available",
                 "type": "string"
               },
-              "type": {
+              "sourceType": {
                 "description": "The type of resource",
                 "enum": [
                   "Dataset",
@@ -4166,7 +6658,7 @@
                   "Analysis",
                   "Protocol", 
                   "SoftwareApplication",
-                  "Other"
+                  "CreativeWork"
                   ]
               },
               "url": {
@@ -4186,31 +6678,720 @@
             },
             "required": [
               "name",
-              "type"
+              "sourceType"
+            ]
+          },
+          "reviewObject": {
+            "description": "A review or descriptive evaluation of the resource",
+            "@type": "Review",
+            "type": "object",
+            "properties": {
+              "name": {
+                    "type": "string",
+                    "description": "The name of the review"
+                  },
+              "reviewAspect":{
+                    "description": "This Review or Rating is relevant to this part or facet of the itemReviewed",
+                    "type": "string"
+                  },
+              "reviewBody": {
+                      "description": "The actual body of the review.",
+                      "type": "string"
+                  },
+              "reviewRating": {
+                "description": "The rating given in this review",
+                    "$ref": "#/definitions/ratingObject"      
+                },
+              "author": {
+                    "description": "The author of this content or rating.",
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/person"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/person"
+                      }
+                      },
+                      {
+                        "$ref": "#/definitions/organization"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/organization"
+                      }
+                }
+              ]
+            },
+              "curationDate":{
+                    "description": "The date this evaluation was added into outbreak.info, or was updated in outbreak.info.",
+                    "type": "string",
+                    "format": "date"
+                  }
+                },
+              "required": [
+              ]
+            },
+          "ratingObject": {
+            "description": "A rating or categorical evaluation of the resource",
+            "@type": "Rating",
+            "type": "object",
+            "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "The name of the rating"
+                  },
+                  "ratingExplanation": {
+                    "type": "string",
+                    "description": "An explanation of the rating"    
+                  },
+                  "ratingValue": {
+                    "type": "string",
+                    "description": "The rating for the content."
+                  },
+                  "reviewAspect": {
+                    "type": "string",
+                    "description": "This Review or Rating is relevant to this part or facet of the itemReviewed"
+                  },
+                  "author": {
+                    "description": "The author of this content or rating.",
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/person"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/person"
+                      }
+                      },
+                      {
+                        "$ref": "#/definitions/organization"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/organization"
+                      }
+                }
+              ]
+            },
+                  "curationDate":{
+                    "description": "The date this evaluation was added into outbreak.info, or was updated in outbreak.info.",
+                    "type": "string",
+                    "format": "date"
+                  }
+                },
+            "required": [
+            ]
+          },
+          "aggregateRatingObject": {
+            "description": "A cumulative evaluation of the resource",
+            "@type": "AggregateRating",
+            "type": "object",
+            "properties": {
+                "name": {
+                "type": "string",
+                "description": "The name of the aggregate rating"
+                },
+                "ratingValue": {
+                    "type": "string",
+                    "description": "The rating for the content."
+                },
+                "reviewAspect":{
+                  "description": "This Review or Rating is relevant to this part or facet of the itemReviewed",
+                  "type": "string"
+                },
+                "author": {
+                    "description": "The author of this content or rating.",
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/person"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/person"
+                      }
+                      },
+                      {
+                        "$ref": "#/definitions/organization"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/organization"
+                      }
+                }
+              ]
+            },
+                "curationDate": {
+                    "description": "The date this evaluation was added into outbreak.info, or was updated in outbreak.info.",
+                    "type": "string",
+                    "format": "date"
+                  },
+                "reviews": {
+                  "oneOf": [
+                      {
+                        "$ref": "#/definitions/reviewObject"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/reviewObject"
+                        }
+                      }
+                      
+                  ]
+                },
+                "ratings": {
+                  "oneOf": [
+                      {
+                        "$ref": "#/definitions/ratingObject"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/ratingObject"
+                        }
+                      }
+                      
+                  ]
+                }
+                },
+            "required": [
             ]
           }
           }
-        }
+      }
     },
-    {"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"Official or scientific title of the study","rdfs:label":"name","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":{"@id":"outbreak:ClinicalTrial"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:alternateName","@type":"rdf:Property","rdfs:comment":"Brief title, acronyms, or public titles for the study","rdfs:label":"alternateName","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:alternateName"},"schema:domainIncludes":{"@id":"outbreak:ClinicalTrial"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:identifier","@type":"rdf:Property","rdfs:comment":"Registration number or identifier assigned to the study","rdfs:label":"identifier","owl:cardinality":"many","marginality":"required","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":{"@id":"outbreak:ClinicalTrial"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:identifierSource","@type":"rdf:Property","rdfs:comment":"Source of identifier assignment or type of identifier (NCTid, China CTRid, EudraCT Number, etc.)","rdfs:label":"identifierSource","owl:cardinality":"many","marginality":"required","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":{"@id":"outbreak:ClinicalTrial"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:url","@type":"rdf:Property","rdfs:comment":"url where the study can be found","rdfs:label":"url","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:url"},"schema:domainIncludes":{"@id":"outbreak:ClinicalTrial"},"schema:rangeIncludes":{"@id":"schema:URL"}},
-    {"@id":"outbreak:abstract","@type":"rdf:Property","rdfs:comment":"A brief summary of the study","rdfs:label":"abstract","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:abstract"},"schema:domainIncludes":{"@id":"outbreak:ClinicalTrial"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:description","@type":"rdf:Property","rdfs:comment":"A description of the study or the stated purpose of the study","rdfs:label":"description","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:description"},"schema:domainIncludes":{"@id":"outbreak:ClinicalTrial"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:dateCreated","@type":"rdf:Property","rdfs:comment":"Date the record was created","rdfs:label":"dateCreated","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:dateCreated"},"schema:domainIncludes":{"@id":"outbreak:ClinicalTrial"},"schema:rangeIncludes":{"@id":"schema:Date"}},{"@id":"outbreak:datePublished","@type":"rdf:Property","rdfs:comment":"Date the record was published","rdfs:label":"datePublished","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:datePublished"},"schema:domainIncludes":{"@id":"outbreak:ClinicalTrial"},"schema:rangeIncludes":{"@id":"schema:Date"}},{"@id":"outbreak:dateModified","@type":"rdf:Property","rdfs:comment":"LastUpdatePostDate","rdfs:label":"dateModified","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:dateModified"},"schema:domainIncludes":{"@id":"outbreak:ClinicalTrial"},"schema:rangeIncludes":{"@id":"schema:Date"}},{"@id":"outbreak:dateModifiedType","@type":"rdf:Property","rdfs:comment":"LastUpdatePostDateType","rdfs:label":"dateModifiedType","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:addtionalType"},"schema:domainIncludes":{"@id":"outbreak:ClinicalTrial"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:healthCondition","@type":"rdf:Property","rdfs:comment":"The health condition or disease being studied","rdfs:label":"healthCondition","owl:cardinality":"many","marginality":"required","rdfs:sameAs":{"@id":"schema:MedicalCondition"},"schema:domainIncludes":{"@id":"outbreak:ClinicalTrial"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:healthConditionIidentifier","@type":"rdf:Property","rdfs:comment":"Ontological or controlled vocabulary identifier for the health condition or disease","rdfs:label":"healthConditionIidentifier","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:MedicalCode"},"schema:domainIncludes":{"@id":"outbreak:ClinicalTrial"},"schema:rangeIncludes":{"@id":"schema:Text"}}, {"@id":"outbreak:keywords","@type":"rdf:Property","rdfs:comment":"keywords","rdfs:label":"keywords","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:keywords"},"schema:domainIncludes":{"@id":"outbreak:ClinicalTrial"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:topicCategory","@type":"rdf:Property","rdfs:comment":"Applicable outbreak.info category","rdfs:label":"topicCategory","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:about"},"schema:domainIncludes":{"@id":"outbreak:ClinicalTrial"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:hasResults","@type":"rdf:Property","rdfs:comment":"Binary for if the clinical trial has published any results","rdfs:label":"hasResults","owl:cardinality":"one","marginality":"optional","schema:domainIncludes":{"@id":"outbreak:ClinicalTrial"},"schema:rangeIncludes":{"@id":"schema:Boolean"}},
-    {"@id":"outbreak:author","@type":"rdf:Property","rdfs:comment":"The study's author, this includes ResponsiblePartyInvestigator, Contacts, and OverallOfficials","rdfs:label":"author","owl:cardinality":"many","marginality":"required","rdfs:sameAs":{"@id":"schema:author"},"schema:domainIncludes":{"@id":"outbreak:ClinicalTrial"},"schema:rangeIncludes":[{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"}]},{"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"The name of the study author as it appears in the registery. May include values from the following NCT fields: ResponsiblePartyInvestigatorFullName, OverallOfficialName, ContactName","rdfs:label":"name","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":{"@id":"outbreak:Person"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:givenName","@type":"rdf:Property","rdfs:comment":"The given name of the study author","rdfs:label":"givenName","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:givenName"},"schema:domainIncludes":{"@id":"outbreak:Person"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:familyName","@type":"rdf:Property","rdfs:comment":"The family name of the study author","rdfs:label":"familyName","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:familyName"},"schema:domainIncludes":{"@id":"outbreak:Person"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:affiliation","@type":"rdf:Property","rdfs:comment":"Affiliation associated with the study author","rdfs:label":"affiliation","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:affiliation"},"schema:domainIncludes":{"@id":"outbreak:Organization"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:role","@type":"rdf:Property","rdfs:comment":"The role of this particular author in this study, this includes roles such as ResponsibleParty, Contacts, values of OverallOfficialRole, Investigator","rdfs:label":"role","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":{"@id":"outbreak:Person"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:funding","@type":"rdf:Property","rdfs:comment":"A sponsor, funder, or collaborator for the study. ","rdfs:label":"funding","owl:cardinality":"many","marginality":"required","rdfs:sameAs":{"@id":"outbreak:MonetaryGrant"},"schema:domainIncludes":{"@id":"outbreak:ClinicalTrial"},"schema:rangeIncludes":{"@id":"outbreak:MonetaryGrant"}},{"@id":"outbreak:funder","@type":"rdf:Property","rdfs:comment":"The funder of the analysis","rdfs:label":"funder","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:funder"},"schema:domainIncludes":{"@id":"outbreak:MonetaryGrant"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"The name of the sponsoring or funding organization","rdfs:label":"name","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":{"@id":"outbreak:Organization"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:class","@type":"rdf:Property","rdfs:comment":"The type of organization","rdfs:label":"class","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:addtionalType"},"schema:domainIncludes":{"@id":"outbreak:Organization"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:role","@type":"rdf:Property","rdfs:comment":"LeadSponsor, funder, collaborator","rdfs:label":"role","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":{"@id":"outbreak:Organization"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:studyEvent","@type":"rdf:Property","rdfs:comment":"an event status such as StudyStart, PrimaryCompletion, Completion, StudyFirstSubmit, StudyFirstSubmitQC, LastUpdateSubmit","rdfs:label":"studyEvent","owl:cardinality":"many","marginality":"recommended","schema:domainIncludes":{"@id":"outbreak:ClinicalTrial"},"schema:rangeIncludes":{"@id":"outbreak:StudyEvent"}},{"@id":"outbreak:studyEventType","@type":"rdf:Property","rdfs:comment":"Type of the event status such as StudyStart, PrimaryCompletion, Completion, StudyFirstSubmit, StudyFirstSubmitQC, LastUpdateSubmit","rdfs:label":"studyEventType","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":{"@id":"outbreak:StudyEvent"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:studyEventDate","@type":"rdf:Property","rdfs:comment":"StartDate, Primary CompletionDate, CompletionDate, StudyFirstSubmitDate, StudyFirstSubmitQCDate, LastUpdateSubmitDate","rdfs:label":"studyEventDate","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:temporal"},"schema:domainIncludes":{"@id":"outbreak:StudyEvent"},"schema:rangeIncludes":{"@id":"schema:Date"}},{"@id":"outbreak:studyEventDateType","@type":"rdf:Property","rdfs:comment":"the type of date provided (actual, anticipated, or estimated)","rdfs:label":"studyEventDateType","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:addtionalType"},"schema:domainIncludes":{"@id":"outbreak:StudyEvent"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:studyStatus","@type":"rdf:Property","rdfs:comment":"The status of the study","rdfs:label":"studyStatus","owl:cardinality":"one","marginality":"recommended","schema:domainIncludes":{"@id":"outbreak:ClinicalTrial"},"schema:rangeIncludes":{"@id":"outbreak:StudyStatus"}},{"@id":"outbreak:status","@type":"rdf:Property","rdfs:comment":"The recruitment status of the study","rdfs:label":"status","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"outbreak:status"},"schema:domainIncludes":{"@id":"outbreak:StudyStatus"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:statusExpandedAccess","@type":"rdf:Property","rdfs:comment":"Flag for whether or not the study has expanded Access status","rdfs:label":"statusExpandedAccess","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"outbreak:statusExpandedAccess"},"schema:domainIncludes":{"@id":"outbreak:StudyStatus"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:statusDate","@type":"rdf:Property","rdfs:comment":"The date that the status was verified. Equivalent to NCT's StatusVerifiedDate","rdfs:label":"statusDate","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"outbreak:statusDate"},"schema:domainIncludes":{"@id":"outbreak:StudyStatus"},"schema:rangeIncludes":{"@id":"schema:Date"}},{"@id":"outbreak:enrollmentCount","@type":"rdf:Property","rdfs:comment":"The number of participants enrolled in the study","rdfs:label":"enrollmentCount","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"outbreak:enrollmentCount"},"schema:domainIncludes":{"@id":"outbreak:StudyStatus"},"schema:rangeIncludes":{"@id":"schema:Number"}},{"@id":"outbreak:enrollmentType","@type":"rdf:Property","rdfs:comment":"The type of estimation used to determine the enrollmentCount (actual counts, target size, etc.)","rdfs:label":"enrollmentType","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"outbreak:enrollmentType"},"schema:domainIncludes":{"@id":"outbreak:StudyStatus"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:whyStopped","@type":"rdf:Property","rdfs:comment":"A brief explanation of the reason(s) why such clinical study was stopped (for a clinical study that is \"Suspended,\" \"Terminated,\" or \"Withdrawn\" prior to its planned completion as anticipated by the protocol)","rdfs:label":"whyStopped","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:description"},"schema:domainIncludes":{"@id":"outbreak:StudyStatus"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:studyDesign","@type":"rdf:Property","rdfs:comment":"The general design of the study","rdfs:label":"studyDesign","owl:cardinality":"one","marginality":"recommended","schema:domainIncludes":{"@id":"outbreak:ClinicalTrial"},"schema:rangeIncludes":{"@id":"outbreak:StudyDesign"}},{"@id":"outbreak:studyType","@type":"rdf:Property","rdfs:comment":"Type of human study, can be subtypes of observational study or interventional studies","rdfs:label":"studyType","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"outbreak:studyType"},"schema:domainIncludes":{"@id":"outbreak:StudyDesign"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:phase","@type":"rdf:Property","rdfs:comment":"Stage or phase of the study in the U.S.","rdfs:label":"phase","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"outbreak:phase"},"schema:domainIncludes":{"@id":"outbreak:StudyDesign"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:phaseNumber","@type":"rdf:Property","rdfs:comment":"The number of the phase or stage of the study","rdfs:label":"phaseNumber","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":{"@id":"outbreak:StudyDesign"},"schema:rangeIncludes":{"@id":"schema:Number"}},{"@id":"outbreak:designAllocation","@type":"rdf:Property","rdfs:comment":"The method by which the study participants were allocated into groups","rdfs:label":"designAllocation","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"outbreak:designAllocation"},"schema:domainIncludes":{"@id":"outbreak:StudyDesign"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:designModel","@type":"rdf:Property","rdfs:comment":"The general design of the strategy for assigning interventions to participants in a clinical intervention study OR the general design of the strategy for identifying and following up with participants during an observational study and may include the temporal relationship of observation period to time of participant enrollment.","rdfs:label":"designModel","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"outbreak:designModel"},"schema:domainIncludes":{"@id":"outbreak:StudyDesign"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:designPrimaryPurpose","@type":"rdf:Property","rdfs:comment":"The primary purpose of the study","rdfs:label":"designPrimaryPurpose","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"outbreak:designPrimaryPurpose"},"schema:domainIncludes":{"@id":"outbreak:StudyDesign"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:designWhoMasked","@type":"rdf:Property","rdfs:comment":"The people who not know which participants have been assigned to which interventions.","rdfs:label":"designWhoMasked","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"outbreak:designWhoMasked"},"schema:domainIncludes":{"@id":"outbreak:StudyDesign"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:designStudyText","@type":"rdf:Property","rdfs:comment":"String description of the study design if structured information not available","rdfs:label":"designStudyText","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:description"},"schema:domainIncludes":{"@id":"outbreak:StudyDesign"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:armGroup","@type":"rdf:Property","rdfs:comment":"The arm or factor of an interventional study","rdfs:label":"armGroup","owl:cardinality":"many","marginality":"optional","schema:domainIncludes":{"@id":"outbreak:ClinicalTrial"},"schema:rangeIncludes":{"@id":"outbreak:ArmGroup"}},{"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"The name of the arm or factor (can include a specific intervention, a placebo or even a lack of intervention, ie- 'no intervention' group). The Group or cohort in the case of observational studies","rdfs:label":"name","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"outbreak:name"},"schema:domainIncludes":{"@id":"outbreak:ArmGroup"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:role","@type":"rdf:Property","rdfs:comment":"The role of the arm or factor in the study this is equivalent to the ArmType in ClinicalTrials.gov","rdfs:label":"role","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"outbreak:role"},"schema:domainIncludes":{"@id":"outbreak:ArmGroup"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:description","@type":"rdf:Property","rdfs:comment":"A description of the arm or factor","rdfs:label":"description","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"outbreak:description"},"schema:domainIncludes":{"@id":"outbreak:ArmGroup"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:intervention","@type":"rdf:Property","rdfs:comment":"The interventions (if any) in this ArmGroup","rdfs:label":"intervention","owl:cardinality":"many","marginality":"optional","schema:domainIncludes":{"@id":"outbreak:ArmGroup"},"schema:rangeIncludes":{"@id":"outbreak:Intervention"}},{"@id":"outbreak:category","@type":"rdf:Property","rdfs:comment":"The category of the arm or factor in the study","rdfs:label":"category","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":{"@id":"outbreak:Intervention"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"The name of the intervention in the study","rdfs:label":"name","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":{"@id":"outbreak:Intervention"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:description","@type":"rdf:Property","rdfs:comment":"A description of the intervention in the study","rdfs:label":"description","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:description"},"schema:domainIncludes":{"@id":"outbreak:Intervention"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:outcome","@type":"rdf:Property","rdfs:comment":"The outcome (expected or actual) of a study","rdfs:label":"outcome","owl:cardinality":"many","marginality":"recommended","schema:domainIncludes":{"@id":"outbreak:ClinicalTrial"},"schema:rangeIncludes":{"@id":"outbreak:Outcome"}},{"@id":"outbreak:outcomeMeasure","@type":"rdf:Property","rdfs:comment":"The outcome measure for the study","rdfs:label":"outcomeMeasure","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"outbreak:outcomeMeasure"},"schema:domainIncludes":{"@id":"outbreak:Outcome"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:outcomeTimeFrame","@type":"rdf:Property","rdfs:comment":"The specific time point(s) and overall duration of evaluation must be specified in this section. ","rdfs:label":"outcomeTimeFrame","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"outbreak:outcomeTimeFrame"},"schema:domainIncludes":{"@id":"outbreak:Outcome"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:outcomeType","@type":"rdf:Property","rdfs:comment":"The classification of the outcome measure as either primary, secondary, or exploratory","rdfs:label":"outcomeType","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"outbreak:outcomeType"},"schema:domainIncludes":{"@id":"outbreak:Outcome"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:eligibilityCriteria","@type":"rdf:Property","rdfs:comment":"eligibility criteria","rdfs:label":"eligibilityCriteria","owl:cardinality":"one","marginality":"recommended","schema:domainIncludes":{"@id":"outbreak:ClinicalTrial"},"schema:rangeIncludes":{"@id":"outbreak:Eligibility"}},{"@id":"outbreak:inclusionCriteria","@type":"rdf:Property","rdfs:comment":"criteria for inclusion in the study","rdfs:label":"inclusionCriteria","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"outbreak:inclusionCriteria"},"schema:domainIncludes":{"@id":"outbreak:Eligibility"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:minimumAge","@type":"rdf:Property","rdfs:comment":"the minimum age for a participant to be included in the study","rdfs:label":"minimumAge","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"outbreak:minimumAge"},"schema:domainIncludes":{"@id":"outbreak:Eligibility"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:maximumAge","@type":"rdf:Property","rdfs:comment":"the maximum age for a participant to be included in the study","rdfs:label":"maximumAge","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:requiredMaxAge"},"schema:domainIncludes":{"@id":"outbreak:Eligibility"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:gender","@type":"rdf:Property","rdfs:comment":"the sex requirement to be included in the study","rdfs:label":"gender","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:requiredGender"},"schema:domainIncludes":{"@id":"outbreak:Eligibility"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:genderBased","@type":"rdf:Property","rdfs:comment":"Boolean for whether or not participation is based on gender","rdfs:label":"genderBased","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"outbreak:genderBased"},"schema:domainIncludes":{"@id":"outbreak:Eligibility"},"schema:rangeIncludes":{"@id":"schema:Boolean"}},{"@id":"outbreak:healthyVolunteers","@type":"rdf:Property","rdfs:comment":"a boolean to indicate whether or not healthy volunteers may be included in the study","rdfs:label":"healthyVolunteers","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"outbreak:healthyVolunteers"},"schema:domainIncludes":{"@id":"outbreak:Eligibility"},"schema:rangeIncludes":{"@id":"schema:Boolean"}},{"@id":"outbreak:stdAge","@type":"rdf:Property","rdfs:comment":"the age category of a participant to be included in the study if a minimum and maximum age is not specified","rdfs:label":"stdAge","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"outbreak:stdAge"},"schema:domainIncludes":{"@id":"outbreak:Eligibility"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:exclusionCriteria","@type":"rdf:Property","rdfs:comment":"criteria for exclusion from the study","rdfs:label":"exclusionCriteria","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"outbreak:exclusionCriteria"},"schema:domainIncludes":{"@id":"outbreak:Eligibility"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:criteriaText","@type":"rdf:Property","rdfs:comment":"The descriptive criteria as published for the Clinical Trial","rdfs:label":"criteriaText","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"outbreak:criteriaText"},"schema:domainIncludes":{"@id":"outbreak:Eligibility"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:citedBy","@type":"rdf:Property","rdfs:comment":"other articles or resources that cite this clinical trial","rdfs:label":"citedBy","owl:cardinality":"many","marginality":"optional","owl:inverseOf":{"@id":"schema:isBasedOn"},"schema:domainIncludes":{"@id":"outbreak:ClinicalTrial"},"schema:rangeIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}]},{"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"name of the citedBy resource","rdfs:label":"name","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:type","@type":"rdf:Property","rdfs:comment":"type (publication, protocol, dataset, code, etc.) of the citedBy resource. Note that this can include ClinicalTrial results","rdfs:label":"type","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:additionalType"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:identifier","@type":"rdf:Property","rdfs:comment":"identifier (pmid, WHO protocol id, etc.) of the citedby resource","rdfs:label":"identifier","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:url","@type":"rdf:Property","rdfs:comment":"url of the cited by resource","rdfs:label":"url","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:url"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:URL"}},{"@id":"outbreak:datePublished","@type":"rdf:Property","rdfs:comment":"The date for which the other articles, resources, or results that cite this clinical trial were posted, published, or made available","rdfs:label":"datePublished","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:datePublished"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:isBasedOn","@type":"rdf:Property","rdfs:comment":"Associated datasets, software, protocols, etc. used by the work described in this clinical study (includes study protocol documents, data analysis plans, reference publications. etc)","rdfs:label":"isBasedOn","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:isBasedOn"},"schema:domainIncludes":{"@id":"outbreak:ClinicalTrial"},"schema:rangeIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}]},{"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"name of the associated dataset, software, protocols, etc used by the work described in this clinical study","rdfs:label":"name","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:type","@type":"rdf:Property","rdfs:comment":"type of the associated resource (dataset, protocols, analysis, etc.) used by the work described in this clinical study","rdfs:label":"type","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:additionalType"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:identifier","@type":"rdf:Property","rdfs:comment":"Identifier of the associated datasets, software, protocols, etc.","rdfs:label":"identifier","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:versionDate","@type":"rdf:Property","rdfs:comment":"date of the version of the associated resource used by the work described in this clinical trial","rdfs:label":"versionDate","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":[{"@id":"schema:releaseDate"},{"@id":"schema:dateModified"}],"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Date"}},{"@id":"outbreak:url","@type":"rdf:Property","rdfs:comment":"url of the associated resource used by the work described in this clinical study (includes study protocol documents, data analysis plans, etc)","rdfs:label":"url","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:url"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:URL"}},
-    {"@id":"outbreak:isRelatedTo","@type":"rdf:Property","rdfs:comment":"Other resources related to, but not a derivative of nor derived from this analysis","rdfs:label":"isRelatedTo","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:isRelatedTo"},"schema:domainIncludes":{"@id":"outbreak:ClinicalTrial"},"schema:rangeIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}]},{"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"name of related resource","rdfs:label":"name","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:type","@type":"rdf:Property","rdfs:comment":"type of related resource","rdfs:label":"type","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:additionalType"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:identifier","@type":"rdf:Property","rdfs:comment":"identifier (if available) of related resource","rdfs:label":"identifier","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:curatedBy","@type":"rdf:Property","rdfs:comment":"The source from which this clinical trial was identified for inclusion into Outbreak.info. Provides provenance for a resource which was curated by another","rdfs:label":"curatedBy","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:citation"},"schema:domainIncludes":{"@id":"outbreak:ClinicalTrial"},"schema:rangeIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}]},
-    {"@id":"outbreak:curatedBy","@type":"rdf:Property","rdfs:comment":"The source from which this dataset was identified for inclusion into Outbreak.info. Provides provenance for a resource which was curated by another","rdfs:label":"curatedBy","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:citation"},"schema:domainIncludes":{"@id":"outbreak:Dataset"},"schema:rangeIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"},{"@id":"schema:Thing"}]},
-    {"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"name of the source from which this dataset was identified for inclusion","rdfs:label":"name","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}}, 
-    {"@id":"outbreak:curationDate","@type":"rdf:Property","rdfs:comment":"The date this resource was added to outbreak.info, or the date when this resource was updated in outbreak.info","rdfs:label":"curationDate","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:releaseDate"},"schema:domainIncludes":{"@id":"outbreak:ClinicalTrial"},"schema:rangeIncludes":{"@id":"schema:Date"}}
+    {
+      "@id": "outbreak:identifierSource",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Source of identifier assignment or type of identifier (NCTid, China CTRid, EudraCT Number, etc.)",
+      "rdfs:label": "identifierSource",
+      "schema:domainIncludes": {
+        "@id": "outbreak:ClinicalTrial"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:dateModifiedType",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The type of date. Equivalent to NCT's LastUpdatePostDateType",
+      "rdfs:label": "dateModifiedType",
+      "schema:domainIncludes": {
+        "@id": "outbreak:ClinicalTrial"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:healthConditionIdentifier",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Ontological or controlled vocabulary identifier for the health condition or disease",
+      "rdfs:label": "healthConditionIdentifier",
+      "schema:domainIncludes": {
+        "@id": "outbreak:ClinicalTrial"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        },
+        {
+          "@id": "schema:DefinedTerm"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:hasResults",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Boolean for if the clinical trial has published any results",
+      "rdfs:label": "hasResults",
+      "schema:domainIncludes": {
+        "@id": "outbreak:ClinicalTrial"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Boolean"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:studyEvent",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "an event status such as StudyStart, PrimaryCompletion, Completion, StudyFirstSubmit, StudyFirstSubmitQC, LastUpdateSubmit",
+      "rdfs:label": "studyEvent",
+      "schema:domainIncludes": {
+        "@id": "outbreak:ClinicalTrial"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "outbreak:StudyEvent"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:studyStatus",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The status of the study",
+      "rdfs:label": "studyStatus",
+      "schema:domainIncludes": {
+        "@id": "outbreak:ClinicalTrial"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "outbreak:StudyStatus"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:studyDesign",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The general design of the study",
+      "rdfs:label": "studyDesign",
+      "schema:domainIncludes": {
+        "@id": "outbreak:ClinicalTrial"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "outbreak:StudyDesign"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:armGroup",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The arm or factor of an interventional study",
+      "rdfs:label": "armGroup",
+      "schema:domainIncludes": {
+        "@id": "outbreak:ClinicalTrial"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "outbreak:ArmGroup"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:outcome",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The arm or factor of an interventional study",
+      "rdfs:label": "outcome",
+      "schema:domainIncludes": {
+        "@id": "outbreak:ClinicalTrial"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "outbreak:Outcome"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:eligibilityCriteria",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "eligibility criteria",
+      "rdfs:label": "eligibilityCriteria",
+      "schema:domainIncludes": {
+        "@id": "outbreak:ClinicalTrial"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "outbreak:Eligibility"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:author",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The author of this resource, content, or rating",
+      "rdfs:label": "author",
+      "rdfs:sameAs": {"@id":"schema:author"},
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "outbreak:Person"
+        },
+        {
+          "@id": "outbreak:Organization"
+        }  
+      ]
+    },
+    {
+      "@id": "outbreak:dateCreated",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Date the record was created",
+      "rdfs:label": "dateCreated",
+      "rdfs:sameAs": {"@id":"schema:dateCreated"},
+      "schema:domainIncludes": [
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Date"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:datePublished",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Date of first broadcast/publication",
+      "rdfs:label": "datePublished",
+      "rdfs:sameAs": {"@id":"schema:datePublished"},
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Date"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:dateModified",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The date on which the CreativeWork was most recently modified or when the item's entry was modified within a DataFeed",
+      "rdfs:label": "dateModified",
+      "rdfs:sameAs": {"@id":"schema:dateModified"},
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Date"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:keywords",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "keywords for describing the record",
+      "rdfs:label": "keywords",
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:abstract",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "A short descriptive summary of the publication or study",
+      "rdfs:label": "abstract",
+      "rdfs:sameAs": {"@id":"schema:abstract"},
+      "schema:domainIncludes": [
+          {"@id": "outbreak:Publication"},
+          {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:pmid",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "A pubmed identifier if available",
+      "rdfs:label": "pmid",
+      "schema:domainIncludes": [
+          {"@id": "outbreak:CitationObject"},
+          {"@id": "outbreak:Correction"},
+          {"@id": "outbreak:Publication"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Integer"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:doi",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "A doi if available",
+      "rdfs:label": "doi",
+      "schema:domainIncludes": [
+          {"@id": "outbreak:CitationObject"},
+          {"@id": "outbreak:Correction"},
+          {"@id": "outbreak:Dataset"},
+          {"@id": "outbreak:Publication"},
+          {"@id": "outbreak:Analysis"},
+          {"@id": "outbreak:Protocol"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:funding",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Funding that supports (sponsors) the collection of this dataset through some kind of financial contribution",
+      "rdfs:label": "funding",
+      "schema:domainIncludes": [
+          {"@id": "outbreak:Dataset"},
+          {"@id": "outbreak:Publication"},
+          {"@id": "outbreak:Analysis"},
+          {"@id": "outbreak:Protocol"},
+          {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:MonetaryGrant"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:measurementTechnique",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "A technique or technology used in this resource",
+      "rdfs:label": "measurementTechnique",
+      "rdfs:sameAs": {"@id":"schema:measurementTechnique"},
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Protocol"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        },
+        {
+          "@id": "schema:DefinedTerm"
+        }  
+      ]
+    },
+    {
+      "@id": "outbreak:species",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Species(es) from which dataset has been collected",
+      "rdfs:label": "species",
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Analysis"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        },
+        {
+          "@id": "schema:DefinedTerm"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:infectiousAgent",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "infectious agents(s) which are the focus of the dataset",
+      "rdfs:label": "infectiousAgent",
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Analysis"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        },
+        {
+          "@id": "schema:DefinedTerm"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:infectiousDisease",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The disease or medical conditions caused by the infectious agent. Important as some agents may cause multiple diseases",
+      "rdfs:label": "infectiousDisease",
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Analysis"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        },
+        {
+          "@id": "schema:DefinedTerm"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:topicCategory",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Applicable outbreak.info category",
+      "rdfs:label": "topicCategory",
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+
+    {
+      "@id": "outbreak:isBasedOn",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "A citation to a resource (eg- publication, protocol, etc.) on which this resource was derived (stored as an object, not a string)",
+      "rdfs:label": "isBasedOn",
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {"@id": "outbreak:CitationObject"},
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:ClinicalTrial"},
+        {"@id": "schema:SoftwareApplication"},
+        {"@id": "schema:CreativeWork"}
+      ]
+    },
+    {
+      "@id": "outbreak:isRelatedTo",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "A citation to a resource (eg- publication, protocol, etc.) which is related to the resource but is not a derivative nor was derived from the resource (stored as an object, not a string)",
+      "rdfs:label": "isRelatedTo",
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {"@id": "outbreak:CitationObject"},
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:ClinicalTrial"},
+        {"@id": "schema:SoftwareApplication"},
+        {"@id": "schema:CreativeWork"}
+      ]
+    },
+    {
+      "@id": "outbreak:citedBy",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "A citation to a resource (eg- publication, protocol, etc.) which is derived from this resource (stored as an object, not a string)",
+      "rdfs:label": "citedBy",
+      "rdfs:sameAs":{"@id":"owl:inverseOf: outbreak:isBasedOn"},
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {"@id": "outbreak:CitationObject"},
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:ClinicalTrial"},
+        {"@id": "schema:SoftwareApplication"},
+        {"@id": "schema:CreativeWork"}
+      ]
+    },
+    {
+      "@id": "outbreak:curatedBy",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The source from which this Dataset was identified for inclusion into Outbreak.info. Provides provenance for a resource which was curated by another.",
+      "rdfs:label": "curatedBy",
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {"@id": "outbreak:Person"},
+        {"@id": "outbreak:Organization"},
+        {"@id": "outbreak:CitationObject"},
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:ClinicalTrial"},
+        {"@id": "schema:SoftwareApplication"},
+        {"@id": "schema:CreativeWork"}
+      ]
+    },
+    {
+      "@id": "outbreak:curationDate",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
+      "rdfs:label": "curationDate",
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {"@id": "schema:Date"}
+      ]
+    },
+    {
+      "@id": "outbreak:evaluations",
+      "@type": "rdf:Property",
+      "rdfs:comment":"One or more reviews, ratings, or other evaluations of this resource",
+      "rdfs:label": "evaluations",
+      "schema:domainIncludes":[
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes":[
+        {"@id": "schema:Review"},
+        {"@id": "schema:Rating"},
+        {"@id": "schema:AggregateRating"}
+      ]
+    }
   ]
 }

--- a/yaml/outbreak_Analysis.json
+++ b/yaml/outbreak_Analysis.json
@@ -1,140 +1,748 @@
 {
   "@context": {
-    "outbreak": "https://discovery.biothings.io/view/outbreak/",
-    "owl": "http://www.w3.org/2002/07/owl/",
-    "rdf": "http://www.w3.org/1999/02/22/-rdf-syntax-ns/",
-    "rdfs": "http://www.w3.org/2000/01/rdf/-schema/",
-    "schema": "http://schema.org/"
+    "schema": "http://schema.org/",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "outbreak": "http://discovery.biothings.io/view/"
   },
-  "@id": "https://discovery.biothings.io/view/outbreak/",
   "@graph": [
-    {
-      "@id": "outbreak:Organization",
-      "@type": "rdfs:Class",
-      "rdfs:label": "Organization",
-      "rdfs:comment": "This is the schema for describing the Organization schema used for outbreak.info.",
-      "rdfs:subClassOf": {
-        "@id": "schema:Organization"
-      },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
-      }
-    },
-    {"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"The name of the organization, team or group","rdfs:label":"name","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":{"@id":"outbreak:Organization"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:alternateName","@type":"rdf:Property","rdfs:comment":"Alternative names or commonly used abbreviations for the organization, team or group","rdfs:label":"alternateName","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:alternateName"},"schema:domainIncludes":{"@id":"outbreak:Organization"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:affiliation","@type":"rdf:Property","rdfs:comment":"An overarching consortia, multi-institutional team or group in which the organization\/team\/group is a member or affiliate","rdfs:label":"affiliation","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:affiliation"},"schema:domainIncludes":{"@id":"outbreak:Organization"},"schema:rangeIncludes":{"@id":"outbreak:Organization"}},{"@id":"outbreak:affiliationStatus","@type":"rdf:Property","rdfs:comment":"The status of the organization's membership or affiliation in the overarching consortial, multi-institutional team or group (current, past)","rdfs:label":"affiliationStatus","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":{"@id":"outbreak:Organization"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:members","@type":"rdf:Property","rdfs:comment":"Members of this organization, team, or group","rdfs:label":"members","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:members"},"schema:domainIncludes":{"@id":"outbreak:Organization"},"schema:rangeIncludes":[{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"}]},{"@id":"outbreak:membershipStatus","@type":"rdf:Property","rdfs:comment":"Status of the members of this organization","rdfs:label":"membershipStatus","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":{"@id":"outbreak:Organization"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:isRelatedTo","@type":"rdf:Property","rdfs:comment":"A resource which a person played a role","rdfs:label":"isRelatedTo","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:isRelatedTo"},"schema:domainIncludes":{"@id":"outbreak:Organization"},"schema:rangeIncludes":[{"@id":"schema:CreativeWork"},{"@id":"schema:HowTo"}]},{"@id":"outbreak:class","@type":"rdf:Property","rdfs:comment":"A classification of the organization by a resource. Eg- for ClinicalTrials funders, it's [\"U.S. National Institutes of Health\", \"Other U.S. Federal agencies\", \"Industry\", \"All others\"]","rdfs:label":"class","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:addtionalType"},"schema:domainIncludes":[{"@id":"schema:CreativeWork"},{"@id":"schema:HowTo"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:role","@type":"rdf:Property","rdfs:comment":"The role of an organization in its involvement with a resource","rdfs:label":"role","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":[{"@id":"schema:CreativeWork"},{"@id":"schema:HowTo"}],"schema:rangeIncludes":{"@id":"schema:Text"}},
     {
       "@id": "outbreak:Person",
       "@type": "rdfs:Class",
+      "rdfs:comment": "This is the Person schema for describing authors and people for outbreak.info resources",
       "rdfs:label": "Person",
-      "rdfs:comment": "This is the schema for describing the Person schema used for outbreak.info.",
       "rdfs:subClassOf": {
         "@id": "schema:Person"
       },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
+      "$validation": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "The name of the person.",
+            "type": "string"
+          },
+          "alternateName": {
+            "description": "An alias for the person.",
+            "type": "string"
+          },
+          "familyName": {
+            "description": "Family name. In the U.S., the last name of an Person. This can be used along with givenName instead of the name property.",
+            "type": "string"
+          },
+          "givenName": {
+            "description": "Given name. In the U.S., the first name of a Person. This can be used along with familyName instead of the name property.",
+            "type": "string"
+          },
+          "affiliation": {
+            "description": "An organization that this person is affiliated with. For example, a school/university, a club, or a team.",
+            "oneOf": [
+              {
+                "$ref": "#/definitions/baseOrgObject"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/baseOrgObject"
+                }
+              }
+            ]
+          },
+          "orcid": {
+            "description": "the ORCID ID of the person",
+            "type": "string"
+          },
+          "role": {
+            "description": "authorship, sponsorship, or other contribution role played by the person or organization in the creation of this resource",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            ]
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "definitions":{
+            "baseOrgObject": {
+                "@type": "outbreak:Organization",
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "alternateName": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ]   
+            }
+        }
       }
     },
-    {"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"The name of the person","rdfs:label":"name","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":{"@id":"outbreak:Person"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:alternateName","@type":"rdf:Property","rdfs:comment":"Alternative ways in which the person's name is included in a record","rdfs:label":"alternateName","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:alternateName"},"schema:domainIncludes":{"@id":"outbreak:Person"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:givenName","@type":"rdf:Property","rdfs:comment":"The given name of the person","rdfs:label":"givenName","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:givenName"},"schema:domainIncludes":{"@id":"outbreak:Person"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:familyName","@type":"rdf:Property","rdfs:comment":"The family name of the person","rdfs:label":"familyName","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:familyName"},"schema:domainIncludes":{"@id":"outbreak:Person"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:affiliation","@type":"rdf:Property","rdfs:comment":"The organization with which the person is affiliated or has membership in","rdfs:label":"affiliation","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:affiliation"},"schema:domainIncludes":{"@id":"outbreak:Person"},"schema:rangeIncludes":{"@id":"outbreak:Organization"}},{"@id":"outbreak:affiliationStatus","@type":"rdf:Property","rdfs:comment":"The status of the person's membership or affiliation in an organization, team or group (current, past)","rdfs:label":"affiliationStatus","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:addtionalType"},"schema:domainIncludes":{"@id":"outbreak:Person"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:orcid","@type":"rdf:Property","rdfs:comment":"The ORCID ID of the person","rdfs:label":"orcid","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":{"@id":"outbreak:Person"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:isRelatedTo","@type":"rdf:Property","rdfs:comment":"A resource which a person played a role","rdfs:label":"isRelatedTo","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:isRelatedTo"},"schema:domainIncludes":{"@id":"outbreak:Person"},"schema:rangeIncludes":[{"@id":"schema:CreativeWork"},{"@id":"schema:HowTo"}]},{"@id":"outbreak:role","@type":"rdf:Property","rdfs:comment":"The role a person played in the creation of a resource","rdfs:label":"role","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:addtionalType"},"schema:domainIncludes":[{"@id":"schema:CreativeWork"},{"@id":"schema:HowTo"}],"schema:rangeIncludes":{"@id":"schema:Text"}},
+    {
+      "@id": "outbreak:orcid",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "the ORCID ID of the person",
+      "rdfs:label": "orcid",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Person"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:Organization",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the organization schema for describing authors, funders and other organizations referenced by outbreak.info resources",
+      "rdfs:label": "Organization",
+      "rdfs:subClassOf": {
+        "@id": "schema:Organization"
+      },
+      "$validation": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "The name of the organization.",
+            "type": "string"
+          },
+          "alternateName": {
+            "description": "An alias or acronym for the organization.",
+            "type": "string"
+          },
+          "affiliation": {
+            "description": "consortia or other organizations with which this organization is affiliated",
+            "oneOf": [
+              {
+                "$ref": "#/definitions/baseOrgObject"
+              },
+              {
+                "type": "array",
+                "items": {
+                    "$ref": "#/definitions/baseOrgObject"
+                }
+              }
+            ]
+          },
+          "class": {
+            "description": "A classification of the organization by a resource. Eg- for ClinicalTrials funders, it's [U.S. National Institutes of Health, Other U.S. Federal agencies, Industry, All others]",
+            "type": "string"
+          },
+          "role": {
+            "description": "The role of an organization in its involvement with a resource",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+              }
+            ]
+          },
+          "members": {
+            "description": "Members of this organization, team, or group",
+            "oneOf": [
+              {
+                "$ref": "#/definitions/basePersonObject"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/basePersonObject"
+                }
+              }
+            ]
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "definitions": {
+            "baseOrgObject":{
+                "description": "Affiliated Organization",
+                "@type": "outbreak:Organization",
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "description": "name of the organization",
+                    "type": "string"
+                  },
+                  "alternateName": {
+                    "description": "Alternate name or Acronym for the organization.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ]              
+            },
+            "basePersonObject":{
+                "@type": "outbreak:Person",
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "alternateName": {
+                        "type": "string"
+                    },
+                    "givenName": {
+                        "type": "string"
+                    },
+                    "familyName": {
+                        "type": "string"
+                    },
+                    "orcid": {
+                        "type": "string"
+                    },
+                    "affiliation": {
+                        "description": "consortia or other organizations with which this person is affiliated",
+                        "oneOf": [
+                          {
+                            "$ref": "#/definitions/baseOrgObject"
+                          },
+                          {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/baseOrgObject"
+                            }
+                          }
+                        ]
+                      }
+                },
+                "required": [
+                    "name"
+                ]                
+            }
+        }
+      }
+    },
+    {
+      "@id": "outbreak:affiliation",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "consortia or other organizations with which this organization is affiliated",
+      "rdfs:label": "affiliation",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Organization"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "outbreak:Organization"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:members",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Members of this organization, team, or group",
+      "rdfs:label": "members",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Organization"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "outbreak:Person"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:class",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "A classification of the organization by a resource. Eg- for ClinicalTrials funders, it's [U.S. National Institutes of Health, Other U.S. Federal agencies, Industry, All others]",
+      "rdfs:label": "class",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Organization"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:role",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "authorship, sponsorship, or other contribution role played by the person or organization in the creation of this resource. In a Clinical Study/Trial ArmGroup, it's equivalent to the ArmType in ClinicalTrials.gov",
+      "rdfs:label": "role",
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Person"},
+        {"@id": "outbreak:Organization"},
+        {"@id": "outbreak:ArmGroup"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
     {
       "@id": "outbreak:MonetaryGrant",
       "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing the MonetaryGrant schema used for outbreak.info",
       "rdfs:label": "MonetaryGrant",
-      "rdfs:comment": "This is the schema for describing the MonetaryGrant schema used for outbreak.info.",
       "rdfs:subClassOf": {
         "@id": "schema:MonetaryGrant"
       },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
+      "$validation": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "The name of the grant or funding.",
+            "type": "string"
+          },
+          "identifier": {
+            "description": "The funding or grant id",
+            "type": "string"
+          },
+          "url": {
+            "description": "URL of the grant or funding award.",
+            "type": "string",
+            "format": "uri"
+          },
+          "funder": {
+            "description": "The organization(s) that supported (sponsored) the grant through some kind of financial contribution.",
+            "oneOf": [
+              {
+                "$ref": "#/definitions/baseOrgObject"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/baseOrgObject"
+                }
+              }
+            ]
+          },
+          "recipient": {
+            "description": "The person or organization to whom or to which the grant was awarded",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/basePersonObject"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/basePersonObject"
+                }
+              },
+              {
+                "$ref": "#/definitions/baseOrgObject"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/baseOrgObject"
+                }
+              }
+            ]
+          }   
+        },
+        "required": [
+          "funder"
+        ],
+        "definitions": {
+            "baseOrgObject":{
+                "description": "Affiliated Organization",
+                "@type": "outbreak:Organization",
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "description": "name of the organization",
+                    "type": "string"
+                  },
+                  "alternateName": {
+                    "description": "Alternate name or Acronym for the organization.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ]              
+            },
+            "basePersonObject":{
+                "@type": "outbreak:Person",
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "alternateName": {
+                        "type": "string"
+                    },
+                    "givenName": {
+                        "type": "string"
+                    },
+                    "familyName": {
+                        "type": "string"
+                    },
+                    "orcid": {
+                        "type": "string"
+                    },
+                    "affiliation": {
+                        "description": "consortia or other organizations with which this person is affiliated",
+                        "oneOf": [
+                          {
+                            "$ref": "#/definitions/baseOrgObject"
+                          },
+                          {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/baseOrgObject"
+                            }
+                          }
+                        ]
+                      }
+                },
+                "required": [
+                    "name"
+                ]                
+            }
+        }
       }
     },
-    {"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"The name of the monetary grant","rdfs:label":"name","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":{"@id":"outbreak:MonetaryGrant"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:identifier","@type":"rdf:Property","rdfs:comment":"The grant ID or an identifier associated with the grant","rdfs:label":"identifier","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":{"@id":"outbreak:MonetaryGrant"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:url","@type":"rdf:Property","rdfs:comment":"The url for the grant (if available)","rdfs:label":"url","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:url"},"schema:domainIncludes":{"@id":"outbreak:MonetaryGrant"},"schema:rangeIncludes":{"@id":"schema:URL"}},{"@id":"outbreak:funder","@type":"rdf:Property","rdfs:comment":"The funding organization of the grant","rdfs:label":"funder","owl:cardinality":"many","marginality":"required","rdfs:sameAs":{"@id":"schema:funder"},"schema:domainIncludes":{"@id":"outbreak:MonetaryGrant"},"schema:rangeIncludes":{"@id":"outbreak:Organization"}},{"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"The name of the funding organization","rdfs:label":"name","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":{"@id":"outbreak:Organization"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:recipient","@type":"rdf:Property","rdfs:comment":"The person or organization to whom or to which the grant was awarded","rdfs:label":"recipient","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:recipient"},"schema:domainIncludes":{"@id":"outbreak:MonetaryGrant"},"schema:rangeIncludes":[{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"}]},{"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"The name of the recipient of the grant","rdfs:label":"name","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":[{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:affiliation","@type":"rdf:Property","rdfs:comment":"The affiliation of the recipient of the grant","rdfs:label":"affiliation","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:affiliation"},"schema:domainIncludes":[{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"}],"schema:rangeIncludes":{"@id":"schema:Text"}},
     {
-      "@id": "outbreak:Analysis",
+      "@id": "outbreak:recipient",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The person or organization to whom or to which the grant was awarded",
+      "rdfs:label": "recipient",
+      "schema:domainIncludes": {
+        "@id": "outbreak:MonetaryGrant"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Person"
+        },
+        {
+          "@id": "schema:Organization"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:DataDownload",
       "@type": "rdfs:Class",
-      "rdfs:label": "Analysis",
-      "rdfs:comment": "This is the schema for describing the Analysis schema used for outbreak.info.",
+      "rdfs:comment": "This is the schema for describing the DataDownload schema used for outbreak.info.",
+      "rdfs:label": "DataDownload",
+      "rdfs:subClassOf": {
+        "@id": "schema:DataDownload"
+      }
+    },
+    {
+      "@id": "outbreak:CitationObject",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "A citation object for a resource which is cited by the subject (ie- is a derivative of the subject), related to the subject, or from which the subject was based on (ie- is derived from).",
+      "rdfs:label": "CitationObject",
       "rdfs:subClassOf": {
         "@id": "schema:CreativeWork"
       },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
+      "$validation": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "The name or title of the cited resource.",
+            "type": "string"
+          },
+          "url": {
+            "description": "URL of the cited resource.",
+            "type": "string",
+            "format": "uri"
+          },
+          "identifier": {
+            "description": "An identifier associated with the citation",
+            "type": "string"
+          },
+          "citeText": {
+            "description": "The bibliographic citation for the referenced resource as is provided",
+            "type": "string"
+          },
+          "versionDate": {
+            "description": "The version date of the resource used at the time of the creation of the citation as certain resources (protocols, datasets) may change frequently over time.",
+            "format": "date",
+            "type": "string"
+          },
+          "pmid": {
+            "description": "A pubmed identifier if available",
+            "type": "string"
+          },
+          "doi": {
+            "description": "A doi if available",
+            "type": "string"
+          },
+          "sourceType": {
+            "description": "The @type of resource",
+            "enum": [
+              "Dataset",
+              "Publication",
+              "ClinicalTrial",
+              "Analysis",
+              "Protocol",
+              "SoftwareApplication",
+              "CreativeWork"
+            ]
+          }
+        },
+        "required": [
+          "name",
+          "sourceType"
+        ]
+      }
+    },
+    {
+      "@id": "outbreak:citeText",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The bibliographic citation for the referenced resource as is provided",
+      "rdfs:label": "citeText",
+      "schema:domainIncludes": {
+        "@id": "outbreak:CitationObject"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:versionDate",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The version date of the resource used at the time of the creation of the citation as certain resources (protocols, datasets) may change frequently over time.",
+      "rdfs:label": "versionDate",
+      "schema:domainIncludes": {
+        "@id": "outbreak:CitationObject"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Date"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:sourceType",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The type of resource",
+      "rdfs:label": "sourceType",
+      "schema:domainIncludes": {
+        "@id": "outbreak:CitationObject"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:Dataset",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing the Dataset schema used for outbreak.info.",
+      "rdfs:label": "Dataset",
+      "rdfs:subClassOf": {
+        "@id": "schema:Dataset"
+      }
+    },
+    {
+      "@id": "outbreak:Correction",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing a Correction used for outbreak.info. A Correction is a specialized subclass of the CitationObject",
+      "rdfs:label": "Correction",
+      "rdfs:subClassOf": {
+        "@id": "schema:CreativeWork"
+      }
+    },
+    {
+      "@id": "outbreak:correctionType",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Type of notice or correction: (correction, retraction, expression of convern, withdrawal, erratum, update, correction/republication, preprint, peer reviewed version)",
+      "rdfs:label": "correctionType",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Correction"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:Publication",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing the Publication used for outbreak.info",
+      "rdfs:label": "Publication",
+      "rdfs:subClassOf": {
+        "@id": "schema:MedicalScholarlyArticle"
+      }
+    },
+    {
+      "@id": "outbreak:journalName",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The name of the journal (or publisher if journal name not available)",
+      "rdfs:label": "journalName",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Publication"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:journalNameAbbrevation",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "abbreviated Journal Title (note, this should be autopopulated)",
+      "rdfs:label": "journalNameAbbrevation",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Publication"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:volumeNumber",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Volume number of journal in which the article was published",
+      "rdfs:label": "volumeNumber",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Publication"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:issueNumber",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Issue of journal in which the article was published",
+      "rdfs:label": "issueNumber",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Publication"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:Analysis",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing an Analysis for inclusion in outbreak.info resources",
+      "rdfs:label": "Analysis",
+      "rdfs:subClassOf": {
+        "@id": "schema:CreativeWork"
       },
       "$validation": {
-          "$schema": "http://json-schema.org/draft-07/schema#",
-          "type": "object",
-          "properties": {
-            "name": {
-              "description": "The name of the item.",
-              "type": "string"
-            },
-            "description": {
-              "description": "A description of the item.",
-              "type": "string"
-            },
-            "url": {
-              "description": "The url of the item",
-              "format": "uri",
-              "type": "string"
-            },
-            "identifier": {
-              "description": "An identifier associated with the analysis if available",
-              "type": "string"
-            },
-            "doi": {
-              "description": "A DOI associated with the analysis if available",
-              "type": "string"
-            },
-            "hasDownloadableContent": {
-              "description": "Indicates the site has content that can be downloaded (raw data, data sheets, charts, etc)",
-              "type": "boolean"
-            },
-            "license": {
-              "description": "A license document that applies to this content, typically indicated by URL",
-              "type": "string"
-            },
-            "domainUrl": {
-              "description": "The domain name or main site on which webpage or specific url can be found",
-              "format": "uri",
-              "type": "string"
-            },
-            "datePublished": {
-              "description": "PublicationDate of the analysis online if available",
-              "format": "date",
-              "type": "string"
-            },
-            "dateModified": {
-              "description": "Most recent date for which the analysis model itself was updated",
-              "format": "date",
-              "type": "string"
-            },
-            "assumption": {
-              "description": "Statement of assumptions / limitations of the model",
-              "oneOf": [
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "The name of the analysis",
+            "type": "string"
+          },
+          "description": {
+            "description": "A description of the analysis",
+            "type": "string"
+          },
+          "identifier": {
+            "description": "An identifier for the analysis, preferably a doi",
+            "type": "string"
+          },
+          "doi": {
+            "description": "The DOI of the analysis if available",
+            "type": "string"
+          },
+          "url": {
+            "description": "URL where the analysis can be found",
+            "type": "string",
+            "format": "uri"
+          },
+          "domainUrl": {
+            "description": "The domain name or main site on which webpage or specific url of the analysis can be found",
+            "type": "string",
+            "format": "uri"
+          },
+          "datePublished": {
+            "description": "Date of first broadcast/publication of the analysis",
+            "format": "date",
+            "type": "string"
+          },
+          "dateModified": {
+            "description": "The date on which the CreativeWork was most recently modified or when the item's entry was modified within a DataFeed.",
+            "format": "date",
+            "type": "string"
+          },
+          "author": {
+              "description": "The author of this content or rating.",
+              "anyOf": [
                 {
-                  "type": "string"
+                  "$ref": "#/definitions/person"
                 },
                 {
                   "type": "array",
                   "items": {
-                    "type": "string"
+                    "$ref": "#/definitions/person"
                   }
-                }
-              ]
-            },
-            "keywords": {
-              "description": "keywords",
-              "oneOf": [
+                },
                 {
-                  "type": "string"
+                  "$ref": "#/definitions/organization"
                 },
                 {
                   "type": "array",
                   "items": {
-                    "type": "string"
+                    "$ref": "#/definitions/organization"
                   }
                 }
               ]
             },
-            "topicCategory": {
+          "assumption": {
+            "description": "Statement of assumptions / limitations of the model",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            ]
+          },
+          "keywords": {
+            "description": "Keywords or tags used to describe this content. Multiple entries in a keywords list are typically delimited by commas.",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            ]
+          },
+          "topicCategory": {
               "description": "Applicable outbreak.info category",
               "oneOf": [
                 {
@@ -171,7 +779,8 @@
                     "Behavioral Research",
                     "Epidemiology",
                     "Classical Epidemiology",
-                    "Molecular Epidemiology"
+                    "Molecular Epidemiology",
+                    "Information Sciences"
                   ]
                 },
                 {
@@ -210,16 +819,17 @@
                         "Behavioral Research",
                         "Epidemiology",
                         "Classical Epidemiology",
-                        "Molecular Epidemiology"
+                        "Molecular Epidemiology",
+                        "Information Sciences"
                       ]
                   }
                 }
               ]
 
             },
-            "analysisTechnique": {
-                "description": "A technique or technology used in a analysis.",
-                "oneOf": [
+          "analysisTechnique": {
+            "description": "A technique or technology used in a analysis",
+            "oneOf": [
                   {
                     "$ref": "#/definitions/moreControlledVocabulary"
                   },
@@ -243,9 +853,9 @@
                     ]
                   }
                 ]
-              },
-            "infectiousAgent": {
-            "description": "infectious agents(s) which are the focus of the dataset",
+          },
+          "infectiousAgent": {
+            "description": "infectious agents(s) which are the focus of the analysis",
             "oneOf": [{
                 "$ref": "#/definitions/miscControlledVocabulary"
               },
@@ -257,9 +867,9 @@
               }
             ]
           },
-            "infectiousDisease": {
-              "description": "The disease or medical conditions caused by the infectious agent. Important as some agents may cause multiple diseases",
-              "oneOf": [
+          "infectiousDisease": {
+            "description": "The disease or medical conditions caused by the infectious agent. Important as some agents may cause multiple diseases",
+            "oneOf": [
                 {
                   "$ref": "#/definitions/diseaseVocabulary"
                 },
@@ -269,11 +879,11 @@
                     "$ref": "#/definitions/diseaseVocabulary"
                   }
                 }
-              ]
-            },
-            "analysisTopic": {
-              "description": "The underlying question, goal, or aim of the analysis",
-              "oneOf": [
+            ]
+          },
+          "analysisTopic": {
+            "description": "The underlying question, goal, or aim of the analysis",
+            "oneOf": [
                 {
                   "$ref": "#/definitions/controlledVocabulary"
                 },
@@ -283,93 +893,24 @@
                         "$ref": "#/definitions/controlledVocabulary"
                   }
                 }
-              ]
-            },
-            "author": {
-              "description": "The author of this content or rating.",
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/person"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/person"
-                  }
-                },
-                {
-                  "$ref": "#/definitions/organization"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/organization"
-                  }
-                }
-              ]
-            },
-            "contributor": {
-              "description": "A secondary contributor to the CreativeWork or Event.",
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/person"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/person"
-                  }
-                },
-                {
-                  "$ref": "#/definitions/organization"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/organization"
-                  }
-                }
-              ]
-            },
-            "maintainer": {
-              "description": "A maintainer of a Dataset, software package (SoftwareApplication), or other Project.",
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/person"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/person"
-                  }
-                },
-                {
-                  "$ref": "#/definitions/organization"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/organization"
-                  }
-                }
-              ]
-            },
-            "funding": {
-              "description": "A person or organization that supports (sponsors) something through some kind of financial contribution.",
-              "oneOf": [
-                {
+            ]
+          },
+          "funding": {
+            "description": "The funding that supported the creation or maintenance of the analysis",
+            "oneOf": [
+              {
+                "$ref": "#/definitions/funding"
+              },
+              {
+                "type": "array",
+                "items": {
                   "$ref": "#/definitions/funding"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/funding"
-                  }
                 }
-              ]
-            },
-            "citedBy": {
-              "description": "A resource (publication, protocol, dataset, etc.) which was derived from this protocol",
+              }
+            ]
+          },          
+          "isBasedOn": {
+              "description": "Associated datasets, software, protocols, etc. used by the work described in this analysis, including reference publications",
               "oneOf": [
                 {
                   "$ref": "#/definitions/citation"
@@ -382,36 +923,34 @@
                 }
               ]
             },
-            "isBasedOn": {
-              "description": "A resource (publication, protocol, dataset, etc) from which this analysis was derived",
-              "oneOf": [
-                {
+          "citedBy": {
+            "description": "A citation to a resource (eg- publication, protocol, etc.) which is derived from this analysis (stored as an object, not a string)",
+            "oneOf": [{
+                "$ref": "#/definitions/citation"
+              },
+              {
+                "type": "array",
+                "items": {
                   "$ref": "#/definitions/citation"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/citation"
-                  }
                 }
-              ]
-            },
-            "isRelatedTo": {
-              "description": "Other resources related to, but not a derivative of nor derived from this analysis",
-              "oneOf": [
-                {
+              }
+            ]
+          },
+          "isRelatedTo": {
+            "description": "A citation to a resource (eg- publication, protocol, etc.) which is related to the analysis but is not a derivative nor was derived from the analysis (stored as an object, not a string)",
+            "oneOf": [{
+                "$ref": "#/definitions/citation"
+              },
+              {
+                "type": "array",
+                "items": {
                   "$ref": "#/definitions/citation"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/citation"
-                  }
                 }
-              ]
-            },
-            "curatedBy": {
-            "description": "The source from which this Dataset was identified for inclusion into Outbreak.info. Provides provenance for a resource which was curated by another.",
+              }
+            ]
+          },
+          "curatedBy": {
+            "description": "The source from which this analysis was identified for inclusion into Outbreak.info. Provides provenance for a resource which was curated by another.",
             "anyOf": [{
                 "$ref": "#/definitions/citation"
               },
@@ -441,23 +980,50 @@
               }
             ]
           },
-            "curationDate":{
+          "curationDate":{
             "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
             "type": "string",
             "format": "date"
-          }
           },
-          "required": [
-            "url",
-            "identifier",
-            "name",
-            "description",
-            "author"
-          ],
+          "license": {
+            "description": "A license document that applies to this content, typically indicated by URL.",
+            "type": "string"
+          },
+          "evaluations":{
+              "description": "Reviews, Ratings, or other types of evaluations on this resource",
+              "anyOf":[
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/reviewObject"
+                }
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/ratingObject"
+                }
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/aggregateRatingObject"
+                }
+              }
+            ]
+            }
+        },
+        "required": [
+          "author",
+          "description",
+          "identifier",
+          "name",
+          "url"
+        ],
           "definitions": {
             "controlledVocabulary": {
               "definition": "collection of vocabulary terms defined in ontologies",
-              "@type": "CreativeWork",
+              "@type": "DefinedTerm",
               "type": "string",
               "strict": false,
               "vocabulary": {
@@ -475,7 +1041,7 @@
             },
             "miscControlledVocabulary": {
               "description": "collection of vocabulary terms defined in ontologies",
-              "@type": "CreativeWork",
+              "@type": "DefinedTerm",
               "type": "string",
               "strict": false,
               "vocabulary": {
@@ -485,7 +1051,7 @@
             },
             "moreControlledVocabulary": {
               "definition": "collection of vocabulary terms defined in ontologies",
-              "@type": "CreativeWork",
+              "@type": "DefinedTerm",
               "type": "string",
               "strict": false,
               "vocabulary": {
@@ -499,7 +1065,7 @@
             },
             "diseaseVocabulary": {
               "description": "collection of vocabulary terms defined in ontologies",
-              "@type": "CreativeWork",
+              "@type": "DefinedTerm",
               "type": "string",
               "strict": false,
               "vocabulary": {
@@ -508,96 +1074,96 @@
               }
             },
             "baseOrgObject":{
-                "description": "A barebones Organization object to work around recursion issues in DDE",
-                "@type": "Organization",
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "description": "name of the organization",
-                    "type": "string"
-                  },
-                  "alternateName": {
-                    "description": "Alternate name or Acronym for the organization.",
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "name"
-                ]              
-              }, 
+            "description": "A barebones Organization object to work around recursion issues in DDE",
+            "@type": "outbreak:Organization",
+            "type": "object",
+            "properties": {
+              "name": {
+                "description": "name of the organization",
+                "type": "string"
+              },
+              "alternateName": {
+                "description": "Alternate name or Acronym for the organization.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ]              
+          }, 
             "person": {
-                  "description": "Reusable person definition",
-                  "@type": "Person",
-                  "type": "object",
-                  "properties": {
-                    "name": {
-                      "type": "string"
-                    },
-                    "givenName": {
-                      "type": "string"
-                    },
-                    "familyName": {
-                      "type": "string"
-                    },
-                    "orcid": {
-                      "type": "string"
-                    },
-                    "affiliation": {
-                      "oneOf": [
-                        {
-                          "$ref": "#/definitions/baseOrgObject"
-                        },
-                        {
-                          "type": "array",
-                          "items": {
-                            "$ref": "#/definitions/baseOrgObject"
-                          }
-                        }
-                      ]
-                    }
-                  },
-                  "required": [
-                    "name"
-                  ]
+              "description": "Reusable person definition",
+              "@type": "outbreak:Person",
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
                 },
+                "givenName": {
+                  "type": "string"
+                },
+                "familyName": {
+                  "type": "string"
+                },
+                "orcid": {
+                  "type": "string"
+                },
+                "affiliation": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/definitions/baseOrgObject"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/baseOrgObject"
+                      }
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "name"
+              ]
+            },
             "memberObject": {
-                  "description": "Reusable person definition accounting for recursion issues in DDE",
-                  "@type": "Person",
-                  "type": "object",
-                  "properties": {
-                    "name": {
-                      "type": "string"
-                    },
-                    "givenName": {
-                      "type": "string"
-                    },
-                    "familyName": {
-                      "type": "string"
-                    },
-                    "orcid": {
-                      "type": "string"
-                    },
-                    "affiliation": {
-                      "oneOf": [
-                        {
-                          "$ref": "#/definitions/baseOrgObject"
-                        },
-                        {
-                          "type": "array",
-                          "items": {
-                            "$ref": "#/definitions/baseOrgObject"
-                          }
-                        }
-                      ]
-                    }
-                  },
-                  "required": [
-                    "name"
-                  ]
+              "description": "Reusable person definition accounting for recursion issues in DDE",
+              "@type": "outbreak:Person",
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
                 },
+                "givenName": {
+                  "type": "string"
+                },
+                "familyName": {
+                  "type": "string"
+                },
+                "orcid": {
+                  "type": "string"
+                },
+                "affiliation": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/definitions/baseOrgObject"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/baseOrgObject"
+                      }
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "name"
+              ]
+            },
             "organization": {
                 "description": "Reusable organization definition",
-                "@type": "Organization",
+                "@type": "outbreak:Organization",
                 "type": "object",
                 "properties": {
                   "name": {
@@ -609,46 +1175,83 @@
                   "affiliation": {
                     "$ref": "#/definitions/baseOrgObject"
                   },
-                  "members": {
-                     "oneOf": [
-                        {
-                          "$ref": "#/definitions/memberObject"
-                        },
-                        {
-                          "type": "array",
-                          "items": {
-                            "$ref": "#/definitions/memberObject"
-                          }
-                        }
-                      ]
-                  }
-                },
-                "required": [
-                  "name"
-                ]
+              "members": {
+                 "oneOf": [
+                    {
+                      "$ref": "#/definitions/memberObject"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/memberObject"
+                      }
+                    }
+                  ]
+              }
+            },
+            "required": [
+              "name"
+            ]
+          },
+            "funding": {
+            "type": "object",
+            "@type": "outbreak:MonetaryGrant",
+            "description": "Information about funding support",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "The name of the monetary grant that funded/funds the analysis"
               },
+              "identifier": {
+                "type": "string",
+                "description": "Unique identifier(s) for the grant(s) used to fund the analysis"
+              },
+              "funder": {
+                "description": "name of the funding organization",
+                "oneOf": [
+              {
+                "$ref": "#/definitions/baseOrgObject"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/baseOrgObject"
+                }
+              }
+            ]
+              },
+              "url": {
+                "type": "string",
+                "format": "uri",
+                "description": "award URL"
+              }
+            },
+            "required": [
+              "funder"
+            ]
+          },
             "citation": {
-                "description": "A citation object for a resource which is cited by the Analysis (ie- is a derivative of the Analysis) , related to the Analysis, or from which the Analysis was based on (ie- is derived from).",
-                "@type": "Thing",
+                "description": "A citation object for a resource which is cited by the analysis (ie- is a derivative of the publication) , related to the analysis, or from which the analysis was based on (ie- is derived from).",
+                "@type": "outbreak:CitationObject",
                 "type": "object",
                 "properties": {
-                  "name": {
+                "name": {
                     "description": "Name of or title of the citation",
                     "type": "string"
-                  },
-                  "identifier": {
+                },
+                "identifier": {
                     "description": "An identifier associated with the citation",
                     "type": "string"
-                  },
-                  "pmid": {
+                },
+                "pmid": {
                     "description": "A pubmed identifier if available",
                     "type": "string"
-                  },
-                  "doi": {
+                },
+                "doi": {
                     "description": "A doi if available",
                     "type": "string"
-                  },
-                  "type": {
+                },
+                "sourceType": {
                     "description": "The type of resource",
                     "enum": [
                       "Dataset",
@@ -657,124 +1260,1526 @@
                       "Analysis",
                       "Protocol", 
                       "SoftwareApplication",
-                      "Other"
+                      "CreativeWork"
                       ]
-                  },
-                  "url": {
-                    "description": "The url of the resource cited.",
+                },
+              "url": {
+                "description": "The url of the resource cited.",
+                "type": "string",
+                "format": "uri"
+              },
+              "versionDate": {
+                "description": "The version date of the resource used at the time of the creation of the citation as certain resources (protocols, datasets) may change frequently over time.",
+                "type": "string",
+                "format": "date"
+              },
+              "citeText": {
+                "description": "The bibliographic citation for the referenced resource as is provided",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "sourceType"
+            ]
+          },
+            "reviewObject": {
+              "description": "A review or descriptive evaluation of the resource",
+              "@type": "Review",
+              "type": "object",
+              "properties": {
+                "name": {
                     "type": "string",
-                    "format": "uri"
+                    "description": "The name of the review"
+                },
+                "reviewAspect":{
+                    "description": "This Review or Rating is relevant to this part or facet of the itemReviewed",
+                    "type": "string"
+                },
+                "reviewBody": {
+                      "description": "The actual body of the review.",
+                      "type": "string"
+                },
+                "reviewRating": {
+                  "description": "The rating given in this review",
+                    "$ref": "#/definitions/ratingObject"      
                   },
-                  "versionDate": {
-                    "description": "The version date of the resource used at the time of the creation of the citation as certain resources (protocols, datasets) may change frequently over time.",
+                "author": {
+                    "description": "The author of this content or rating.",
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/person"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/person"
+                      }
+                      },
+                      {
+                        "$ref": "#/definitions/organization"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/organization"
+                      }
+                }
+              ]
+            },
+                "curationDate":{
+                    "description": "The date this evaluation was added into outbreak.info, or was updated in outbreak.info.",
                     "type": "string",
                     "format": "date"
-                  },
-                  "citeText": {
-                    "description": "The bibliographic citation for the referenced resource as is provided",
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "name",
-                  "type"
-                ]
-          },
-            "funding": {
+                }
+              },
+              "required": [
+              ]
+            },
+            "ratingObject": {
+                "description": "A rating or categorical evaluation of the resource",
+                "@type": "Rating",
                 "type": "object",
-                "@type": "MonetaryGrant",
-                "description": "Information about funding support",
                 "properties": {
                   "name": {
                     "type": "string",
-                    "description": "The name of the monetary grant that funded/funds the analysis"
+                    "description": "The name of the rating"
                   },
-                  "identifier": {
+                  "ratingExplanation": {
                     "type": "string",
-                    "description": "Unique identifier(s) for the grant(s) used to fund the analysis"
+                    "description": "An explanation of the rating"    
                   },
-                  "funder": {
-                    "description": "name of the funding organization",
-                    "oneOf": [
-                  {
-                    "$ref": "#/definitions/baseOrgObject"
-                  },
-                  {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/definitions/baseOrgObject"
-                    }
-                  }
-                ]
-                  },
-                  "url": {
+                  "ratingValue": {
                     "type": "string",
-                    "format": "uri",
-                    "description": "award URL"
+                    "description": "The rating for the content."
+                  },
+                  "reviewAspect": {
+                    "type": "string",
+                    "description": "This Review or Rating is relevant to this part or facet of the itemReviewed"
+                  },
+                  "author": {
+                    "description": "The author of this content or rating.",
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/person"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/person"
+                      }
+                      },
+                      {
+                        "$ref": "#/definitions/organization"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/organization"
+                      }
+                }
+              ]
+            },
+                  "curationDate":{
+                    "description": "The date this evaluation was added into outbreak.info, or was updated in outbreak.info.",
+                    "type": "string",
+                    "format": "date"
                   }
                 },
                 "required": [
-                  "funder"
                 ]
+            },
+            "aggregateRatingObject": {
+              "description": "A cumulative evaluation of the resource",
+              "@type": "AggregateRating",
+              "type": "object",
+              "properties": {
+                "name": {
+                "type": "string",
+                "description": "The name of the aggregate rating"
+                },
+                "ratingValue": {
+                    "type": "string",
+                    "description": "The rating for the content."
+                },
+                "reviewAspect":{
+                  "description": "This Review or Rating is relevant to this part or facet of the itemReviewed",
+                  "type": "string"
+                },
+                "author": {
+                    "description": "The author of this content or rating.",
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/person"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/person"
+                      }
+                      },
+                      {
+                        "$ref": "#/definitions/organization"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/organization"
+                      }
+                }
+              ]
+            },
+                "curationDate": {
+                    "description": "The date this evaluation was added into outbreak.info, or was updated in outbreak.info.",
+                    "type": "string",
+                    "format": "date"
+                  },
+                "reviews": {
+                  "anyOf": [
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/reviewObject"
+                        }
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/ratingObject"
+                        }
+                      }
+                      
+                  ]
+                }
+                },
+            "required": [
+            ]
           }
+            }
           }
+        },
+    {
+      "@id": "outbreak:domainUrl",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The domain name or main site on which webpage or specific url can be found",
+      "rdfs:label": "domainUrl",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Analysis"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:URL"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:assumption",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Statement of assumptions / limitations of the model",
+      "rdfs:label": "assumption",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Analysis"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:analysisTechnique",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "A technique or technology used in a analysis",
+      "rdfs:label": "analysisTechnique",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Analysis"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:analysisTopic",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The underlying question, goal, or aim of the analysis",
+      "rdfs:label": "analysisTopic",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Analysis"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:Product",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing a reagent, material, sample, or some other product used in a protocol resource in outbreak.info",
+      "rdfs:label": "Product",
+      "rdfs:subClassOf": {
+        "@id": "schema:Product"
       }
     },
-    {"@id":"outbreak:url","@type":"rdf:Property","rdfs:comment":"The url of the item","rdfs:label":"url","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:url"},"schema:domainIncludes":{"@id":"outbreak:Analysis"},"schema:rangeIncludes":{"@id":"schema:URL"}},{"@id":"outbreak:domainUrl","@type":"rdf:Property","rdfs:comment":"The domain name or main site on which webpage or specific url can be found","rdfs:label":"domainUrl","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:url"},"schema:domainIncludes":{"@id":"outbreak:Analysis"},"schema:rangeIncludes":{"@id":"schema:URL"}},{"@id":"outbreak:identifier","@type":"rdf:Property","rdfs:comment":"An identifier associated with the analysis if available, otherwise one should be assigned","rdfs:label":"identifier","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":{"@id":"outbreak:Analysis"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:doi","@type":"rdf:Property","rdfs:comment":"A DOI associated with the analysis if available","rdfs:label":"doi","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":{"@id":"outbreak:Analysis"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"The name of the item.","rdfs:label":"name","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":{"@id":"outbreak:Analysis"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:description","@type":"rdf:Property","rdfs:comment":"A description of the item.","rdfs:label":"description","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:description"},"schema:domainIncludes":{"@id":"outbreak:Analysis"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:author","@type":"rdf:Property","rdfs:comment":"The author of this content or rating.","rdfs:label":"author","owl:cardinality":"many","marginality":"required","rdfs:sameAs":{"@id":"schema:author"},"schema:domainIncludes":{"@id":"outbreak:Analysis"},"schema:rangeIncludes":[{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"}]},{"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"The name of the author as provided by the resource","rdfs:label":"name","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":[{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:affiliation","@type":"rdf:Property","rdfs:comment":"The affiliation of the author","rdfs:label":"affiliation","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:affiliation"},"schema:domainIncludes":[{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"}],"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:funding","@type":"rdf:Property","rdfs:comment":"Funding for the generation of the analysis","rdfs:label":"funding","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"outbreak:MonetaryGrant"},"schema:domainIncludes":{"@id":"outbreak:Analysis"},"schema:rangeIncludes":{"@id":"outbreak:MonetaryGrant"}},{"@id":"outbreak:funder","@type":"rdf:Property","rdfs:comment":"The funder of the analysis","rdfs:label":"funder","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:funder"},"schema:domainIncludes":{"@id":"outbreak:MonetaryGrant"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:identifier","@type":"rdf:Property","rdfs:comment":"The identifier of the grant (if available)","rdfs:label":"identifier","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":{"@id":"outbreak:MonetaryGrant"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:hasDownloadableContent","@type":"rdf:Property","rdfs:comment":"Indicates the site has content that can be downloaded (raw data, data sheets, charts, etc)","rdfs:label":"hasDownloadableContent","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:isAccessibleForFree"},"schema:domainIncludes":{"@id":"outbreak:Analysis"},"schema:rangeIncludes":{"@id":"schema:Boolean"}},{"@id":"outbreak:infectiousAgent","@type":"rdf:Property","rdfs:comment":"The actual infectious agent, such as a specific bacterium","rdfs:label":"infectiousAgent","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:infectiousAgent"},"schema:domainIncludes":{"@id":"outbreak:Analysis"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:infectiousDisease","@type":"rdf:Property","rdfs:comment":"The disease caused by the infectious agent. Important as some agents may cause multiple diseases","rdfs:label":"infectiousDisease","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:infectousDisease"},"schema:domainIncludes":{"@id":"outbreak:Analysis"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:license","@type":"rdf:Property","rdfs:comment":"A license document that applies to this content, typically indicated by URL","rdfs:label":"license","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:license"},"schema:domainIncludes":{"@id":"outbreak:Analysis"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:datePublished","@type":"rdf:Property","rdfs:comment":"PublicationDate of the analysis online if available","rdfs:label":"datePublished","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:datePublished"},"schema:domainIncludes":{"@id":"outbreak:Analysis"},"schema:rangeIncludes":{"@id":"schema:Date"}},{"@id":"outbreak:dateModified","@type":"rdf:Property","rdfs:comment":"Most recent date for which the analysis model itself was updated","rdfs:label":"dateModified","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:dateModified"},"schema:domainIncludes":{"@id":"outbreak:Analysis"},"schema:rangeIncludes":{"@id":"schema:Date"}},{"@id":"outbreak:analysisTechnique","@type":"rdf:Property","rdfs:comment":"This is the analysis type, analytical technique or mathematical model used in this analysis","rdfs:label":"analysisTechnique","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":{"@id":"outbreak:Analysis"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:analysisTopic","@type":"rdf:Property","rdfs:comment":"The underlying question, goal, or aim of the analysis","rdfs:label":"analysisTopic","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:purpose"},"schema:domainIncludes":{"@id":"outbreak:Analysis"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:assumption","@type":"rdf:Property","rdfs:comment":"Statement of assumptions \/ limitations of the model","rdfs:label":"assumption","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:text"},"schema:domainIncludes":{"@id":"outbreak:Analysis"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:citedBy","@type":"rdf:Property","rdfs:comment":"A resource (publication, protocol, dataset, etc.) which was derived from this protocol","rdfs:label":"citedBy","owl:cardinality":"many","marginality":"optional","owl:inverseOf":{"@id":"schema:isBasedOn"},"schema:domainIncludes":{"@id":"outbreak:Analysis"},"schema:rangeIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}]},{"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"name of the citedBy resource","rdfs:label":"name","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:type","@type":"rdf:Property","rdfs:comment":"type (publication, protocol, dataset, code, etc.) of the citedBy resource","rdfs:label":"type","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:additionalType"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:identifier","@type":"rdf:Property","rdfs:comment":"identifier (pmid, WHO protocol id, etc.) of the citedby resource","rdfs:label":"identifier","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:isBasedOn","@type":"rdf:Property","rdfs:comment":"A resource (publication, protocol, dataset, etc) from which this analysis was derived","rdfs:label":"isBasedOn","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:isBasedOn"},"schema:domainIncludes":{"@id":"outbreak:Analysis"},"schema:rangeIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}]},
-    {"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"name of the isBasedOn resource","rdfs:label":"name","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:type","@type":"rdf:Property","rdfs:comment":"type (publication, protocol, dataset, code, etc.) of the isBasedOn resource","rdfs:label":"type","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:additionalType"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:identifier","@type":"rdf:Property","rdfs:comment":"identifier (pmid, WHO protocol id, etc.) of the isBasedOn resource","rdfs:label":"identifier","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:versionDate","@type":"rdf:Property","rdfs:comment":"date of the version of the resource from which this analysis was derived. Note this is NOT the same as dateModified, as the protocol may be based on an earlier 'dateModified' than is what is available from the resource","rdfs:label":"versionDate","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:releaseDate"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Date"}},{"@id":"outbreak:isRelatedTo","@type":"rdf:Property","rdfs:comment":"Other resources related to, but not a derivative of nor derived from this analysis","rdfs:label":"isRelatedTo","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:isRelatedTo"},"schema:domainIncludes":{"@id":"outbreak:Analysis"},"schema:rangeIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}]},{"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"name of related resource","rdfs:label":"name","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:type","@type":"rdf:Property","rdfs:comment":"type of related resource","rdfs:label":"type","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:additionalType"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:identifier","@type":"rdf:Property","rdfs:comment":"identifier (if available) of related resource","rdfs:label":"identifier","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:contributor","@type":"rdf:Property","rdfs:comment":"A secondary contributor to the CreativeWork or Event.","rdfs:label":"contributor","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:contributor"},"schema:domainIncludes":{"@id":"outbreak:Analysis"},"schema:rangeIncludes":{"@id":"outbreak:author"}},{"@id":"outbreak:maintainer","@type":"rdf:Property","rdfs:comment":"A maintainer of a Dataset, software package (SoftwareApplication), or other Project.","rdfs:label":"maintainer","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:maintainer"},"schema:domainIncludes":{"@id":"outbreak:Analysis"},"schema:rangeIncludes":{"@id":"outbreak:author"}},{"@id":"outbreak:keywords","@type":"rdf:Property","rdfs:comment":"keywords","rdfs:label":"keywords","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:keywords"},"schema:domainIncludes":{"@id":"outbreak:Analysis"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:topicCategory","@type":"rdf:Property","rdfs:comment":"Applicable outbreak.info category","rdfs:label":"topicCategory","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:about"},"schema:domainIncludes":{"@id":"outbreak:Analysis"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:curatedBy","@type":"rdf:Property","rdfs:comment":"The source from which this analysis was identified for inclusion into Outbreak.info. Provides provenance for a resource which was curated by another","rdfs:label":"curatedBy","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:citation"},"schema:domainIncludes":{"@id":"outbreak:Analysis"},"schema:rangeIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"},{"@id":"schema:Thing"}]},
-    {"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"name of the source from which this analysis was identified for inclusion","rdfs:label":"name","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:curationDate","@type":"rdf:Property","rdfs:comment":"The date this resource was added to outbreak.info, or the date when this resource was updated in outbreak.info","rdfs:label":"curationDate","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:releaseDate"},"schema:domainIncludes":{"@id":"outbreak:Analysis"},"schema:rangeIncludes":{"@id":"schema:Date"}},
     {
-      "@id": "outbreak:Dataset",
+      "@id": "outbreak:Instrument",
       "@type": "rdfs:Class",
-      "rdfs:label": "Dataset",
-      "rdfs:comment": "This is the schema for describing the Dataset schema used for outbreak.info.",
+      "rdfs:comment": "This is the schema for describing an instrument used in a protocol resource listed in outbreak.info",
+      "rdfs:label": "Instrument",
       "rdfs:subClassOf": {
-        "@id": "schema:Dataset"
-      },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
+        "@id": "schema:Product"
       }
     },
     {
       "@id": "outbreak:Protocol",
       "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing the Protocols for outbreak.info Resources.",
       "rdfs:label": "Protocol",
-      "rdfs:comment": "This is the schema for describing the Protocol schema used for outbreak.info.",
       "rdfs:subClassOf": {
         "@id": "schema:HowTo"
-      },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
       }
     },
     {
-      "@id": "outbreak:Publication",
+      "@id": "outbreak:warning",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Precautions, warnings, and/or safety warnings associated with or highlighted by the protocol",
+      "rdfs:label": "warning",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Protocol"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:correctionNote",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "statement of what was updated/changed since prior version",
+      "rdfs:label": "correctionNote",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Protocol"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:protocolStatus",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The status of the protocol",
+      "rdfs:label": "protocolStatus",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Protocol"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:instrument",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "A laboratory equipment use by a person to follow one or more steps described in this Protocol",
+      "rdfs:label": "instrument",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Protocol"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "outbreak:Instrument"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:protocolSetting",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The type of 'protocol' based on setting in which it would apply",
+      "rdfs:label": "protocolSetting",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Protocol"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:protocolCategory",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The type of 'protocol' based on degree of specificity and purpose",
+      "rdfs:label": "protocolCategory",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Protocol"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:usedToGenerate",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Type of evidence/data generated by the protocol",
+      "rdfs:label": "usedToGenerate",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Protocol"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:inComplianceWith",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Guidelines or Standards to which these protocols adhere. ie- GMP, GCP, other EQUATOR guidelines. Useful for selecting protocols where certain standards/guidelines must be met",
+      "rdfs:label": "inComplianceWith",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Protocol"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    }, 
+    {
+      "@id": "outbreak:StudyEvent",
       "@type": "rdfs:Class",
-      "rdfs:label": "Publication",
-      "rdfs:comment": "This is the schema for describing the Publication schema used for outbreak.info.",
+      "rdfs:comment": "This is the schema for describing StudyEvents, a class that describes categorical events in Clinical Trials added to outbreak.info",
+      "rdfs:label": "StudyEvent",
       "rdfs:subClassOf": {
-        "@id": "schema:ScholarlyArticle"
-      },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
+        "@id": "schema:Thing"
       }
     },
     {
+      "@id": "outbreak:studyEventType",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Type of the event status such as StudyStart, PrimaryCompletion, Completion, StudyFirstSubmit, StudyFirstSubmitQC, LastUpdateSubmit",
+      "rdfs:label": "studyEventType",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyEvent"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:studyEventDate",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The corresponding/actual date of the study event (ie- the StartDate, Primary CompletionDate, CompletionDate, StudyFirstSubmitDate, StudyFirstSubmitQCDate, LastUpdateSubmitDate)",
+      "rdfs:label": "studyEventDate",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyEvent"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Date"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:studyEventDateType",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "the type of date provided (actual, anticipated, or estimated)",
+      "rdfs:label": "studyEventDateType",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyEvent"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },  
+    {
+      "@id": "outbreak:StudyStatus",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing the status of a ClinicalTrial resource in outbreak.info",
+      "rdfs:label": "StudyStatus",
+      "rdfs:subClassOf": {
+        "@id": "schema:Thing"
+      }
+    },
+    {
+      "@id": "outbreak:status",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The recruitment status of the study",
+      "rdfs:label": "status",
+      "rdfs:sameAs":{"@id":"schema:status"},
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyStatus"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:statusExpandedAccess",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Flag for whether or not the study has expanded Access status",
+      "rdfs:label": "statusExpandedAccess",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyStatus"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Boolean"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:statusDate",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The date that the status was verified. Equivalent to NCT's StatusVerifiedDate",
+      "rdfs:label": "statusDate",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyStatus"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Date"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:enrollmentCount",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The number of participants enrolled in the study",
+      "rdfs:label": "enrollmentCount",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyStatus"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Number"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:enrollmentType",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The type of estimation used to determine the enrollmentCount (actual counts, target size, etc.)",
+      "rdfs:label": "enrollmentType",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyStatus"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:whyStopped",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "A brief explanation of the reason(s) why such clinical study was stopped (for a clinical study that is Suspended, Terminated, or Withdrawn prior to its planned completion as anticipated by the protocol)",
+      "rdfs:label": "whyStopped",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyStatus"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:StudyDesign",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing the study design of a clinical trial/study for inclusion into outbreak.info resources",
+      "rdfs:label": "StudyDesign",
+      "rdfs:subClassOf": {
+        "@id": "schema:Thing"
+      }
+    },
+    {
+      "@id": "outbreak:studyType",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Type of human study, can be subtypes of observational study or interventional studies and may include the temporal relationship of observation period to time of participant enrollment.",
+      "rdfs:label": "studyType",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyDesign"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:phase",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Stage or phase of the study in the U.S. if applicable",
+      "rdfs:label": "phase",
+      "rdfs:sameAs":{"@id":"schema:phase"},
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyDesign"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:phaseNumber",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The number of the phase or stage of the study",
+      "rdfs:label": "phaseNumber",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyDesign"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Number"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:designAllocation",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The method by which the study participants were allocated into groups",
+      "rdfs:label": "designAllocation",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyDesign"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:designModel",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The general design of the strategy for assigning interventions to participants in a clinical intervention study OR the general design of the strategy for identifying and following up with participants during an observational study",
+      "rdfs:label": "designModel",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyDesign"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:designPrimaryPurpose",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The primary purpose of the study",
+      "rdfs:label": "designPrimaryPurpose",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyDesign"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:designWhoMasked",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The people who do not know which participants have been assigned to which interventions",
+      "rdfs:label": "designWhoMasked",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyDesign"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:designStudyText",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "String description of the study design if structured information not available",
+      "rdfs:label": "designStudyText",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyDesign"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:Intervention",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "a schema to describe Interventions discussed in Clinical Studies/Trials for inclusion in outbreak.info Resources",
+      "rdfs:label": "Intervention",
+      "rdfs:subClassOf": {
+        "@id": "schema:Thing"
+      }
+    },
+    {
+      "@id": "outbreak:category",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The category of an intervention in the study",
+      "rdfs:label": "category",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Intervention"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:ArmGroup",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing arm groups in clinical studies/trials for inclusion in outbreak.info Resources",
+      "rdfs:label": "ArmGroup",
+      "rdfs:subClassOf": {
+        "@id": "schema:Thing"
+      }
+    },
+    {
+      "@id": "outbreak:intervention",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The interventions (if any) in this ArmGroup",
+      "rdfs:label": "intervention",
+      "schema:domainIncludes": {
+        "@id": "outbreak:ArmGroup"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "outbreak:Intervention"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:Outcome",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing a Clinical Trial/Study Outcome for inclusion in  outbreak.info Resources",
+      "rdfs:label": "Outcome",
+      "rdfs:subClassOf": {
+        "@id": "schema:Thing"
+      }
+    },
+    {
+      "@id": "outbreak:outcomeMeasure",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The outcome measure for the study",
+      "rdfs:label": "outcomeMeasure",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Outcome"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:outcomeTimeFrame",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The specific time point(s) and overall duration of evaluation must be specified in this section",
+      "rdfs:label": "outcomeTimeFrame",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Outcome"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Duration"
+        },
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:outcomeType",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The classification of the outcome measure as either primary, secondary, or exploratory",
+      "rdfs:label": "outcomeType",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Outcome"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:Eligibility",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing information about Clinical Trials/Studies eligibility criteria for inclusion in outbreak.info Resources",
+      "rdfs:label": "Eligibility",
+      "rdfs:subClassOf": {
+        "@id": "schema:Thing"
+      }
+    },
+    {
+      "@id": "outbreak:inclusionCriteria",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "\"criteria for inclusion in the study",
+      "rdfs:label": "inclusionCriteria",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Eligibility"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:minimumAge",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "the minimum age for a participant to be included in the study",
+      "rdfs:label": "minimumAge",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Eligibility"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:maximumAge",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "the maximum age for a participant to be included in the study",
+      "rdfs:label": "maximumAge",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Eligibility"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:gender",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "the sex requirement to be included in the study",
+      "rdfs:label": "gender",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Eligibility"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:genderBased",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Boolean for whether or not participation is based on gender",
+      "rdfs:label": "genderBased",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Eligibility"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Boolean"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:healthyVolunteers",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Boolean to indicate whether or not healthy volunteers may be included in the study",
+      "rdfs:label": "healthyVolunteers",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Eligibility"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Boolean"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:stdAge",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "the age category of a participant to be included in the study if a minimum and maximum age is not specified",
+      "rdfs:label": "stdAge",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Eligibility"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:exclusionCriteria",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "criteria for exclusion from the study",
+      "rdfs:label": "exclusionCriteria",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Eligibility"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:criteriaText",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The descriptive criteria as published for the Clinical Trial",
+      "rdfs:label": "criteriaText",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Eligibility"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:StudyLocation",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing Clinical Trial/Study locations for inclusion in outbreak.info Resources",
+      "rdfs:label": "StudyLocation",
+      "rdfs:subClassOf": {
+        "@id": "schema:Place"
+      }
+    },
+    {
+      "@id": "outbreak:studyLocation",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The location of the study",
+      "rdfs:label": "studyLocation",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyLocation"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Place"
+        },
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:studyLocationCity",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The city in which the facility used for the study is located",
+      "rdfs:label": "studyLocationCity",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyLocation"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:City"
+        },
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:studyLocationState",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The state or province in which the facility used for the study is located",
+      "rdfs:label": "studyLocationState",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyLocation"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:State"
+        },
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:studyLocationCountry",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The country in which the facility used for the study is located",
+      "rdfs:label": "studyLocationCountry",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyLocation"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Country"
+        },
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:studyLocationStatus",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The recruitment status of the study at the specific study site",
+      "rdfs:label": "studyLocationStatus",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyLocation"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+{
       "@id": "outbreak:ClinicalTrial",
       "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing the Clinical Trials and other medical studies used for outbreak.info Resources",
       "rdfs:label": "ClinicalTrial",
-      "rdfs:comment": "This is the schema for describing the ClinicalTrial schema used for outbreak.info.",
       "rdfs:subClassOf": {
         "@id": "schema:MedicalStudy"
-      },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
       }
+    },
+    {
+      "@id": "outbreak:identifierSource",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Source of identifier assignment or type of identifier (NCTid, China CTRid, EudraCT Number, etc.)",
+      "rdfs:label": "identifierSource",
+      "schema:domainIncludes": {
+        "@id": "outbreak:ClinicalTrial"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:dateModifiedType",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The type of date. Equivalent to NCT's LastUpdatePostDateType",
+      "rdfs:label": "dateModifiedType",
+      "schema:domainIncludes": {
+        "@id": "outbreak:ClinicalTrial"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:healthConditionIdentifier",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Ontological or controlled vocabulary identifier for the health condition or disease",
+      "rdfs:label": "healthConditionIdentifier",
+      "schema:domainIncludes": {
+        "@id": "outbreak:ClinicalTrial"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        },
+        {
+          "@id": "schema:DefinedTerm"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:hasResults",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Boolean for if the clinical trial has published any results",
+      "rdfs:label": "hasResults",
+      "schema:domainIncludes": {
+        "@id": "outbreak:ClinicalTrial"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Boolean"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:studyEvent",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "an event status such as StudyStart, PrimaryCompletion, Completion, StudyFirstSubmit, StudyFirstSubmitQC, LastUpdateSubmit",
+      "rdfs:label": "studyEvent",
+      "schema:domainIncludes": {
+        "@id": "outbreak:ClinicalTrial"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "outbreak:StudyEvent"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:studyStatus",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The status of the study",
+      "rdfs:label": "studyStatus",
+      "schema:domainIncludes": {
+        "@id": "outbreak:ClinicalTrial"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "outbreak:StudyStatus"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:studyDesign",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The general design of the study",
+      "rdfs:label": "studyDesign",
+      "schema:domainIncludes": {
+        "@id": "outbreak:ClinicalTrial"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "outbreak:StudyDesign"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:armGroup",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The arm or factor of an interventional study",
+      "rdfs:label": "armGroup",
+      "schema:domainIncludes": {
+        "@id": "outbreak:ClinicalTrial"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "outbreak:ArmGroup"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:outcome",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The arm or factor of an interventional study",
+      "rdfs:label": "outcome",
+      "schema:domainIncludes": {
+        "@id": "outbreak:ClinicalTrial"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "outbreak:Outcome"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:eligibilityCriteria",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "eligibility criteria",
+      "rdfs:label": "eligibilityCriteria",
+      "schema:domainIncludes": {
+        "@id": "outbreak:ClinicalTrial"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "outbreak:Eligibility"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:author",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The author of this resource, content, or rating",
+      "rdfs:label": "author",
+      "rdfs:sameAs": {"@id":"schema:author"},
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "outbreak:Person"
+        },
+        {
+          "@id": "outbreak:Organization"
+        }  
+      ]
+    },
+    {
+      "@id": "outbreak:dateCreated",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Date the record was created",
+      "rdfs:label": "dateCreated",
+      "rdfs:sameAs": {"@id":"schema:dateCreated"},
+      "schema:domainIncludes": [
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Date"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:datePublished",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Date of first broadcast/publication",
+      "rdfs:label": "datePublished",
+      "rdfs:sameAs": {"@id":"schema:datePublished"},
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Date"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:dateModified",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The date on which the CreativeWork was most recently modified or when the item's entry was modified within a DataFeed",
+      "rdfs:label": "dateModified",
+      "rdfs:sameAs": {"@id":"schema:dateModified"},
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Date"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:keywords",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "keywords for describing the record",
+      "rdfs:label": "keywords",
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:abstract",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "A short descriptive summary of the publication or study",
+      "rdfs:label": "abstract",
+      "rdfs:sameAs": {"@id":"schema:abstract"},
+      "schema:domainIncludes": [
+          {"@id": "outbreak:Publication"},
+          {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:pmid",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "A pubmed identifier if available",
+      "rdfs:label": "pmid",
+      "schema:domainIncludes": [
+          {"@id": "outbreak:CitationObject"},
+          {"@id": "outbreak:Correction"},
+          {"@id": "outbreak:Publication"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Integer"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:doi",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "A doi if available",
+      "rdfs:label": "doi",
+      "schema:domainIncludes": [
+          {"@id": "outbreak:CitationObject"},
+          {"@id": "outbreak:Correction"},
+          {"@id": "outbreak:Dataset"},
+          {"@id": "outbreak:Publication"},
+          {"@id": "outbreak:Analysis"},
+          {"@id": "outbreak:Protocol"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:funding",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Funding that supports (sponsors) the collection of this dataset through some kind of financial contribution",
+      "rdfs:label": "funding",
+      "schema:domainIncludes": [
+          {"@id": "outbreak:Dataset"},
+          {"@id": "outbreak:Publication"},
+          {"@id": "outbreak:Analysis"},
+          {"@id": "outbreak:Protocol"},
+          {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:MonetaryGrant"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:measurementTechnique",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "A technique or technology used in this resource",
+      "rdfs:label": "measurementTechnique",
+      "rdfs:sameAs": {"@id":"schema:measurementTechnique"},
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Protocol"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        },
+        {
+          "@id": "schema:DefinedTerm"
+        }  
+      ]
+    },
+    {
+      "@id": "outbreak:species",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Species(es) from which dataset has been collected",
+      "rdfs:label": "species",
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Analysis"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        },
+        {
+          "@id": "schema:DefinedTerm"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:infectiousAgent",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "infectious agents(s) which are the focus of the dataset",
+      "rdfs:label": "infectiousAgent",
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Analysis"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        },
+        {
+          "@id": "schema:DefinedTerm"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:infectiousDisease",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The disease or medical conditions caused by the infectious agent. Important as some agents may cause multiple diseases",
+      "rdfs:label": "infectiousDisease",
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Analysis"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        },
+        {
+          "@id": "schema:DefinedTerm"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:topicCategory",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Applicable outbreak.info category",
+      "rdfs:label": "topicCategory",
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+
+    {
+      "@id": "outbreak:isBasedOn",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "A citation to a resource (eg- publication, protocol, etc.) on which this resource was derived (stored as an object, not a string)",
+      "rdfs:label": "isBasedOn",
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {"@id": "outbreak:CitationObject"},
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:ClinicalTrial"},
+        {"@id": "schema:SoftwareApplication"},
+        {"@id": "schema:CreativeWork"}
+      ]
+    },
+    {
+      "@id": "outbreak:isRelatedTo",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "A citation to a resource (eg- publication, protocol, etc.) which is related to the resource but is not a derivative nor was derived from the resource (stored as an object, not a string)",
+      "rdfs:label": "isRelatedTo",
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {"@id": "outbreak:CitationObject"},
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:ClinicalTrial"},
+        {"@id": "schema:SoftwareApplication"},
+        {"@id": "schema:CreativeWork"}
+      ]
+    },
+    {
+      "@id": "outbreak:citedBy",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "A citation to a resource (eg- publication, protocol, etc.) which is derived from this resource (stored as an object, not a string)",
+      "rdfs:label": "citedBy",
+      "rdfs:sameAs":{"@id":"owl:inverseOf: outbreak:isBasedOn"},
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {"@id": "outbreak:CitationObject"},
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:ClinicalTrial"},
+        {"@id": "schema:SoftwareApplication"},
+        {"@id": "schema:CreativeWork"}
+      ]
+    },
+    {
+      "@id": "outbreak:curatedBy",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The source from which this Dataset was identified for inclusion into Outbreak.info. Provides provenance for a resource which was curated by another.",
+      "rdfs:label": "curatedBy",
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {"@id": "outbreak:Person"},
+        {"@id": "outbreak:Organization"},
+        {"@id": "outbreak:CitationObject"},
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:ClinicalTrial"},
+        {"@id": "schema:SoftwareApplication"},
+        {"@id": "schema:CreativeWork"}
+      ]
+    },
+    {
+      "@id": "outbreak:curationDate",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
+      "rdfs:label": "curationDate",
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {"@id": "schema:Date"}
+      ]
+    },
+    {
+      "@id": "outbreak:evaluations",
+      "@type": "rdf:Property",
+      "rdfs:comment":"One or more reviews, ratings, or other evaluations of this resource",
+      "rdfs:label": "evaluations",
+      "schema:domainIncludes":[
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes":[
+        {"@id": "schema:Review"},
+        {"@id": "schema:Rating"},
+        {"@id": "schema:AggregateRating"}
+      ]
     }
   ]
 }

--- a/yaml/outbreak_Analysis.yml
+++ b/yaml/outbreak_Analysis.yml
@@ -1,487 +1,103 @@
 '@context':
-  outbreak: https://discovery.biothings.io/view/outbreak/
-  owl: http://www.w3.org/2002/07/owl/
-  rdf: http://www.w3.org/1999/02/22/-rdf-syntax-ns/
-  rdfs: http://www.w3.org/2000/01/rdf/-schema/
+  outbreak: http://discovery.biothings.io/view/
+  rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
+  rdfs: http://www.w3.org/2000/01/rdf-schema#
   schema: http://schema.org/
 '@graph':
-- '@id': outbreak:Organization
-  '@type': rdfs:Class
-  rdfs:comment: This is the schema for describing the Organization schema used for
-    outbreak.info.
-  rdfs:label: Organization
-  rdfs:subClassOf:
-    '@id': schema:Organization
-  schema:isPartOf:
-    '@id': https://discovery.biothings.io/view/outbreak/
-- '@id': outbreak:name
-  '@type': rdf:Property
-  marginality: required
-  owl:cardinality: one
-  rdfs:comment: The name of the organization, team or group
-  rdfs:label: name
-  rdfs:sameAs:
-    '@id': schema:name
-  schema:domainIncludes:
-    '@id': outbreak:Organization
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:alternateName
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: Alternative names or commonly used abbreviations for the organization,
-    team or group
-  rdfs:label: alternateName
-  rdfs:sameAs:
-    '@id': schema:alternateName
-  schema:domainIncludes:
-    '@id': outbreak:Organization
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:affiliation
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: An overarching consortia, multi-institutional team or group in which
-    the organization/team/group is a member or affiliate
-  rdfs:label: affiliation
-  rdfs:sameAs:
-    '@id': schema:affiliation
-  schema:domainIncludes:
-    '@id': outbreak:Organization
-  schema:rangeIncludes:
-    '@id': outbreak:Organization
-- '@id': outbreak:affiliationStatus
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The status of the organization's membership or affiliation in the
-    overarching consortial, multi-institutional team or group (current, past)
-  rdfs:label: affiliationStatus
-  rdfs:sameAs:
-    '@id': schema:additionalType
-  schema:domainIncludes:
-    '@id': outbreak:Organization
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:members
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: Members of this organization, team, or group
-  rdfs:label: members
-  rdfs:sameAs:
-    '@id': schema:members
-  schema:domainIncludes:
-    '@id': outbreak:Organization
-  schema:rangeIncludes:
-  - '@id': outbreak:Person
-  - '@id': outbreak:Organization
-- '@id': outbreak:membershipStatus
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: Status of the members of this organization
-  rdfs:label: membershipStatus
-  rdfs:sameAs:
-    '@id': schema:additionalType
-  schema:domainIncludes:
-    '@id': outbreak:Organization
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:relatedTo
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: many
-  rdfs:comment: A resource which a person played a role
-  rdfs:label: relatedTo
-  rdfs:sameAs:
-    '@id': schema:relatedTo
-  schema:domainIncludes:
-    '@id': outbreak:Organization
-  schema:rangeIncludes:
-  - '@id': schema:CreativeWork
-  - '@id': schema:HowTo
-- '@id': outbreak:class
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: many
-  rdfs:comment: A classification of the organization by a resource. Eg- for ClinicalTrials
-    funders, it's ["U.S. National Institutes of Health", "Other U.S. Federal agencies",
-    "Industry", "All others"]
-  rdfs:label: class
-  rdfs:sameAs:
-    '@id': schema:addtionalType
-  schema:domainIncludes:
-  - '@id': schema:CreativeWork
-  - '@id': schema:HowTo
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:role
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: many
-  rdfs:comment: The role of an organization in its involvement with a resource
-  rdfs:label: role
-  rdfs:sameAs:
-    '@id': schema:additionalType
-  schema:domainIncludes:
-  - '@id': schema:CreativeWork
-  - '@id': schema:HowTo
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:Person
-  '@type': rdfs:Class
-  rdfs:comment: This is the schema for describing the Person schema used for outbreak.info.
-  rdfs:label: Person
-  rdfs:subClassOf:
-    '@id': schema:Person
-  schema:isPartOf:
-    '@id': https://discovery.biothings.io/view/outbreak/
-- '@id': outbreak:name
-  '@type': rdf:Property
-  marginality: required
-  owl:cardinality: one
-  rdfs:comment: The name of the person
-  rdfs:label: name
-  rdfs:sameAs:
-    '@id': schema:name
-  schema:domainIncludes:
-    '@id': outbreak:Person
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:alternateName
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: Alternative ways in which the person's name is included in a record
-  rdfs:label: alternateName
-  rdfs:sameAs:
-    '@id': schema:alternateName
-  schema:domainIncludes:
-    '@id': outbreak:Person
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:givenName
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The given name of the person
-  rdfs:label: givenName
-  rdfs:sameAs:
-    '@id': schema:givenName
-  schema:domainIncludes:
-    '@id': outbreak:Person
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:familyName
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The family name of the person
-  rdfs:label: familyName
-  rdfs:sameAs:
-    '@id': schema:familyName
-  schema:domainIncludes:
-    '@id': outbreak:Person
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:affiliation
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: The organization with which the person is affiliated or has membership
-    in
-  rdfs:label: affiliation
-  rdfs:sameAs:
-    '@id': schema:affiliation
-  schema:domainIncludes:
-    '@id': outbreak:Person
-  schema:rangeIncludes:
-    '@id': outbreak:Organization
-- '@id': outbreak:affiliationStatus
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The status of the person's membership or affiliation in an organization,
-    team or group (current, past)
-  rdfs:label: affiliationStatus
-  rdfs:sameAs:
-    '@id': schema:addtionalType
-  schema:domainIncludes:
-    '@id': outbreak:Person
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:orcid
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The ORCID ID of the person
-  rdfs:label: orcid
-  rdfs:sameAs:
-    '@id': schema:identifier
-  schema:domainIncludes:
-    '@id': outbreak:Person
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:relatedTo
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: many
-  rdfs:comment: A resource which a person played a role
-  rdfs:label: relatedTo
-  rdfs:sameAs:
-    '@id': schema:relatedTo
-  schema:domainIncludes:
-    '@id': outbreak:Person
-  schema:rangeIncludes:
-  - '@id': schema:CreativeWork
-  - '@id': schema:HowTo
-- '@id': outbreak:role
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: The role a person played in the creation of a resource
-  rdfs:label: role
-  rdfs:sameAs:
-    '@id': schema:addtionalType
-  schema:domainIncludes:
-  - '@id': schema:CreativeWork
-  - '@id': schema:HowTo
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:MonetaryGrant
-  '@type': rdfs:Class
-  rdfs:comment: This is the schema for describing the MonetaryGrant schema used for
-    outbreak.info.
-  rdfs:label: MonetaryGrant
-  rdfs:subClassOf:
-    '@id': schema:MonetaryGrant
-  schema:isPartOf:
-    '@id': https://discovery.biothings.io/view/outbreak/
-- '@id': outbreak:name
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The name of the monetary grant
-  rdfs:label: name
-  rdfs:sameAs:
-    '@id': schema:name
-  schema:domainIncludes:
-    '@id': outbreak:MonetaryGrant
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:identifier
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The grant ID or an identifier associated with the grant
-  rdfs:label: identifier
-  rdfs:sameAs:
-    '@id': schema:identifier
-  schema:domainIncludes:
-    '@id': outbreak:MonetaryGrant
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:url
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The url for the grant (if available)
-  rdfs:label: url
-  rdfs:sameAs:
-    '@id': schema:url
-  schema:domainIncludes:
-    '@id': outbreak:MonetaryGrant
-  schema:rangeIncludes:
-    '@id': schema:URL
-- '@id': outbreak:funder
-  '@type': rdf:Property
-  marginality: required
-  owl:cardinality: many
-  rdfs:comment: The funding organization of the grant
-  rdfs:label: funder
-  rdfs:sameAs:
-    '@id': schema:funder
-  schema:domainIncludes:
-    '@id': outbreak:MonetaryGrant
-  schema:rangeIncludes:
-    '@id': outbreak:Organization
-- '@id': outbreak:name
-  '@type': rdf:Property
-  marginality: required
-  owl:cardinality: one
-  rdfs:comment: The name of the funding organization
-  rdfs:label: name
-  rdfs:sameAs:
-    '@id': schema:name
-  schema:domainIncludes:
-    '@id': outbreak:Organization
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:recipient
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: The person or organization to whom or to which the grant was awarded
-  rdfs:label: recipient
-  rdfs:sameAs:
-    '@id': schema:recipient
-  schema:domainIncludes:
-    '@id': outbreak:MonetaryGrant
-  schema:rangeIncludes:
-  - '@id': outbreak:Person
-  - '@id': outbreak:Organization
-- '@id': outbreak:name
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The name of the recipient of the grant
-  rdfs:label: name
-  rdfs:sameAs:
-    '@id': schema:name
-  schema:domainIncludes:
-  - '@id': outbreak:Person
-  - '@id': outbreak:Organization
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:affiliation
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: The affiliation of the recipient of the grant
-  rdfs:label: affiliation
-  rdfs:sameAs:
-    '@id': schema:affiliation
-  schema:domainIncludes:
-  - '@id': outbreak:Person
-  - '@id': outbreak:Organization
-  schema:rangeIncludes:
-    '@id': schema:Text
 - $validation:
     $schema: http://json-schema.org/draft-07/schema#
     definitions:
-      citation:
-        '@type': CreativeWork
-        description: A citation object for a resource which is cited by the analysis
-          (ie- is a derivative of the analysis) , related to the analysis, or from
-          which the analysis was based on (ie- is derived from).
+      baseOrgObject:
+        '@type': outbreak:Organization
         properties:
-          citeText:
-            description: The bibliographic citation for the referenced resource as
-              is provided
-            type: string
-          doi:
-            type: string
-          identifier:
-            type: string
-          name:
-            description: name of the referenced resource
-            type: string
-          pmid:
-            type: integer
-          type:
-            enum:
-            - ClinicalStudy
-            - Analysis
-            - Publication
-            - Dataset
-            - Protocol
-            - SoftwareApplication
-            - Other
-          url:
-            format: uri
-            type: string
-          versionDate:
-            description: Date of the version of the resource that is referenced
-            format: date
-            type: string
-        required:
-        - name
-        - type
-        type: object
-      controlledVocabulary:
-        '@type': CreativeWork
-        definition: collection of vocabulary terms defined in ontologies
-        strict: false
-        type: string
-        vocabulary:
-          children_of:
-          - https://bioportal.bioontology.org/ontologies/COVID19
-          - http://purl.obolibrary.org/obo/cido.owl
-          - http://purl.obolibrary.org/obo/epo
-          ontology:
-          - covid19
-          - cido
-          - epo
-      funding:
-        '@type': MonetaryGrant
-        description: Information about funding support
-        properties:
-          funder:
-            description: name of the funding organization
-            oneOf:
-            - $ref: '#/definitions/organization'
-            - items:
-                $ref: '#/definitions/organization'
-              type: array
-            type: array
-          identifier:
-            description: Unique identifier(s) for the grant(s) used to fund the Analysis
-            type: string
-          name:
-            description: The name of the monetary grant that funded/funds the Analysis
-            type: string
-          url:
-            description: award URL
-            type: string
-        required:
-        - funder
-        type: object
-      miscControlledVocabulary:
-        '@type': CreativeWork
-        description: collection of vocabulary terms defined in ontologies
-        strict: false
-        type: string
-        vocabulary:
-          children_of:
-          - http://purl.obolibrary.org/obo/NCBITaxon_10239
-          - http://purl.obolibrary.org/obo/NCBITaxon_131567l
-          ontology:
-          - ncbitaxon
-      moreControlledVocabulary:
-        '@type': CreativeWork
-        definition: collection of vocabulary terms defined in ontologies
-        strict: false
-        type: string
-        vocabulary:
-          children_of:
-          - http://identifiers.org/mamo/MAMO_0000037
-          ontology:
-          - mamo
-      organization:
-        '@type': Organization
-        description: Reusable organization definition
-        properties:
-          affiliation:
+          alternateName:
             type: string
           name:
             type: string
         required:
         - name
         type: object
-      person:
-        '@type': Person
-        description: Reusable person definition
+    properties:
+      affiliation:
+        description: An organization that this person is affiliated with. For example,
+          a school/university, a club, or a team.
+        oneOf:
+        - $ref: '#/definitions/baseOrgObject'
+        - items:
+            $ref: '#/definitions/baseOrgObject'
+          type: array
+      alternateName:
+        description: An alias for the person.
+        type: string
+      familyName:
+        description: Family name. In the U.S., the last name of an Person. This can
+          be used along with givenName instead of the name property.
+        type: string
+      givenName:
+        description: Given name. In the U.S., the first name of a Person. This can
+          be used along with familyName instead of the name property.
+        type: string
+      name:
+        description: The name of the person.
+        type: string
+      orcid:
+        description: the ORCID ID of the person
+        type: string
+      role:
+        description: authorship, sponsorship, or other contribution role played by
+          the person or organization in the creation of this resource
+        oneOf:
+        - type: string
+        - items:
+            type: string
+          type: array
+    required:
+    - name
+    type: object
+  '@id': outbreak:Person
+  '@type': rdfs:Class
+  rdfs:comment: This is the Person schema for describing authors and people for outbreak.info
+    resources
+  rdfs:label: Person
+  rdfs:subClassOf:
+    '@id': schema:Person
+- '@id': outbreak:orcid
+  '@type': rdfs:Property
+  rdfs:comment: the ORCID ID of the person
+  rdfs:label: orcid
+  schema:domainIncludes:
+    '@id': outbreak:Person
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- $validation:
+    $schema: http://json-schema.org/draft-07/schema#
+    definitions:
+      baseOrgObject:
+        '@type': outbreak:Organization
+        description: Affiliated Organization
+        properties:
+          alternateName:
+            description: Alternate name or Acronym for the organization.
+            type: string
+          name:
+            description: name of the organization
+            type: string
+        required:
+        - name
+        type: object
+      basePersonObject:
+        '@type': outbreak:Person
         properties:
           affiliation:
+            description: consortia or other organizations with which this person is
+              affiliated
             oneOf:
-            - $ref: '#/definitions/organization'
+            - $ref: '#/definitions/baseOrgObject'
             - items:
-                $ref: '#/definitions/organization'
+                $ref: '#/definitions/baseOrgObject'
               type: array
-            type: array
+          alternateName:
+            type: string
           familyName:
             type: string
           givenName:
@@ -494,8 +110,628 @@
         - name
         type: object
     properties:
+      affiliation:
+        description: consortia or other organizations with which this organization
+          is affiliated
+        oneOf:
+        - $ref: '#/definitions/baseOrgObject'
+        - items:
+            $ref: '#/definitions/baseOrgObject'
+          type: array
+      alternateName:
+        description: An alias or acronym for the organization.
+        type: string
+      class:
+        description: A classification of the organization by a resource. Eg- for ClinicalTrials
+          funders, it's [U.S. National Institutes of Health, Other U.S. Federal agencies,
+          Industry, All others]
+        type: string
+      members:
+        description: Members of this organization, team, or group
+        oneOf:
+        - $ref: '#/definitions/basePersonObject'
+        - items:
+            $ref: '#/definitions/basePersonObject'
+          type: array
+      name:
+        description: The name of the organization.
+        type: string
+      role:
+        description: The role of an organization in its involvement with a resource
+        oneOf:
+        - type: string
+        - items:
+            type: string
+          type: array
+    required:
+    - name
+    type: object
+  '@id': outbreak:Organization
+  '@type': rdfs:Class
+  rdfs:comment: This is the organization schema for describing authors, funders and
+    other organizations referenced by outbreak.info resources
+  rdfs:label: Organization
+  rdfs:subClassOf:
+    '@id': schema:Organization
+- '@id': outbreak:affiliation
+  '@type': rdfs:Property
+  rdfs:comment: consortia or other organizations with which this organization is affiliated
+  rdfs:label: affiliation
+  schema:domainIncludes:
+    '@id': outbreak:Organization
+  schema:rangeIncludes:
+  - '@id': outbreak:Organization
+- '@id': outbreak:members
+  '@type': rdfs:Property
+  rdfs:comment: Members of this organization, team, or group
+  rdfs:label: members
+  schema:domainIncludes:
+    '@id': outbreak:Organization
+  schema:rangeIncludes:
+  - '@id': outbreak:Person
+- '@id': outbreak:class
+  '@type': rdfs:Property
+  rdfs:comment: A classification of the organization by a resource. Eg- for ClinicalTrials
+    funders, it's [U.S. National Institutes of Health, Other U.S. Federal agencies,
+    Industry, All others]
+  rdfs:label: class
+  schema:domainIncludes:
+    '@id': outbreak:Organization
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:role
+  '@type': rdfs:Property
+  rdfs:comment: authorship, sponsorship, or other contribution role played by the
+    person or organization in the creation of this resource. In a Clinical Study/Trial
+    ArmGroup, it's equivalent to the ArmType in ClinicalTrials.gov
+  rdfs:label: role
+  schema:domainIncludes:
+  - '@id': outbreak:Person
+  - '@id': outbreak:Organization
+  - '@id': outbreak:ArmGroup
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- $validation:
+    $schema: http://json-schema.org/draft-07/schema#
+    definitions:
+      baseOrgObject:
+        '@type': outbreak:Organization
+        description: Affiliated Organization
+        properties:
+          alternateName:
+            description: Alternate name or Acronym for the organization.
+            type: string
+          name:
+            description: name of the organization
+            type: string
+        required:
+        - name
+        type: object
+      basePersonObject:
+        '@type': outbreak:Person
+        properties:
+          affiliation:
+            description: consortia or other organizations with which this person is
+              affiliated
+            oneOf:
+            - $ref: '#/definitions/baseOrgObject'
+            - items:
+                $ref: '#/definitions/baseOrgObject'
+              type: array
+          alternateName:
+            type: string
+          familyName:
+            type: string
+          givenName:
+            type: string
+          name:
+            type: string
+          orcid:
+            type: string
+        required:
+        - name
+        type: object
+    properties:
+      funder:
+        description: The organization(s) that supported (sponsored) the grant through
+          some kind of financial contribution.
+        oneOf:
+        - $ref: '#/definitions/baseOrgObject'
+        - items:
+            $ref: '#/definitions/baseOrgObject'
+          type: array
+      identifier:
+        description: The funding or grant id
+        type: string
+      name:
+        description: The name of the grant or funding.
+        type: string
+      recipient:
+        anyOf:
+        - $ref: '#/definitions/basePersonObject'
+        - items:
+            $ref: '#/definitions/basePersonObject'
+          type: array
+        - $ref: '#/definitions/baseOrgObject'
+        - items:
+            $ref: '#/definitions/baseOrgObject'
+          type: array
+        description: The person or organization to whom or to which the grant was
+          awarded
+      url:
+        description: URL of the grant or funding award.
+        format: uri
+        type: string
+    required:
+    - funder
+    type: object
+  '@id': outbreak:MonetaryGrant
+  '@type': rdfs:Class
+  rdfs:comment: This is the schema for describing the MonetaryGrant schema used for
+    outbreak.info
+  rdfs:label: MonetaryGrant
+  rdfs:subClassOf:
+    '@id': schema:MonetaryGrant
+- '@id': outbreak:recipient
+  '@type': rdfs:Property
+  rdfs:comment: The person or organization to whom or to which the grant was awarded
+  rdfs:label: recipient
+  schema:domainIncludes:
+    '@id': outbreak:MonetaryGrant
+  schema:rangeIncludes:
+  - '@id': schema:Person
+  - '@id': schema:Organization
+- '@id': outbreak:DataDownload
+  '@type': rdfs:Class
+  rdfs:comment: This is the schema for describing the DataDownload schema used for
+    outbreak.info.
+  rdfs:label: DataDownload
+  rdfs:subClassOf:
+    '@id': schema:DataDownload
+- $validation:
+    $schema: http://json-schema.org/draft-07/schema#
+    properties:
+      citeText:
+        description: The bibliographic citation for the referenced resource as is
+          provided
+        type: string
+      doi:
+        description: A doi if available
+        type: string
+      identifier:
+        description: An identifier associated with the citation
+        type: string
+      name:
+        description: The name or title of the cited resource.
+        type: string
+      pmid:
+        description: A pubmed identifier if available
+        type: string
+      sourceType:
+        description: The @type of resource
+        enum:
+        - Dataset
+        - Publication
+        - ClinicalTrial
+        - Analysis
+        - Protocol
+        - SoftwareApplication
+        - CreativeWork
+      url:
+        description: URL of the cited resource.
+        format: uri
+        type: string
+      versionDate:
+        description: The version date of the resource used at the time of the creation
+          of the citation as certain resources (protocols, datasets) may change frequently
+          over time.
+        format: date
+        type: string
+    required:
+    - name
+    - sourceType
+    type: object
+  '@id': outbreak:CitationObject
+  '@type': rdfs:Class
+  rdfs:comment: A citation object for a resource which is cited by the subject (ie-
+    is a derivative of the subject), related to the subject, or from which the subject
+    was based on (ie- is derived from).
+  rdfs:label: CitationObject
+  rdfs:subClassOf:
+    '@id': schema:CreativeWork
+- '@id': outbreak:citeText
+  '@type': rdfs:Property
+  rdfs:comment: The bibliographic citation for the referenced resource as is provided
+  rdfs:label: citeText
+  schema:domainIncludes:
+    '@id': outbreak:CitationObject
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:versionDate
+  '@type': rdfs:Property
+  rdfs:comment: The version date of the resource used at the time of the creation
+    of the citation as certain resources (protocols, datasets) may change frequently
+    over time.
+  rdfs:label: versionDate
+  schema:domainIncludes:
+    '@id': outbreak:CitationObject
+  schema:rangeIncludes:
+  - '@id': schema:Date
+- '@id': outbreak:sourceType
+  '@type': rdfs:Property
+  rdfs:comment: The type of resource
+  rdfs:label: sourceType
+  schema:domainIncludes:
+    '@id': outbreak:CitationObject
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:Dataset
+  '@type': rdfs:Class
+  rdfs:comment: This is the schema for describing the Dataset schema used for outbreak.info.
+  rdfs:label: Dataset
+  rdfs:subClassOf:
+    '@id': schema:Dataset
+- '@id': outbreak:Correction
+  '@type': rdfs:Class
+  rdfs:comment: This is the schema for describing a Correction used for outbreak.info.
+    A Correction is a specialized subclass of the CitationObject
+  rdfs:label: Correction
+  rdfs:subClassOf:
+    '@id': schema:CreativeWork
+- '@id': outbreak:correctionType
+  '@type': rdfs:Property
+  rdfs:comment: 'Type of notice or correction: (correction, retraction, expression
+    of convern, withdrawal, erratum, update, correction/republication, preprint, peer
+    reviewed version)'
+  rdfs:label: correctionType
+  schema:domainIncludes:
+    '@id': outbreak:Correction
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:Publication
+  '@type': rdfs:Class
+  rdfs:comment: This is the schema for describing the Publication used for outbreak.info
+  rdfs:label: Publication
+  rdfs:subClassOf:
+    '@id': schema:MedicalScholarlyArticle
+- '@id': outbreak:journalName
+  '@type': rdfs:Property
+  rdfs:comment: The name of the journal (or publisher if journal name not available)
+  rdfs:label: journalName
+  schema:domainIncludes:
+    '@id': outbreak:Publication
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:journalNameAbbrevation
+  '@type': rdfs:Property
+  rdfs:comment: abbreviated Journal Title (note, this should be autopopulated)
+  rdfs:label: journalNameAbbrevation
+  schema:domainIncludes:
+    '@id': outbreak:Publication
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:volumeNumber
+  '@type': rdfs:Property
+  rdfs:comment: Volume number of journal in which the article was published
+  rdfs:label: volumeNumber
+  schema:domainIncludes:
+    '@id': outbreak:Publication
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:issueNumber
+  '@type': rdfs:Property
+  rdfs:comment: Issue of journal in which the article was published
+  rdfs:label: issueNumber
+  schema:domainIncludes:
+    '@id': outbreak:Publication
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- $validation:
+    $schema: http://json-schema.org/draft-07/schema#
+    definitions:
+      aggregateRatingObject:
+        '@type': AggregateRating
+        description: A cumulative evaluation of the resource
+        properties:
+          author:
+            anyOf:
+            - $ref: '#/definitions/person'
+            - items:
+                $ref: '#/definitions/person'
+              type: array
+            - $ref: '#/definitions/organization'
+            - items:
+                $ref: '#/definitions/organization'
+              type: array
+            description: The author of this content or rating.
+          curationDate:
+            description: The date this evaluation was added into outbreak.info, or
+              was updated in outbreak.info.
+            format: date
+            type: string
+          name:
+            description: The name of the aggregate rating
+            type: string
+          ratingValue:
+            description: The rating for the content.
+            type: string
+          reviewAspect:
+            description: This Review or Rating is relevant to this part or facet of
+              the itemReviewed
+            type: string
+          reviews:
+            anyOf:
+            - items:
+                $ref: '#/definitions/reviewObject'
+              type: array
+            - items:
+                $ref: '#/definitions/ratingObject'
+              type: array
+        required: []
+        type: object
+      baseOrgObject:
+        '@type': outbreak:Organization
+        description: A barebones Organization object to work around recursion issues
+          in DDE
+        properties:
+          alternateName:
+            description: Alternate name or Acronym for the organization.
+            type: string
+          name:
+            description: name of the organization
+            type: string
+        required:
+        - name
+        type: object
+      citation:
+        '@type': outbreak:CitationObject
+        description: A citation object for a resource which is cited by the analysis
+          (ie- is a derivative of the publication) , related to the analysis, or from
+          which the analysis was based on (ie- is derived from).
+        properties:
+          citeText:
+            description: The bibliographic citation for the referenced resource as
+              is provided
+            type: string
+          doi:
+            description: A doi if available
+            type: string
+          identifier:
+            description: An identifier associated with the citation
+            type: string
+          name:
+            description: Name of or title of the citation
+            type: string
+          pmid:
+            description: A pubmed identifier if available
+            type: string
+          sourceType:
+            description: The type of resource
+            enum:
+            - Dataset
+            - Publication
+            - ClinicalTrial
+            - Analysis
+            - Protocol
+            - SoftwareApplication
+            - CreativeWork
+          url:
+            description: The url of the resource cited.
+            format: uri
+            type: string
+          versionDate:
+            description: The version date of the resource used at the time of the
+              creation of the citation as certain resources (protocols, datasets)
+              may change frequently over time.
+            format: date
+            type: string
+        required:
+        - name
+        - sourceType
+        type: object
+      controlledVocabulary:
+        '@type': DefinedTerm
+        definition: collection of vocabulary terms defined in ontologies
+        strict: false
+        type: string
+        vocabulary:
+          children_of:
+          - https://bioportal.bioontology.org/ontologies/COVID19
+          - http://purl.obolibrary.org/obo/cido.owl
+          - http://purl.obolibrary.org/obo/epo
+          ontology:
+          - covid19
+          - cido
+          - epo
+      diseaseVocabulary:
+        '@type': DefinedTerm
+        description: collection of vocabulary terms defined in ontologies
+        strict: false
+        type: string
+        vocabulary:
+          children_of:
+          - http://purl.obolibrary.org/obo/MONDO_0000001
+          ontology:
+          - mondo
+      funding:
+        '@type': outbreak:MonetaryGrant
+        description: Information about funding support
+        properties:
+          funder:
+            description: name of the funding organization
+            oneOf:
+            - $ref: '#/definitions/baseOrgObject'
+            - items:
+                $ref: '#/definitions/baseOrgObject'
+              type: array
+          identifier:
+            description: Unique identifier(s) for the grant(s) used to fund the analysis
+            type: string
+          name:
+            description: The name of the monetary grant that funded/funds the analysis
+            type: string
+          url:
+            description: award URL
+            format: uri
+            type: string
+        required:
+        - funder
+        type: object
+      memberObject:
+        '@type': outbreak:Person
+        description: Reusable person definition accounting for recursion issues in
+          DDE
+        properties:
+          affiliation:
+            oneOf:
+            - $ref: '#/definitions/baseOrgObject'
+            - items:
+                $ref: '#/definitions/baseOrgObject'
+              type: array
+          familyName:
+            type: string
+          givenName:
+            type: string
+          name:
+            type: string
+          orcid:
+            type: string
+        required:
+        - name
+        type: object
+      miscControlledVocabulary:
+        '@type': DefinedTerm
+        description: collection of vocabulary terms defined in ontologies
+        strict: false
+        type: string
+        vocabulary:
+          children_of:
+          - http://purl.obolibrary.org/obo/NCBITaxon_10239
+          ontology:
+          - ncbitaxon
+      moreControlledVocabulary:
+        '@type': DefinedTerm
+        definition: collection of vocabulary terms defined in ontologies
+        strict: false
+        type: string
+        vocabulary:
+          children_of:
+          - http://identifiers.org/mamo/MAMO_0000037
+          ontology:
+          - mamo
+      organization:
+        '@type': outbreak:Organization
+        description: Reusable organization definition
+        properties:
+          affiliation:
+            $ref: '#/definitions/baseOrgObject'
+          alternateName:
+            type: string
+          members:
+            oneOf:
+            - $ref: '#/definitions/memberObject'
+            - items:
+                $ref: '#/definitions/memberObject'
+              type: array
+          name:
+            type: string
+        required:
+        - name
+        type: object
+      person:
+        '@type': outbreak:Person
+        description: Reusable person definition
+        properties:
+          affiliation:
+            oneOf:
+            - $ref: '#/definitions/baseOrgObject'
+            - items:
+                $ref: '#/definitions/baseOrgObject'
+              type: array
+          familyName:
+            type: string
+          givenName:
+            type: string
+          name:
+            type: string
+          orcid:
+            type: string
+        required:
+        - name
+        type: object
+      ratingObject:
+        '@type': Rating
+        description: A rating or categorical evaluation of the resource
+        properties:
+          author:
+            anyOf:
+            - $ref: '#/definitions/person'
+            - items:
+                $ref: '#/definitions/person'
+              type: array
+            - $ref: '#/definitions/organization'
+            - items:
+                $ref: '#/definitions/organization'
+              type: array
+            description: The author of this content or rating.
+          curationDate:
+            description: The date this evaluation was added into outbreak.info, or
+              was updated in outbreak.info.
+            format: date
+            type: string
+          name:
+            description: The name of the rating
+            type: string
+          ratingExplanation:
+            description: An explanation of the rating
+            type: string
+          ratingValue:
+            description: The rating for the content.
+            type: string
+          reviewAspect:
+            description: This Review or Rating is relevant to this part or facet of
+              the itemReviewed
+            type: string
+        required: []
+        type: object
+      reviewObject:
+        '@type': Review
+        description: A review or descriptive evaluation of the resource
+        properties:
+          author:
+            anyOf:
+            - $ref: '#/definitions/person'
+            - items:
+                $ref: '#/definitions/person'
+              type: array
+            - $ref: '#/definitions/organization'
+            - items:
+                $ref: '#/definitions/organization'
+              type: array
+            description: The author of this content or rating.
+          curationDate:
+            description: The date this evaluation was added into outbreak.info, or
+              was updated in outbreak.info.
+            format: date
+            type: string
+          name:
+            description: The name of the review
+            type: string
+          reviewAspect:
+            description: This Review or Rating is relevant to this part or facet of
+              the itemReviewed
+            type: string
+          reviewBody:
+            description: The actual body of the review.
+            type: string
+          reviewRating:
+            $ref: '#/definitions/ratingObject'
+            description: The rating given in this review
+        required: []
+        type: object
+    properties:
       analysisTechnique:
-        description: A technique or technology used in a analysis.
+        description: A technique or technology used in a analysis
         oneOf:
         - $ref: '#/definitions/moreControlledVocabulary'
         - enum:
@@ -523,8 +759,7 @@
             type: string
           type: array
       author:
-        description: The author of this content or rating.
-        oneOf:
+        anyOf:
         - $ref: '#/definitions/person'
         - items:
             $ref: '#/definitions/person'
@@ -533,30 +768,17 @@
         - items:
             $ref: '#/definitions/organization'
           type: array
+        description: The author of this content or rating.
       citedBy:
-        description: A resource (publication, protocol, dataset, etc.) which was derived
-          from this protocol
+        description: A citation to a resource (eg- publication, protocol, etc.) which
+          is derived from this analysis (stored as an object, not a string)
         oneOf:
         - $ref: '#/definitions/citation'
         - items:
             $ref: '#/definitions/citation'
-          type: array
-      contributor:
-        description: A secondary contributor to the CreativeWork or Event.
-        oneOf:
-        - $ref: '#/definitions/person'
-        - items:
-            $ref: '#/definitions/person'
-          type: array
-        - $ref: '#/definitions/organization'
-        - items:
-            $ref: '#/definitions/organization'
           type: array
       curatedBy:
-        description: The source from which this Analysis was identified for inclusion
-          into Outbreak.info. Provides provenance for a resource which was curated
-          by another.
-        oneOf:
+        anyOf:
         - $ref: '#/definitions/citation'
         - $ref: '#/definitions/person'
         - $ref: '#/definitions/organization'
@@ -569,44 +791,56 @@
         - items:
             $ref: '#/definitions/citation'
           type: array
+        description: The source from which this analysis was identified for inclusion
+          into Outbreak.info. Provides provenance for a resource which was curated
+          by another.
       curationDate:
         description: The date this resource was added into outbreak.info, or was updated
           in outbreak.info.
         format: date
         type: string
       dateModified:
-        description: Most recent date for which the analysis model itself was updated
+        description: The date on which the CreativeWork was most recently modified
+          or when the item's entry was modified within a DataFeed.
         format: date
         type: string
       datePublished:
-        description: PublicationDate of the analysis online if available
+        description: Date of first broadcast/publication of the analysis
         format: date
         type: string
       description:
-        description: A description of the item.
+        description: A description of the analysis
         type: string
       doi:
-        description: A DOI associated with the analysis if available
+        description: The DOI of the analysis if available
         type: string
       domainUrl:
         description: The domain name or main site on which webpage or specific url
-          can be found
+          of the analysis can be found
         format: uri
         type: string
+      evaluations:
+        anyOf:
+        - items:
+            $ref: '#/definitions/reviewObject'
+          type: array
+        - items:
+            $ref: '#/definitions/ratingObject'
+          type: array
+        - items:
+            $ref: '#/definitions/aggregateRatingObject'
+          type: array
+        description: Reviews, Ratings, or other types of evaluations on this resource
       funding:
-        description: A person or organization that supports (sponsors) something through
-          some kind of financial contribution.
+        description: The funding that supported the creation or maintenance of the
+          analysis
         oneOf:
         - $ref: '#/definitions/funding'
         - items:
             $ref: '#/definitions/funding'
           type: array
-      hasDownloadableContent:
-        description: Indicates the site has content that can be downloaded (raw data,
-          data sheets, charts, etc)
-        type: boolean
       identifier:
-        description: An identifier associated with the analysis if available
+        description: An identifier for the analysis, preferably a doi
         type: string
       infectiousAgent:
         description: infectious agents(s) which are the focus of the analysis
@@ -616,23 +850,33 @@
             $ref: '#/definitions/miscControlledVocabulary'
           type: array
       infectiousDisease:
-        description: The disease caused by the infectious agent. Important as some
-          agents may cause multiple diseases
+        description: The disease or medical conditions caused by the infectious agent.
+          Important as some agents may cause multiple diseases
         oneOf:
-        - type: string
+        - $ref: '#/definitions/diseaseVocabulary'
         - items:
-            type: string
+            $ref: '#/definitions/diseaseVocabulary'
           type: array
       isBasedOn:
-        description: A resource (publication, protocol, dataset, etc) from which this
-          analysis was derived
+        description: Associated datasets, software, protocols, etc. used by the work
+          described in this analysis, including reference publications
+        oneOf:
+        - $ref: '#/definitions/citation'
+        - items:
+            $ref: '#/definitions/citation'
+          type: array
+      isRelatedTo:
+        description: A citation to a resource (eg- publication, protocol, etc.) which
+          is related to the analysis but is not a derivative nor was derived from
+          the analysis (stored as an object, not a string)
         oneOf:
         - $ref: '#/definitions/citation'
         - items:
             $ref: '#/definitions/citation'
           type: array
       keywords:
-        description: keywords
+        description: Keywords or tags used to describe this content. Multiple entries
+          in a keywords list are typically delimited by commas.
         oneOf:
         - type: string
         - items:
@@ -640,31 +884,11 @@
           type: array
       license:
         description: A license document that applies to this content, typically indicated
-          by URL
+          by URL.
         type: string
-      maintainer:
-        description: A maintainer of a Dataset, software package (SoftwareApplication),
-          or other Project.
-        oneOf:
-        - $ref: '#/definitions/person'
-        - items:
-            $ref: '#/definitions/person'
-          type: array
-        - $ref: '#/definitions/organization'
-        - items:
-            $ref: '#/definitions/organization'
-          type: array
       name:
-        description: The name of the item.
+        description: The name of the analysis
         type: string
-      relatedTo:
-        description: Other resources related to, but not a derivative of nor derived
-          from this analysis
-        oneOf:
-        - $ref: '#/definitions/citation'
-        - items:
-            $ref: '#/definitions/citation'
-          type: array
       topicCategory:
         description: Applicable outbreak.info category
         oneOf:
@@ -702,6 +926,7 @@
           - Epidemiology
           - Classical Epidemiology
           - Molecular Epidemiology
+          - Information Sciences
         - items:
             enum:
             - Clinical
@@ -737,693 +962,886 @@
             - Epidemiology
             - Classical Epidemiology
             - Molecular Epidemiology
+            - Information Sciences
           type: array
       url:
-        description: The url of the item
+        description: URL where the analysis can be found
         format: uri
         type: string
     required:
-    - url
-    - name
-    - description
     - author
+    - description
+    - identifier
+    - name
+    - url
     type: object
   '@id': outbreak:Analysis
   '@type': rdfs:Class
-  rdfs:comment: This is the schema for describing the Analysis schema used for outbreak.info.
+  rdfs:comment: This is the schema for describing an Analysis for inclusion in outbreak.info
+    resources
   rdfs:label: Analysis
   rdfs:subClassOf:
     '@id': schema:CreativeWork
-  schema:isPartOf:
-    '@id': https://discovery.biothings.io/view/outbreak/
-- '@id': outbreak:url
-  '@type': rdf:Property
-  marginality: required
-  owl:cardinality: one
-  rdfs:comment: The url of the item
-  rdfs:label: url
-  rdfs:sameAs:
-    '@id': schema:url
-  schema:domainIncludes:
-    '@id': outbreak:Analysis
-  schema:rangeIncludes:
-    '@id': schema:URL
 - '@id': outbreak:domainUrl
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
+  '@type': rdfs:Property
   rdfs:comment: The domain name or main site on which webpage or specific url can
     be found
   rdfs:label: domainUrl
-  rdfs:sameAs:
-    '@id': schema:url
   schema:domainIncludes:
     '@id': outbreak:Analysis
   schema:rangeIncludes:
-    '@id': schema:URL
-- '@id': outbreak:identifier
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: An identifier associated with the analysis if available
-  rdfs:label: identifier
-  rdfs:sameAs:
-    '@id': schema:identifier
+  - '@id': schema:URL
+- '@id': outbreak:assumption
+  '@type': rdfs:Property
+  rdfs:comment: Statement of assumptions / limitations of the model
+  rdfs:label: assumption
   schema:domainIncludes:
     '@id': outbreak:Analysis
   schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:doi
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: A DOI associated with the analysis if available
-  rdfs:label: doi
-  rdfs:sameAs:
-    '@id': schema:identifier
+  - '@id': schema:Text
+- '@id': outbreak:analysisTechnique
+  '@type': rdfs:Property
+  rdfs:comment: A technique or technology used in a analysis
+  rdfs:label: analysisTechnique
   schema:domainIncludes:
     '@id': outbreak:Analysis
   schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:name
-  '@type': rdf:Property
-  marginality: required
-  owl:cardinality: one
-  rdfs:comment: The name of the item.
-  rdfs:label: name
-  rdfs:sameAs:
-    '@id': schema:name
+  - '@id': schema:Text
+- '@id': outbreak:analysisTopic
+  '@type': rdfs:Property
+  rdfs:comment: The underlying question, goal, or aim of the analysis
+  rdfs:label: analysisTopic
   schema:domainIncludes:
     '@id': outbreak:Analysis
   schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:description
-  '@type': rdf:Property
-  marginality: required
-  owl:cardinality: one
-  rdfs:comment: A description of the item.
-  rdfs:label: description
-  rdfs:sameAs:
-    '@id': schema:description
+  - '@id': schema:Text
+- '@id': outbreak:Product
+  '@type': rdfs:Class
+  rdfs:comment: This is the schema for describing a reagent, material, sample, or
+    some other product used in a protocol resource in outbreak.info
+  rdfs:label: Product
+  rdfs:subClassOf:
+    '@id': schema:Product
+- '@id': outbreak:Instrument
+  '@type': rdfs:Class
+  rdfs:comment: This is the schema for describing an instrument used in a protocol
+    resource listed in outbreak.info
+  rdfs:label: Instrument
+  rdfs:subClassOf:
+    '@id': schema:Product
+- '@id': outbreak:Protocol
+  '@type': rdfs:Class
+  rdfs:comment: This is the schema for describing the Protocols for outbreak.info
+    Resources.
+  rdfs:label: Protocol
+  rdfs:subClassOf:
+    '@id': schema:HowTo
+- '@id': outbreak:warning
+  '@type': rdfs:Property
+  rdfs:comment: Precautions, warnings, and/or safety warnings associated with or highlighted
+    by the protocol
+  rdfs:label: warning
   schema:domainIncludes:
-    '@id': outbreak:Analysis
+    '@id': outbreak:Protocol
   schema:rangeIncludes:
-    '@id': schema:Text
+  - '@id': schema:Text
+- '@id': outbreak:correctionNote
+  '@type': rdfs:Property
+  rdfs:comment: statement of what was updated/changed since prior version
+  rdfs:label: correctionNote
+  schema:domainIncludes:
+    '@id': outbreak:Protocol
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:protocolStatus
+  '@type': rdfs:Property
+  rdfs:comment: The status of the protocol
+  rdfs:label: protocolStatus
+  schema:domainIncludes:
+    '@id': outbreak:Protocol
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:instrument
+  '@type': rdfs:Property
+  rdfs:comment: A laboratory equipment use by a person to follow one or more steps
+    described in this Protocol
+  rdfs:label: instrument
+  schema:domainIncludes:
+    '@id': outbreak:Protocol
+  schema:rangeIncludes:
+  - '@id': outbreak:Instrument
+- '@id': outbreak:protocolSetting
+  '@type': rdfs:Property
+  rdfs:comment: The type of 'protocol' based on setting in which it would apply
+  rdfs:label: protocolSetting
+  schema:domainIncludes:
+    '@id': outbreak:Protocol
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:protocolCategory
+  '@type': rdfs:Property
+  rdfs:comment: The type of 'protocol' based on degree of specificity and purpose
+  rdfs:label: protocolCategory
+  schema:domainIncludes:
+    '@id': outbreak:Protocol
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:usedToGenerate
+  '@type': rdfs:Property
+  rdfs:comment: Type of evidence/data generated by the protocol
+  rdfs:label: usedToGenerate
+  schema:domainIncludes:
+    '@id': outbreak:Protocol
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:inComplianceWith
+  '@type': rdfs:Property
+  rdfs:comment: Guidelines or Standards to which these protocols adhere. ie- GMP,
+    GCP, other EQUATOR guidelines. Useful for selecting protocols where certain standards/guidelines
+    must be met
+  rdfs:label: inComplianceWith
+  schema:domainIncludes:
+    '@id': outbreak:Protocol
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:StudyEvent
+  '@type': rdfs:Class
+  rdfs:comment: This is the schema for describing StudyEvents, a class that describes
+    categorical events in Clinical Trials added to outbreak.info
+  rdfs:label: StudyEvent
+  rdfs:subClassOf:
+    '@id': schema:Thing
+- '@id': outbreak:studyEventType
+  '@type': rdfs:Property
+  rdfs:comment: Type of the event status such as StudyStart, PrimaryCompletion, Completion,
+    StudyFirstSubmit, StudyFirstSubmitQC, LastUpdateSubmit
+  rdfs:label: studyEventType
+  schema:domainIncludes:
+    '@id': outbreak:StudyEvent
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:studyEventDate
+  '@type': rdfs:Property
+  rdfs:comment: The corresponding/actual date of the study event (ie- the StartDate,
+    Primary CompletionDate, CompletionDate, StudyFirstSubmitDate, StudyFirstSubmitQCDate,
+    LastUpdateSubmitDate)
+  rdfs:label: studyEventDate
+  schema:domainIncludes:
+    '@id': outbreak:StudyEvent
+  schema:rangeIncludes:
+  - '@id': schema:Date
+- '@id': outbreak:studyEventDateType
+  '@type': rdfs:Property
+  rdfs:comment: the type of date provided (actual, anticipated, or estimated)
+  rdfs:label: studyEventDateType
+  schema:domainIncludes:
+    '@id': outbreak:StudyEvent
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:StudyStatus
+  '@type': rdfs:Class
+  rdfs:comment: This is the schema for describing the status of a ClinicalTrial resource
+    in outbreak.info
+  rdfs:label: StudyStatus
+  rdfs:subClassOf:
+    '@id': schema:Thing
+- '@id': outbreak:status
+  '@type': rdfs:Property
+  rdfs:comment: The recruitment status of the study
+  rdfs:label: status
+  rdfs:sameAs:
+    '@id': schema:status
+  schema:domainIncludes:
+    '@id': outbreak:StudyStatus
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:statusExpandedAccess
+  '@type': rdfs:Property
+  rdfs:comment: Flag for whether or not the study has expanded Access status
+  rdfs:label: statusExpandedAccess
+  schema:domainIncludes:
+    '@id': outbreak:StudyStatus
+  schema:rangeIncludes:
+  - '@id': schema:Boolean
+- '@id': outbreak:statusDate
+  '@type': rdfs:Property
+  rdfs:comment: The date that the status was verified. Equivalent to NCT's StatusVerifiedDate
+  rdfs:label: statusDate
+  schema:domainIncludes:
+    '@id': outbreak:StudyStatus
+  schema:rangeIncludes:
+  - '@id': schema:Date
+- '@id': outbreak:enrollmentCount
+  '@type': rdfs:Property
+  rdfs:comment: The number of participants enrolled in the study
+  rdfs:label: enrollmentCount
+  schema:domainIncludes:
+    '@id': outbreak:StudyStatus
+  schema:rangeIncludes:
+  - '@id': schema:Number
+- '@id': outbreak:enrollmentType
+  '@type': rdfs:Property
+  rdfs:comment: The type of estimation used to determine the enrollmentCount (actual
+    counts, target size, etc.)
+  rdfs:label: enrollmentType
+  schema:domainIncludes:
+    '@id': outbreak:StudyStatus
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:whyStopped
+  '@type': rdfs:Property
+  rdfs:comment: A brief explanation of the reason(s) why such clinical study was stopped
+    (for a clinical study that is Suspended, Terminated, or Withdrawn prior to its
+    planned completion as anticipated by the protocol)
+  rdfs:label: whyStopped
+  schema:domainIncludes:
+    '@id': outbreak:StudyStatus
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:StudyDesign
+  '@type': rdfs:Class
+  rdfs:comment: This is the schema for describing the study design of a clinical trial/study
+    for inclusion into outbreak.info resources
+  rdfs:label: StudyDesign
+  rdfs:subClassOf:
+    '@id': schema:Thing
+- '@id': outbreak:studyType
+  '@type': rdfs:Property
+  rdfs:comment: Type of human study, can be subtypes of observational study or interventional
+    studies and may include the temporal relationship of observation period to time
+    of participant enrollment.
+  rdfs:label: studyType
+  schema:domainIncludes:
+    '@id': outbreak:StudyDesign
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:phase
+  '@type': rdfs:Property
+  rdfs:comment: Stage or phase of the study in the U.S. if applicable
+  rdfs:label: phase
+  rdfs:sameAs:
+    '@id': schema:phase
+  schema:domainIncludes:
+    '@id': outbreak:StudyDesign
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:phaseNumber
+  '@type': rdfs:Property
+  rdfs:comment: The number of the phase or stage of the study
+  rdfs:label: phaseNumber
+  schema:domainIncludes:
+    '@id': outbreak:StudyDesign
+  schema:rangeIncludes:
+  - '@id': schema:Number
+- '@id': outbreak:designAllocation
+  '@type': rdfs:Property
+  rdfs:comment: The method by which the study participants were allocated into groups
+  rdfs:label: designAllocation
+  schema:domainIncludes:
+    '@id': outbreak:StudyDesign
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:designModel
+  '@type': rdfs:Property
+  rdfs:comment: The general design of the strategy for assigning interventions to
+    participants in a clinical intervention study OR the general design of the strategy
+    for identifying and following up with participants during an observational study
+  rdfs:label: designModel
+  schema:domainIncludes:
+    '@id': outbreak:StudyDesign
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:designPrimaryPurpose
+  '@type': rdfs:Property
+  rdfs:comment: The primary purpose of the study
+  rdfs:label: designPrimaryPurpose
+  schema:domainIncludes:
+    '@id': outbreak:StudyDesign
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:designWhoMasked
+  '@type': rdfs:Property
+  rdfs:comment: The people who do not know which participants have been assigned to
+    which interventions
+  rdfs:label: designWhoMasked
+  schema:domainIncludes:
+    '@id': outbreak:StudyDesign
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:designStudyText
+  '@type': rdfs:Property
+  rdfs:comment: String description of the study design if structured information not
+    available
+  rdfs:label: designStudyText
+  schema:domainIncludes:
+    '@id': outbreak:StudyDesign
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:Intervention
+  '@type': rdfs:Class
+  rdfs:comment: a schema to describe Interventions discussed in Clinical Studies/Trials
+    for inclusion in outbreak.info Resources
+  rdfs:label: Intervention
+  rdfs:subClassOf:
+    '@id': schema:Thing
+- '@id': outbreak:category
+  '@type': rdfs:Property
+  rdfs:comment: The category of an intervention in the study
+  rdfs:label: category
+  schema:domainIncludes:
+    '@id': outbreak:Intervention
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:ArmGroup
+  '@type': rdfs:Class
+  rdfs:comment: This is the schema for describing arm groups in clinical studies/trials
+    for inclusion in outbreak.info Resources
+  rdfs:label: ArmGroup
+  rdfs:subClassOf:
+    '@id': schema:Thing
+- '@id': outbreak:intervention
+  '@type': rdfs:Property
+  rdfs:comment: The interventions (if any) in this ArmGroup
+  rdfs:label: intervention
+  schema:domainIncludes:
+    '@id': outbreak:ArmGroup
+  schema:rangeIncludes:
+  - '@id': outbreak:Intervention
+- '@id': outbreak:Outcome
+  '@type': rdfs:Class
+  rdfs:comment: This is the schema for describing a Clinical Trial/Study Outcome for
+    inclusion in  outbreak.info Resources
+  rdfs:label: Outcome
+  rdfs:subClassOf:
+    '@id': schema:Thing
+- '@id': outbreak:outcomeMeasure
+  '@type': rdfs:Property
+  rdfs:comment: The outcome measure for the study
+  rdfs:label: outcomeMeasure
+  schema:domainIncludes:
+    '@id': outbreak:Outcome
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:outcomeTimeFrame
+  '@type': rdfs:Property
+  rdfs:comment: The specific time point(s) and overall duration of evaluation must
+    be specified in this section
+  rdfs:label: outcomeTimeFrame
+  schema:domainIncludes:
+    '@id': outbreak:Outcome
+  schema:rangeIncludes:
+  - '@id': schema:Duration
+  - '@id': schema:Text
+- '@id': outbreak:outcomeType
+  '@type': rdfs:Property
+  rdfs:comment: The classification of the outcome measure as either primary, secondary,
+    or exploratory
+  rdfs:label: outcomeType
+  schema:domainIncludes:
+    '@id': outbreak:Outcome
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:Eligibility
+  '@type': rdfs:Class
+  rdfs:comment: This is the schema for describing information about Clinical Trials/Studies
+    eligibility criteria for inclusion in outbreak.info Resources
+  rdfs:label: Eligibility
+  rdfs:subClassOf:
+    '@id': schema:Thing
+- '@id': outbreak:inclusionCriteria
+  '@type': rdfs:Property
+  rdfs:comment: '"criteria for inclusion in the study'
+  rdfs:label: inclusionCriteria
+  schema:domainIncludes:
+    '@id': outbreak:Eligibility
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:minimumAge
+  '@type': rdfs:Property
+  rdfs:comment: the minimum age for a participant to be included in the study
+  rdfs:label: minimumAge
+  schema:domainIncludes:
+    '@id': outbreak:Eligibility
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:maximumAge
+  '@type': rdfs:Property
+  rdfs:comment: the maximum age for a participant to be included in the study
+  rdfs:label: maximumAge
+  schema:domainIncludes:
+    '@id': outbreak:Eligibility
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:gender
+  '@type': rdfs:Property
+  rdfs:comment: the sex requirement to be included in the study
+  rdfs:label: gender
+  schema:domainIncludes:
+    '@id': outbreak:Eligibility
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:genderBased
+  '@type': rdfs:Property
+  rdfs:comment: Boolean for whether or not participation is based on gender
+  rdfs:label: genderBased
+  schema:domainIncludes:
+    '@id': outbreak:Eligibility
+  schema:rangeIncludes:
+  - '@id': schema:Boolean
+- '@id': outbreak:healthyVolunteers
+  '@type': rdfs:Property
+  rdfs:comment: Boolean to indicate whether or not healthy volunteers may be included
+    in the study
+  rdfs:label: healthyVolunteers
+  schema:domainIncludes:
+    '@id': outbreak:Eligibility
+  schema:rangeIncludes:
+  - '@id': schema:Boolean
+- '@id': outbreak:stdAge
+  '@type': rdfs:Property
+  rdfs:comment: the age category of a participant to be included in the study if a
+    minimum and maximum age is not specified
+  rdfs:label: stdAge
+  schema:domainIncludes:
+    '@id': outbreak:Eligibility
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:exclusionCriteria
+  '@type': rdfs:Property
+  rdfs:comment: criteria for exclusion from the study
+  rdfs:label: exclusionCriteria
+  schema:domainIncludes:
+    '@id': outbreak:Eligibility
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:criteriaText
+  '@type': rdfs:Property
+  rdfs:comment: The descriptive criteria as published for the Clinical Trial
+  rdfs:label: criteriaText
+  schema:domainIncludes:
+    '@id': outbreak:Eligibility
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:StudyLocation
+  '@type': rdfs:Class
+  rdfs:comment: This is the schema for describing Clinical Trial/Study locations for
+    inclusion in outbreak.info Resources
+  rdfs:label: StudyLocation
+  rdfs:subClassOf:
+    '@id': schema:Place
+- '@id': outbreak:studyLocation
+  '@type': rdfs:Property
+  rdfs:comment: The location of the study
+  rdfs:label: studyLocation
+  schema:domainIncludes:
+    '@id': outbreak:StudyLocation
+  schema:rangeIncludes:
+  - '@id': schema:Place
+  - '@id': schema:Text
+- '@id': outbreak:studyLocationCity
+  '@type': rdfs:Property
+  rdfs:comment: The city in which the facility used for the study is located
+  rdfs:label: studyLocationCity
+  schema:domainIncludes:
+    '@id': outbreak:StudyLocation
+  schema:rangeIncludes:
+  - '@id': schema:City
+  - '@id': schema:Text
+- '@id': outbreak:studyLocationState
+  '@type': rdfs:Property
+  rdfs:comment: The state or province in which the facility used for the study is
+    located
+  rdfs:label: studyLocationState
+  schema:domainIncludes:
+    '@id': outbreak:StudyLocation
+  schema:rangeIncludes:
+  - '@id': schema:State
+  - '@id': schema:Text
+- '@id': outbreak:studyLocationCountry
+  '@type': rdfs:Property
+  rdfs:comment: The country in which the facility used for the study is located
+  rdfs:label: studyLocationCountry
+  schema:domainIncludes:
+    '@id': outbreak:StudyLocation
+  schema:rangeIncludes:
+  - '@id': schema:Country
+  - '@id': schema:Text
+- '@id': outbreak:studyLocationStatus
+  '@type': rdfs:Property
+  rdfs:comment: The recruitment status of the study at the specific study site
+  rdfs:label: studyLocationStatus
+  schema:domainIncludes:
+    '@id': outbreak:StudyLocation
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:ClinicalTrial
+  '@type': rdfs:Class
+  rdfs:comment: This is the schema for describing the Clinical Trials and other medical
+    studies used for outbreak.info Resources
+  rdfs:label: ClinicalTrial
+  rdfs:subClassOf:
+    '@id': schema:MedicalStudy
+- '@id': outbreak:identifierSource
+  '@type': rdfs:Property
+  rdfs:comment: Source of identifier assignment or type of identifier (NCTid, China
+    CTRid, EudraCT Number, etc.)
+  rdfs:label: identifierSource
+  schema:domainIncludes:
+    '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:dateModifiedType
+  '@type': rdfs:Property
+  rdfs:comment: The type of date. Equivalent to NCT's LastUpdatePostDateType
+  rdfs:label: dateModifiedType
+  schema:domainIncludes:
+    '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:healthConditionIdentifier
+  '@type': rdfs:Property
+  rdfs:comment: Ontological or controlled vocabulary identifier for the health condition
+    or disease
+  rdfs:label: healthConditionIdentifier
+  schema:domainIncludes:
+    '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': schema:Text
+  - '@id': schema:DefinedTerm
+- '@id': outbreak:hasResults
+  '@type': rdfs:Property
+  rdfs:comment: Boolean for if the clinical trial has published any results
+  rdfs:label: hasResults
+  schema:domainIncludes:
+    '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': schema:Boolean
+- '@id': outbreak:studyEvent
+  '@type': rdfs:Property
+  rdfs:comment: an event status such as StudyStart, PrimaryCompletion, Completion,
+    StudyFirstSubmit, StudyFirstSubmitQC, LastUpdateSubmit
+  rdfs:label: studyEvent
+  schema:domainIncludes:
+    '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': outbreak:StudyEvent
+- '@id': outbreak:studyStatus
+  '@type': rdfs:Property
+  rdfs:comment: The status of the study
+  rdfs:label: studyStatus
+  schema:domainIncludes:
+    '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': outbreak:StudyStatus
+- '@id': outbreak:studyDesign
+  '@type': rdfs:Property
+  rdfs:comment: The general design of the study
+  rdfs:label: studyDesign
+  schema:domainIncludes:
+    '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': outbreak:StudyDesign
+- '@id': outbreak:armGroup
+  '@type': rdfs:Property
+  rdfs:comment: The arm or factor of an interventional study
+  rdfs:label: armGroup
+  schema:domainIncludes:
+    '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': outbreak:ArmGroup
+- '@id': outbreak:outcome
+  '@type': rdfs:Property
+  rdfs:comment: The arm or factor of an interventional study
+  rdfs:label: outcome
+  schema:domainIncludes:
+    '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': outbreak:Outcome
+- '@id': outbreak:eligibilityCriteria
+  '@type': rdfs:Property
+  rdfs:comment: eligibility criteria
+  rdfs:label: eligibilityCriteria
+  schema:domainIncludes:
+    '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': outbreak:Eligibility
 - '@id': outbreak:author
-  '@type': rdf:Property
-  marginality: required
-  owl:cardinality: many
-  rdfs:comment: The author of this content or rating.
+  '@type': rdfs:Property
+  rdfs:comment: The author of this resource, content, or rating
   rdfs:label: author
   rdfs:sameAs:
     '@id': schema:author
   schema:domainIncludes:
-    '@id': outbreak:Analysis
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Protocol
+  - '@id': outbreak:Publication
+  - '@id': outbreak:ClinicalTrial
   schema:rangeIncludes:
   - '@id': outbreak:Person
   - '@id': outbreak:Organization
-- '@id': outbreak:name
-  '@type': rdf:Property
-  marginality: required
-  owl:cardinality: one
-  rdfs:comment: The name of the author as provided by the resource
-  rdfs:label: name
+- '@id': outbreak:dateCreated
+  '@type': rdfs:Property
+  rdfs:comment: Date the record was created
+  rdfs:label: dateCreated
   rdfs:sameAs:
-    '@id': schema:name
+    '@id': schema:dateCreated
   schema:domainIncludes:
-  - '@id': outbreak:Person
-  - '@id': outbreak:Organization
+  - '@id': outbreak:ClinicalTrial
   schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:affiliation
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: The affiliation of the author
-  rdfs:label: affiliation
-  rdfs:sameAs:
-    '@id': schema:affiliation
-  schema:domainIncludes:
-  - '@id': outbreak:Person
-  - '@id': outbreak:Organization
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:funding
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: Funding for the generation of the analysis
-  rdfs:label: funding
-  rdfs:sameAs:
-    '@id': outbreak:MonetaryGrant
-  schema:domainIncludes:
-    '@id': outbreak:Analysis
-  schema:rangeIncludes:
-    '@id': outbreak:MonetaryGrant
-- '@id': outbreak:funder
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: The funder of the analysis
-  rdfs:label: funder
-  rdfs:sameAs:
-    '@id': schema:funder
-  schema:domainIncludes:
-    '@id': outbreak:MonetaryGrant
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:identifier
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: The identifier of the grant (if available)
-  rdfs:label: identifier
-  rdfs:sameAs:
-    '@id': schema:identifier
-  schema:domainIncludes:
-    '@id': outbreak:MonetaryGrant
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:hasDownloadableContent
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: Indicates the site has content that can be downloaded (raw data, data
-    sheets, charts, etc)
-  rdfs:label: hasDownloadableContent
-  rdfs:sameAs:
-    '@id': schema:isAccessibleForFree
-  schema:domainIncludes:
-    '@id': outbreak:Analysis
-  schema:rangeIncludes:
-    '@id': schema:Boolean
-- '@id': outbreak:infectiousAgent
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: The actual infectious agent, such as a specific bacterium
-  rdfs:label: infectiousAgent
-  rdfs:sameAs:
-    '@id': schema:infectiousAgent
-  schema:domainIncludes:
-    '@id': outbreak:Analysis
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:infectiousDisease
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: The disease caused by the infectious agent. Important as some agents
-    may cause multiple diseases
-  rdfs:label: infectiousDisease
-  rdfs:sameAs:
-    '@id': schema:infectousDisease
-  schema:domainIncludes:
-    '@id': outbreak:Analysis
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:license
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: A license document that applies to this content, typically indicated
-    by URL
-  rdfs:label: license
-  rdfs:sameAs:
-    '@id': schema:license
-  schema:domainIncludes:
-    '@id': outbreak:Analysis
-  schema:rangeIncludes:
-    '@id': schema:Text
+  - '@id': schema:Date
 - '@id': outbreak:datePublished
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: PublicationDate of the analysis online if available
+  '@type': rdfs:Property
+  rdfs:comment: Date of first broadcast/publication
   rdfs:label: datePublished
   rdfs:sameAs:
     '@id': schema:datePublished
   schema:domainIncludes:
-    '@id': outbreak:Analysis
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Protocol
+  - '@id': outbreak:Publication
+  - '@id': outbreak:ClinicalTrial
   schema:rangeIncludes:
-    '@id': schema:Date
+  - '@id': schema:Date
 - '@id': outbreak:dateModified
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: Most recent date for which the analysis model itself was updated
+  '@type': rdfs:Property
+  rdfs:comment: The date on which the CreativeWork was most recently modified or when
+    the item's entry was modified within a DataFeed
   rdfs:label: dateModified
   rdfs:sameAs:
     '@id': schema:dateModified
   schema:domainIncludes:
-    '@id': outbreak:Analysis
-  schema:rangeIncludes:
-    '@id': schema:Date
-- '@id': outbreak:analysisTechnique
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: This is the analysis type, analytical technique or mathematical model
-    used in this analysis
-  rdfs:label: analysisTechnique
-  rdfs:sameAs:
-    '@id': schema:additionalType
-  schema:domainIncludes:
-    '@id': outbreak:Analysis
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:analysisTopic
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: The underlying question, goal, or aim of the analysis
-  rdfs:label: analysisTopic
-  rdfs:sameAs:
-    '@id': schema:purpose
-  schema:domainIncludes:
-    '@id': outbreak:Analysis
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:assumption
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: Statement of assumptions / limitations of the model
-  rdfs:label: assumption
-  rdfs:sameAs:
-    '@id': schema:text
-  schema:domainIncludes:
-    '@id': outbreak:Analysis
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:citedBy
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: many
-  owl:inverseOf:
-    '@id': schema:isBasedOn
-  rdfs:comment: A resource (publication, protocol, dataset, etc.) which was derived
-    from this protocol
-  rdfs:label: citedBy
-  schema:domainIncludes:
-    '@id': outbreak:Analysis
-  schema:rangeIncludes:
-  - '@id': outbreak:ClinicalTrial
   - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
   - '@id': outbreak:Dataset
   - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-- '@id': outbreak:name
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: name of the citedBy resource
-  rdfs:label: name
-  rdfs:sameAs:
-    '@id': schema:name
-  schema:domainIncludes:
-  - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
   - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:type
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: type (publication, protocol, dataset, code, etc.) of the citedBy resource
-  rdfs:label: type
-  rdfs:sameAs:
-    '@id': schema:additionalType
-  schema:domainIncludes:
   - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
   schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:identifier
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: identifier (pmid, WHO protocol id, etc.) of the citedby resource
-  rdfs:label: identifier
-  rdfs:sameAs:
-    '@id': schema:identifier
-  schema:domainIncludes:
-  - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:isBasedOn
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: many
-  rdfs:comment: A resource (publication, protocol, dataset, etc) from which this analysis
-    was derived
-  rdfs:label: isBasedOn
-  rdfs:sameAs:
-    '@id': schema:isBasedOn
-  schema:domainIncludes:
-    '@id': outbreak:Analysis
-  schema:rangeIncludes:
-  - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-- '@id': outbreak:name
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: name of the isBasedOn resource
-  rdfs:label: name
-  rdfs:sameAs:
-    '@id': schema:name
-  schema:domainIncludes:
-  - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:type
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: type (publication, protocol, dataset, code, etc.) of the isBasedOn
-    resource
-  rdfs:label: type
-  rdfs:sameAs:
-    '@id': schema:additionalType
-  schema:domainIncludes:
-  - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:identifier
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: identifier (pmid, WHO protocol id, etc.) of the isBasedOn resource
-  rdfs:label: identifier
-  rdfs:sameAs:
-    '@id': schema:identifier
-  schema:domainIncludes:
-  - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:versionDate
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: date of the version of the resource from which this analysis was derived.
-    Note this is NOT the same as dateModified, as the protocol may be based on an
-    earlier 'dateModified' than is what is available from the resource
-  rdfs:label: versionDate
-  rdfs:sameAs:
-    '@id': schema:releaseDate
-  schema:domainIncludes:
-  - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-  schema:rangeIncludes:
-    '@id': schema:Date
-- '@id': outbreak:relatedTo
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: many
-  rdfs:comment: Other resources related to, but not a derivative of nor derived from
-    this analysis
-  rdfs:label: relatedTo
-  rdfs:sameAs:
-    '@id': schema:relatedTo
-  schema:domainIncludes:
-    '@id': outbreak:Analysis
-  schema:rangeIncludes:
-  - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-- '@id': outbreak:name
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: name of related resource
-  rdfs:label: name
-  rdfs:sameAs:
-    '@id': schema:name
-  schema:domainIncludes:
-  - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:type
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: type of related resource
-  rdfs:label: type
-  rdfs:sameAs:
-    '@id': schema:additionalType
-  schema:domainIncludes:
-  - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:identifier
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: identifier (if available) of related resource
-  rdfs:label: identifier
-  rdfs:sameAs:
-    '@id': schema:identifier
-  schema:domainIncludes:
-  - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:contributor
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: many
-  rdfs:comment: A secondary contributor to the CreativeWork or Event.
-  rdfs:label: contributor
-  rdfs:sameAs:
-    '@id': schema:contributor
-  schema:domainIncludes:
-    '@id': outbreak:Analysis
-  schema:rangeIncludes:
-    '@id': outbreak:author
-- '@id': outbreak:maintainer
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: many
-  rdfs:comment: A maintainer of a Dataset, software package (SoftwareApplication),
-    or other Project.
-  rdfs:label: maintainer
-  rdfs:sameAs:
-    '@id': schema:maintainer
-  schema:domainIncludes:
-    '@id': outbreak:Analysis
-  schema:rangeIncludes:
-    '@id': outbreak:author
+  - '@id': schema:Date
 - '@id': outbreak:keywords
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: keywords
+  '@type': rdfs:Property
+  rdfs:comment: keywords for describing the record
   rdfs:label: keywords
-  rdfs:sameAs:
-    '@id': schema:keywords
   schema:domainIncludes:
-    '@id': outbreak:Analysis
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Protocol
+  - '@id': outbreak:Publication
+  - '@id': outbreak:ClinicalTrial
   schema:rangeIncludes:
-    '@id': schema:Text
+  - '@id': schema:Text
+- '@id': outbreak:abstract
+  '@type': rdfs:Property
+  rdfs:comment: A short descriptive summary of the publication or study
+  rdfs:label: abstract
+  rdfs:sameAs:
+    '@id': schema:abstract
+  schema:domainIncludes:
+  - '@id': outbreak:Publication
+  - '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:pmid
+  '@type': rdfs:Property
+  rdfs:comment: A pubmed identifier if available
+  rdfs:label: pmid
+  schema:domainIncludes:
+  - '@id': outbreak:CitationObject
+  - '@id': outbreak:Correction
+  - '@id': outbreak:Publication
+  schema:rangeIncludes:
+  - '@id': schema:Integer
+- '@id': outbreak:doi
+  '@type': rdfs:Property
+  rdfs:comment: A doi if available
+  rdfs:label: doi
+  schema:domainIncludes:
+  - '@id': outbreak:CitationObject
+  - '@id': outbreak:Correction
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Publication
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Protocol
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:funding
+  '@type': rdfs:Property
+  rdfs:comment: Funding that supports (sponsors) the collection of this dataset through
+    some kind of financial contribution
+  rdfs:label: funding
+  schema:domainIncludes:
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Publication
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Protocol
+  - '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': schema:MonetaryGrant
+- '@id': outbreak:measurementTechnique
+  '@type': rdfs:Property
+  rdfs:comment: A technique or technology used in this resource
+  rdfs:label: measurementTechnique
+  rdfs:sameAs:
+    '@id': schema:measurementTechnique
+  schema:domainIncludes:
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Protocol
+  schema:rangeIncludes:
+  - '@id': schema:Text
+  - '@id': schema:DefinedTerm
+- '@id': outbreak:species
+  '@type': rdfs:Property
+  rdfs:comment: Species(es) from which dataset has been collected
+  rdfs:label: species
+  schema:domainIncludes:
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Analysis
+  schema:rangeIncludes:
+  - '@id': schema:Text
+  - '@id': schema:DefinedTerm
+- '@id': outbreak:infectiousAgent
+  '@type': rdfs:Property
+  rdfs:comment: infectious agents(s) which are the focus of the dataset
+  rdfs:label: infectiousAgent
+  schema:domainIncludes:
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Analysis
+  schema:rangeIncludes:
+  - '@id': schema:Text
+  - '@id': schema:DefinedTerm
+- '@id': outbreak:infectiousDisease
+  '@type': rdfs:Property
+  rdfs:comment: The disease or medical conditions caused by the infectious agent.
+    Important as some agents may cause multiple diseases
+  rdfs:label: infectiousDisease
+  schema:domainIncludes:
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Analysis
+  schema:rangeIncludes:
+  - '@id': schema:Text
+  - '@id': schema:DefinedTerm
 - '@id': outbreak:topicCategory
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
+  '@type': rdfs:Property
   rdfs:comment: Applicable outbreak.info category
   rdfs:label: topicCategory
-  rdfs:sameAs:
-    '@id': schema:about
   schema:domainIncludes:
-    '@id': outbreak:Analysis
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Publication
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Protocol
+  - '@id': outbreak:ClinicalTrial
   schema:rangeIncludes:
-    '@id': schema:Text
+  - '@id': schema:Text
+- '@id': outbreak:isBasedOn
+  '@type': rdfs:Property
+  rdfs:comment: A citation to a resource (eg- publication, protocol, etc.) on which
+    this resource was derived (stored as an object, not a string)
+  rdfs:label: isBasedOn
+  schema:domainIncludes:
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Publication
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Protocol
+  - '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': outbreak:CitationObject
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Publication
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Protocol
+  - '@id': outbreak:ClinicalTrial
+  - '@id': schema:SoftwareApplication
+  - '@id': schema:CreativeWork
+- '@id': outbreak:isRelatedTo
+  '@type': rdfs:Property
+  rdfs:comment: A citation to a resource (eg- publication, protocol, etc.) which is
+    related to the resource but is not a derivative nor was derived from the resource
+    (stored as an object, not a string)
+  rdfs:label: isRelatedTo
+  schema:domainIncludes:
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Publication
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Protocol
+  - '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': outbreak:CitationObject
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Publication
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Protocol
+  - '@id': outbreak:ClinicalTrial
+  - '@id': schema:SoftwareApplication
+  - '@id': schema:CreativeWork
+- '@id': outbreak:citedBy
+  '@type': rdfs:Property
+  rdfs:comment: A citation to a resource (eg- publication, protocol, etc.) which is
+    derived from this resource (stored as an object, not a string)
+  rdfs:label: citedBy
+  rdfs:sameAs:
+    '@id': 'owl:inverseOf: outbreak:isBasedOn'
+  schema:domainIncludes:
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Publication
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Protocol
+  - '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': outbreak:CitationObject
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Publication
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Protocol
+  - '@id': outbreak:ClinicalTrial
+  - '@id': schema:SoftwareApplication
+  - '@id': schema:CreativeWork
 - '@id': outbreak:curatedBy
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  owl:inverseOf:
-    '@id': schema:isBasedOn
-  rdfs:comment: The source from which this Analysis was identified for inclusion into
-    Outbreak.info. Provides provenance for a resource which was curated by another
+  '@type': rdfs:Property
+  rdfs:comment: The source from which this Dataset was identified for inclusion into
+    Outbreak.info. Provides provenance for a resource which was curated by another.
   rdfs:label: curatedBy
   schema:domainIncludes:
-    '@id': outbreak:Analysis
-  schema:rangeIncludes:
-  - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
   - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-- '@id': outbreak:name
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: name of the source from which this Analysis was identified for inclusion
-  rdfs:label: name
-  rdfs:sameAs:
-    '@id': schema:name
-  schema:domainIncludes:
-  - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
   - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:url
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The corresponding url for the item in the source from which this Analysis
-    was identified (if available)
-  rdfs:label: url
-  rdfs:sameAs:
-    '@id': schema:url
-  schema:domainIncludes:
-  - '@id': outbreak:ClinicalTrial
   - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
   - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:versionDate
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: The last date when items were pulled from the source
-  rdfs:label: versionDate
-  rdfs:sameAs:
-    '@id': schema:releaseDate
-  schema:domainIncludes:
   - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
   schema:rangeIncludes:
-    '@id': schema:Date
+  - '@id': outbreak:Person
+  - '@id': outbreak:Organization
+  - '@id': outbreak:CitationObject
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Publication
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Protocol
+  - '@id': outbreak:ClinicalTrial
+  - '@id': schema:SoftwareApplication
+  - '@id': schema:CreativeWork
 - '@id': outbreak:curationDate
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The date this resource was added to outbreak.info, or the date when
-    this resource was updated in outbreak.info
+  '@type': rdfs:Property
+  rdfs:comment: The date this resource was added into outbreak.info, or was updated
+    in outbreak.info.
   rdfs:label: curationDate
-  rdfs:sameAs:
-    '@id': schema:releaseDate
   schema:domainIncludes:
-    '@id': outbreak:Analysis
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Publication
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Protocol
+  - '@id': outbreak:ClinicalTrial
   schema:rangeIncludes:
-    '@id': schema:Date
-- '@id': outbreak:Dataset
-  '@type': rdfs:Class
-  rdfs:comment: This is the schema for describing the Dataset schema used for outbreak.info.
-  rdfs:label: Dataset
-  rdfs:subClassOf:
-    '@id': schema:Dataset
-  schema:isPartOf:
-    '@id': https://discovery.biothings.io/view/outbreak/
-- '@id': outbreak:Protocol
-  '@type': rdfs:Class
-  rdfs:comment: This is the schema for describing the Protocol schema used for outbreak.info.
-  rdfs:label: Protocol
-  rdfs:subClassOf:
-    '@id': schema:HowTo
-  schema:isPartOf:
-    '@id': https://discovery.biothings.io/view/outbreak/
-- '@id': outbreak:Publication
-  '@type': rdfs:Class
-  rdfs:comment: This is the schema for describing the Publication schema used for
-    outbreak.info.
-  rdfs:label: Publication
-  rdfs:subClassOf:
-    '@id': schema:ScholarlyArticle
-  schema:isPartOf:
-    '@id': https://discovery.biothings.io/view/outbreak/
-- '@id': outbreak:ClinicalTrial
-  '@type': rdfs:Class
-  rdfs:comment: This is the schema for describing the ClinicalTrial schema used for
-    outbreak.info.
-  rdfs:label: ClinicalTrial
-  rdfs:subClassOf:
-    '@id': schema:MedicalStudy
-  schema:isPartOf:
-    '@id': https://discovery.biothings.io/view/outbreak/
-'@id': https://discovery.biothings.io/view/outbreak/
+  - '@id': schema:Date
+- '@id': outbreak:evaluations
+  '@type': rdf:Property
+  rdfs:comment: One or more reviews, ratings, or other evaluations of this resource
+  rdfs:label: evaluations
+  schema:domainIncludes:
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Publication
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Protocol
+  - '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': schema:Review
+  - '@id': schema:Rating
+  - '@id': schema:AggregateRating

--- a/yaml/outbreak_ClinicalTrial.json
+++ b/yaml/outbreak_ClinicalTrial.json
@@ -1,238 +1,2008 @@
 {
   "@context": {
-    "outbreak": "https://discovery.biothings.io/view/outbreak/",
-    "owl": "http://www.w3.org/2002/07/owl/",
-    "rdf": "http://www.w3.org/1999/02/22/-rdf-syntax-ns/",
-    "rdfs": "http://www.w3.org/2000/01/rdf/-schema/",
-    "schema": "http://schema.org/"
+    "schema": "http://schema.org/",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "outbreak": "http://discovery.biothings.io/view/"
   },
-  "@id": "https://discovery.biothings.io/view/outbreak/",
   "@graph": [
-    {
-      "@id": "outbreak:Organization",
-      "@type": "rdfs:Class",
-      "rdfs:label": "Organization",
-      "rdfs:comment": "This is the schema for describing the Organization schema used for outbreak.info.",
-      "rdfs:subClassOf": {
-        "@id": "schema:Organization"
-      },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
-      }
-    },
-    {"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"The name of the organization, team or group","rdfs:label":"name","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":{"@id":"outbreak:Organization"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:alternateName","@type":"rdf:Property","rdfs:comment":"Alternative names or commonly used abbreviations for the organization, team or group","rdfs:label":"alternateName","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:alternateName"},"schema:domainIncludes":{"@id":"outbreak:Organization"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:affiliation","@type":"rdf:Property","rdfs:comment":"An overarching consortia, multi-institutional team or group in which the organization\/team\/group is a member or affiliate","rdfs:label":"affiliation","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:affiliation"},"schema:domainIncludes":{"@id":"outbreak:Organization"},"schema:rangeIncludes":{"@id":"outbreak:Organization"}},{"@id":"outbreak:affiliationStatus","@type":"rdf:Property","rdfs:comment":"The status of the organization's membership or affiliation in the overarching consortial, multi-institutional team or group (current, past)","rdfs:label":"affiliationStatus","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":{"@id":"outbreak:Organization"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:members","@type":"rdf:Property","rdfs:comment":"Members of this organization, team, or group","rdfs:label":"members","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:members"},"schema:domainIncludes":{"@id":"outbreak:Organization"},"schema:rangeIncludes":[{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"}]},{"@id":"outbreak:membershipStatus","@type":"rdf:Property","rdfs:comment":"Status of the members of this organization","rdfs:label":"membershipStatus","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":{"@id":"outbreak:Organization"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:isRelatedTo","@type":"rdf:Property","rdfs:comment":"A resource which a person played a role","rdfs:label":"isRelatedTo","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:isRelatedTo"},"schema:domainIncludes":{"@id":"outbreak:Organization"},"schema:rangeIncludes":[{"@id":"schema:CreativeWork"},{"@id":"schema:HowTo"}]},{"@id":"outbreak:class","@type":"rdf:Property","rdfs:comment":"A classification of the organization by a resource. Eg- for ClinicalTrials funders, it's [\"U.S. National Institutes of Health\", \"Other U.S. Federal agencies\", \"Industry\", \"All others\"]","rdfs:label":"class","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":[{"@id":"schema:CreativeWork"},{"@id":"schema:HowTo"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:role","@type":"rdf:Property","rdfs:comment":"The role of an organization in its involvement with a resource","rdfs:label":"role","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":[{"@id":"schema:CreativeWork"},{"@id":"schema:HowTo"}],"schema:rangeIncludes":{"@id":"schema:Text"}},
     {
       "@id": "outbreak:Person",
       "@type": "rdfs:Class",
+      "rdfs:comment": "This is the Person schema for describing authors and people for outbreak.info resources",
       "rdfs:label": "Person",
-      "rdfs:comment": "This is the schema for describing the Person schema used for outbreak.info.",
       "rdfs:subClassOf": {
         "@id": "schema:Person"
       },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
+      "$validation": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "The name of the person.",
+            "type": "string"
+          },
+          "alternateName": {
+            "description": "An alias for the person.",
+            "type": "string"
+          },
+          "familyName": {
+            "description": "Family name. In the U.S., the last name of an Person. This can be used along with givenName instead of the name property.",
+            "type": "string"
+          },
+          "givenName": {
+            "description": "Given name. In the U.S., the first name of a Person. This can be used along with familyName instead of the name property.",
+            "type": "string"
+          },
+          "affiliation": {
+            "description": "An organization that this person is affiliated with. For example, a school/university, a club, or a team.",
+            "oneOf": [
+              {
+                "$ref": "#/definitions/baseOrgObject"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/baseOrgObject"
+                }
+              }
+            ]
+          },
+          "orcid": {
+            "description": "the ORCID ID of the person",
+            "type": "string"
+          },
+          "role": {
+            "description": "authorship, sponsorship, or other contribution role played by the person or organization in the creation of this resource",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            ]
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "definitions":{
+            "baseOrgObject": {
+                "@type": "outbreak:Organization",
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "alternateName": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ]   
+            }
+        }
       }
     },
-    {"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"The name of the person","rdfs:label":"name","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":{"@id":"outbreak:Person"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:alternateName","@type":"rdf:Property","rdfs:comment":"Alternative ways in which the person's name is included in a record","rdfs:label":"alternateName","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:alternateName"},"schema:domainIncludes":{"@id":"outbreak:Person"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:givenName","@type":"rdf:Property","rdfs:comment":"The given name of the person","rdfs:label":"givenName","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:givenName"},"schema:domainIncludes":{"@id":"outbreak:Person"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:familyName","@type":"rdf:Property","rdfs:comment":"The family name of the person","rdfs:label":"familyName","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:familyName"},"schema:domainIncludes":{"@id":"outbreak:Person"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:affiliation","@type":"rdf:Property","rdfs:comment":"The organization with which the person is affiliated or has membership in","rdfs:label":"affiliation","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:affiliation"},"schema:domainIncludes":{"@id":"outbreak:Person"},"schema:rangeIncludes":{"@id":"outbreak:Organization"}},{"@id":"outbreak:affiliationStatus","@type":"rdf:Property","rdfs:comment":"The status of the person's membership or affiliation in an organization, team or group (current, past)","rdfs:label":"affiliationStatus","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":{"@id":"outbreak:Person"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:orcid","@type":"rdf:Property","rdfs:comment":"The ORCID ID of the person","rdfs:label":"orcid","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":{"@id":"outbreak:Person"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:isRelatedTo","@type":"rdf:Property","rdfs:comment":"A resource which a person played a role","rdfs:label":"isRelatedTo","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:isRelatedTo"},"schema:domainIncludes":{"@id":"outbreak:Person"},"schema:rangeIncludes":[{"@id":"schema:CreativeWork"},{"@id":"schema:HowTo"}]},{"@id":"outbreak:role","@type":"rdf:Property","rdfs:comment":"The role a person played in the creation of a resource","rdfs:label":"role","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":[{"@id":"schema:CreativeWork"},{"@id":"schema:HowTo"}],"schema:rangeIncludes":{"@id":"schema:Text"}},
     {
-      "@id": "outbreak:StudyEvent",
-      "@type": "rdfs:Class",
-      "rdfs:label": "StudyEvent",
-      "rdfs:comment": "This is the schema for describing the StudyEvent schema used for outbreak.info.",
-      "rdfs:subClassOf": {
-        "@id": "schema:Thing"
+      "@id": "outbreak:orcid",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "the ORCID ID of the person",
+      "rdfs:label": "orcid",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Person"
       },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
-      }
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
     },
-      {"@id":"outbreak:studyEventType","@type":"rdf:Property","rdfs:comment":"Type of the event status such as StudyStart, PrimaryCompletion, Completion, StudyFirstSubmit, StudyFirstSubmitQC, LastUpdateSubmit","rdfs:label":"studyEventType","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":{"@id":"outbreak:StudyEvent"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:studyEventDate","@type":"rdf:Property","rdfs:comment":"StartDate, Primary CompletionDate, CompletionDate, StudyFirstSubmitDate, StudyFirstSubmitQCDate, LastUpdateSubmitDate","rdfs:label":"studyEventDate","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:temporal"},"schema:domainIncludes":{"@id":"outbreak:StudyEvent"},"schema:rangeIncludes":{"@id":"schema:Date"}},{"@id":"outbreak:studyEventDateType","@type":"rdf:Property","rdfs:comment":"the type of date provided (actual, anticipated, or estimated)","rdfs:label":"studyEventDateType","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":{"@id":"outbreak:StudyEvent"},"schema:rangeIncludes":{"@id":"schema:Text"}},
     {
-      "@id": "outbreak:StudyStatus",
+      "@id": "outbreak:Organization",
       "@type": "rdfs:Class",
-      "rdfs:label": "StudyStatus",
-      "rdfs:comment": "This is the schema for describing the StudyStatus schema used for outbreak.info.",
+      "rdfs:comment": "This is the organization schema for describing authors, funders and other organizations referenced by outbreak.info resources",
+      "rdfs:label": "Organization",
       "rdfs:subClassOf": {
-        "@id": "schema:Thing"
+        "@id": "schema:Organization"
       },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
+      "$validation": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "The name of the organization.",
+            "type": "string"
+          },
+          "alternateName": {
+            "description": "An alias or acronym for the organization.",
+            "type": "string"
+          },
+          "affiliation": {
+            "description": "consortia or other organizations with which this organization is affiliated",
+            "oneOf": [
+              {
+                "$ref": "#/definitions/baseOrgObject"
+              },
+              {
+                "type": "array",
+                "items": {
+                    "$ref": "#/definitions/baseOrgObject"
+                }
+              }
+            ]
+          },
+          "class": {
+            "description": "A classification of the organization by a resource. Eg- for ClinicalTrials funders, it's [U.S. National Institutes of Health, Other U.S. Federal agencies, Industry, All others]",
+            "type": "string"
+          },
+          "role": {
+            "description": "The role of an organization in its involvement with a resource",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+              }
+            ]
+          },
+          "members": {
+            "description": "Members of this organization, team, or group",
+            "oneOf": [
+              {
+                "$ref": "#/definitions/basePersonObject"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/basePersonObject"
+                }
+              }
+            ]
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "definitions": {
+            "baseOrgObject":{
+                "description": "Affiliated Organization",
+                "@type": "outbreak:Organization",
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "description": "name of the organization",
+                    "type": "string"
+                  },
+                  "alternateName": {
+                    "description": "Alternate name or Acronym for the organization.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ]              
+            },
+            "basePersonObject":{
+                "@type": "outbreak:Person",
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "alternateName": {
+                        "type": "string"
+                    },
+                    "givenName": {
+                        "type": "string"
+                    },
+                    "familyName": {
+                        "type": "string"
+                    },
+                    "orcid": {
+                        "type": "string"
+                    },
+                    "affiliation": {
+                        "description": "consortia or other organizations with which this person is affiliated",
+                        "oneOf": [
+                          {
+                            "$ref": "#/definitions/baseOrgObject"
+                          },
+                          {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/baseOrgObject"
+                            }
+                          }
+                        ]
+                      }
+                },
+                "required": [
+                    "name"
+                ]                
+            }
+        }
       }
     },
-    {"@id":"outbreak:status","@type":"rdf:Property","rdfs:comment":"The recruitment status of the study","rdfs:label":"status","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:status"},"schema:domainIncludes":{"@id":"outbreak:StudyStatus"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:statusExpandedAccess","@type":"rdf:Property","rdfs:comment":"Flag for whether or not the study has expanded Access status","rdfs:label":"statusExpandedAccess","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":{"@id":"outbreak:StudyStatus"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:statusDate","@type":"rdf:Property","rdfs:comment":"The date that the status was verified. Equivalent to NCT's StatusVerifiedDate","rdfs:label":"statusDate","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:temporal"},"schema:domainIncludes":{"@id":"outbreak:StudyStatus"},"schema:rangeIncludes":{"@id":"schema:Date"}},{"@id":"outbreak:enrollmentCount","@type":"rdf:Property","rdfs:comment":"The number of participants enrolled in the study","rdfs:label":"enrollmentCount","owl:cardinality":"one","marginality":"recommended","schema:domainIncludes":{"@id":"outbreak:StudyStatus"},"schema:rangeIncludes":{"@id":"schema:Number"}},{"@id":"outbreak:enrollmentType","@type":"rdf:Property","rdfs:comment":"The type of estimation used to determine the enrollmentCount (actual counts, target size, etc.)","rdfs:label":"enrollmentType","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":{"@id":"outbreak:StudyStatus"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:whyStopped","@type":"rdf:Property","rdfs:comment":"A brief explanation of the reason(s) why such clinical study was stopped (for a clinical study that is \"Suspended,\" \"Terminated,\" or \"Withdrawn\" prior to its planned completion as anticipated by the protocol)","rdfs:label":"whyStopped","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:description"},"schema:domainIncludes":{"@id":"outbreak:StudyStatus"},"schema:rangeIncludes":{"@id":"schema:Text"}},
     {
-      "@id": "outbreak:StudyDesign",
-      "@type": "rdfs:Class",
-      "rdfs:label": "StudyDesign",
-      "rdfs:comment": "This is the schema for describing the StudyDesign schema used for outbreak.info.",
-      "rdfs:subClassOf": {
-        "@id": "schema:Thing"
+      "@id": "outbreak:affiliation",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "consortia or other organizations with which this organization is affiliated",
+      "rdfs:label": "affiliation",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Organization"
       },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
-      }
+      "schema:rangeIncludes": [
+        {
+          "@id": "outbreak:Organization"
+        }
+      ]
     },
-    {"@id":"outbreak:studyType","@type":"rdf:Property","rdfs:comment":"Type of human study, can be subtypes of observational study or interventional studies and may include the temporal relationship of observation period to time of participant enrollment.","rdfs:label":"studyType","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":{"@id":"outbreak:StudyDesign"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:phase","@type":"rdf:Property","rdfs:comment":"Stage or phase of the study in the U.S.","rdfs:label":"phase","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":{"@id":"outbreak:StudyDesign"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:phaseNumber","@type":"rdf:Property","rdfs:comment":"The number of the phase or stage of the study","rdfs:label":"phaseNumber","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":{"@id":"outbreak:StudyDesign"},"schema:rangeIncludes":{"@id":"schema:Number"}},{"@id":"outbreak:designAllocation","@type":"rdf:Property","rdfs:comment":"The method by which the study participants were allocated into groups","rdfs:label":"designAllocation","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":{"@id":"outbreak:StudyDesign"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:designModel","@type":"rdf:Property","rdfs:comment":"The general design of the strategy for assigning interventions to participants in a clinical intervention study OR the general design of the strategy for identifying and following up with participants during an observational study.","rdfs:label":"designModel","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":{"@id":"outbreak:StudyDesign"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:designPrimaryPurpose","@type":"rdf:Property","rdfs:comment":"The primary purpose of the study","rdfs:label":"designPrimaryPurpose","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":{"@id":"outbreak:StudyDesign"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:designWhoMasked","@type":"rdf:Property","rdfs:comment":"The people who not know which participants have been assigned to which interventions.","rdfs:label":"designWhoMasked","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":{"@id":"outbreak:StudyDesign"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:designStudyText","@type":"rdf:Property","rdfs:comment":"String description of the study design if structured information not available","rdfs:label":"designStudyText","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:description"},"schema:domainIncludes":{"@id":"outbreak:StudyDesign"},"schema:rangeIncludes":{"@id":"schema:Text"}},
     {
-      "@id": "outbreak:Intervention",
-      "@type": "rdfs:Class",
-      "rdfs:label": "Intervention",
-      "rdfs:comment": "This is the schema for describing the Intervention schema used for outbreak.info.",
-      "rdfs:subClassOf": {
-        "@id": "schema:Thing"
+      "@id": "outbreak:members",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Members of this organization, team, or group",
+      "rdfs:label": "members",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Organization"
       },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
-      }
+      "schema:rangeIncludes": [
+        {
+          "@id": "outbreak:Person"
+        }
+      ]
     },
-    {"@id":"outbreak:category","@type":"rdf:Property","rdfs:comment":"The category of an intervention in the study","rdfs:label":"category","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":{"@id":"outbreak:Intervention"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"The name of the intervention in the study","rdfs:label":"name","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":{"@id":"outbreak:Intervention"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:description","@type":"rdf:Property","rdfs:comment":"A description of the intervention in the study","rdfs:label":"description","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:description"},"schema:domainIncludes":{"@id":"outbreak:Intervention"},"schema:rangeIncludes":{"@id":"schema:Text"}},
     {
-      "@id": "outbreak:ArmGroup",
-      "@type": "rdfs:Class",
-      "rdfs:label": "ArmGroup",
-      "rdfs:comment": "This is the schema for describing the ArmGroup schema used for outbreak.info.",
-      "rdfs:subClassOf": {
-        "@id": "schema:Thing"
+      "@id": "outbreak:class",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "A classification of the organization by a resource. Eg- for ClinicalTrials funders, it's [U.S. National Institutes of Health, Other U.S. Federal agencies, Industry, All others]",
+      "rdfs:label": "class",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Organization"
       },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
-      }
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
     },
-    {"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"The name of the arm or factor (can include a specific intervention, a placebo or even a lack of intervention, ie- 'no intervention' group)","rdfs:label":"name","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":{"@id":"outbreak:ArmGroup"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:role","@type":"rdf:Property","rdfs:comment":"The role of the arm or factor in the study this is equivalent to the ArmType in ClinicalTrials.gov","rdfs:label":"role","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":{"@id":"outbreak:ArmGroup"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:description","@type":"rdf:Property","rdfs:comment":"A description of the arm or factor","rdfs:label":"description","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:description"},"schema:domainIncludes":{"@id":"outbreak:ArmGroup"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:intervention","@type":"rdf:Property","rdfs:comment":"The interventions (if any) in this ArmGroup","rdfs:label":"intervention","owl:cardinality":"many","marginality":"optional","schema:domainIncludes":{"@id":"outbreak:ArmGroup"},"schema:rangeIncludes":{"@id":"outbreak:Intervention"}},{"@id":"outbreak:category","@type":"rdf:Property","rdfs:comment":"The category of the arm or factor in the study","rdfs:label":"category","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":{"@id":"outbreak:Intervention"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"The name of the intervention in the study","rdfs:label":"name","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":{"@id":"outbreak:Intervention"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:description","@type":"rdf:Property","rdfs:comment":"A description of the intervention in the study","rdfs:label":"description","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:description"},"schema:domainIncludes":{"@id":"outbreak:Intervention"},"schema:rangeIncludes":{"@id":"schema:Text"}},
     {
-      "@id": "outbreak:Eligibility",
-      "@type": "rdfs:Class",
-      "rdfs:label": "Eligibility",
-      "rdfs:comment": "This is the schema for describing the Eligibility schema used for outbreak.info.",
-      "rdfs:subClassOf": {
-        "@id": "schema:Thing"
-      },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
-      }
+      "@id": "outbreak:role",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "authorship, sponsorship, or other contribution role played by the person or organization in the creation of this resource. In a Clinical Study/Trial ArmGroup, it's equivalent to the ArmType in ClinicalTrials.gov",
+      "rdfs:label": "role",
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Person"},
+        {"@id": "outbreak:Organization"},
+        {"@id": "outbreak:ArmGroup"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
     },
-    {"@id":"outbreak:inclusionCriteria","@type":"rdf:Property","rdfs:comment":"criteria for inclusion in the study","rdfs:label":"inclusionCriteria","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:qualifications"},"schema:domainIncludes":{"@id":"outbreak:Eligibility"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:minimumAge","@type":"rdf:Property","rdfs:comment":"the minimum age for a participant to be included in the study","rdfs:label":"minimumAge","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:requiredMinAge"},"schema:domainIncludes":{"@id":"outbreak:Eligibility"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:maximumAge","@type":"rdf:Property","rdfs:comment":"the maximum age for a participant to be included in the study","rdfs:label":"maximumAge","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:requiredMaxAge"},"schema:domainIncludes":{"@id":"outbreak:Eligibility"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:gender","@type":"rdf:Property","rdfs:comment":"the sex requirement to be included in the study","rdfs:label":"gender","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:requiredGender"},"schema:domainIncludes":{"@id":"outbreak:Eligibility"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:genderBased","@type":"rdf:Property","rdfs:comment":"Boolean for whether or not participation is based on gender","rdfs:label":"genderBased","owl:cardinality":"one","marginality":"recommended","schema:domainIncludes":{"@id":"outbreak:Eligibility"},"schema:rangeIncludes":{"@id":"schema:Boolean"}},{"@id":"outbreak:healthyVolunteers","@type":"rdf:Property","rdfs:comment":"Boolean to indicate whether or not healthy volunteers may be included in the study","rdfs:label":"healthyVolunteers","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":{"@id":"outbreak:Eligibility"},"schema:rangeIncludes":{"@id":"schema:Boolean"}},{"@id":"outbreak:stdAge","@type":"rdf:Property","rdfs:comment":"the age category of a participant to be included in the study if a minimum and maximum age is not specified","rdfs:label":"stdAge","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":{"@id":"outbreak:Eligibility"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:exclusionCriteria","@type":"rdf:Property","rdfs:comment":"criteria for exclusion from the study","rdfs:label":"exclusionCriteria","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:qualifications"},"schema:domainIncludes":{"@id":"outbreak:Eligibility"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:criteriaText","@type":"rdf:Property","rdfs:comment":"The descriptive criteria as published for the Clinical Trial","rdfs:label":"criteriaText","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:description"},"schema:domainIncludes":{"@id":"outbreak:Eligibility"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {
-      "@id": "outbreak:Outcome",
-      "@type": "rdfs:Class",
-      "rdfs:label": "Outcome",
-      "rdfs:comment": "This is the schema for describing the Outcome schema used for outbreak.info.",
-      "rdfs:subClassOf": {
-        "@id": "schema:Thing"
-      },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
-      }
-    },
-    {"@id":"outbreak:outcomeMeasure","@type":"rdf:Property","rdfs:comment":"The outcome measure for the study","rdfs:label":"outcomeMeasure","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:description"},"schema:domainIncludes":{"@id":"outbreak:Outcome"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:outcomeTimeFrame","@type":"rdf:Property","rdfs:comment":"The specific time point(s) and overall duration of evaluation must be specified in this section. ","rdfs:label":"outcomeTimeFrame","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:duration"},"schema:domainIncludes":{"@id":"outbreak:Outcome"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:outcomeType","@type":"rdf:Property","rdfs:comment":"The classification of the outcome measure as either primary, secondary, or exploratory","rdfs:label":"outcomeType","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":{"@id":"outbreak:Outcome"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {
-      "@id": "outbreak:StudyLocation",
-      "@type": "rdfs:Class",
-      "rdfs:label": "StudyLocation",
-      "rdfs:comment": "This is the schema for describing the StudyLocation schema used for outbreak.info.",
-      "rdfs:subClassOf": {
-        "@id": "schema:Place"
-      },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
-      }
-    },
-    {"@id":"outbreak:studyLocation","@type":"rdf:Property","rdfs:comment":"The location of the study","rdfs:label":"studyLocation","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:studyLocation"},"schema:domainIncludes":{"@id":"outbreak:ClinicalTrial"},"schema:rangeIncludes":{"@id":"schema:Place"}},{"@id":"outbreak:studyLocationCity","@type":"rdf:Property","rdfs:comment":"The city in which the facility used for the study is located","rdfs:label":"studyLocationCity","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:studyLocation"},"schema:domainIncludes":{"@id":"outbreak:ClinicalTrial"},"schema:rangeIncludes":{"@id":"schema:City"}},{"@id":"outbreak:studyLocationState","@type":"rdf:Property","rdfs:comment":"The state or province in which the facility used for the study is located","rdfs:label":"studyLocationState","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:studyLocation"},"schema:domainIncludes":{"@id":"outbreak:ClinicalTrial"},"schema:rangeIncludes":{"@id":"schema:State"}},{"@id":"outbreak:studyLocationCountry","@type":"rdf:Property","rdfs:comment":"The country in which the facility used for the study is located","rdfs:label":"studyLocationCountry","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:studyLocation"},"schema:domainIncludes":{"@id":"outbreak:ClinicalTrial"},"schema:rangeIncludes":{"@id":"schema:Country"}},{"@id":"outbreak:studyLocationStatus","@type":"rdf:Property","rdfs:comment":"The recruitment status of the study at the specific study site","rdfs:label":"studyLocationStatus","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":{"@id":"outbreak:ClinicalTrial"},"schema:rangeIncludes":{"@id":"schema:Text"}},
     {
       "@id": "outbreak:MonetaryGrant",
       "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing the MonetaryGrant schema used for outbreak.info",
       "rdfs:label": "MonetaryGrant",
-      "rdfs:comment": "This is the schema for describing the MonetaryGrant schema used for outbreak.info.",
       "rdfs:subClassOf": {
         "@id": "schema:MonetaryGrant"
       },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
+      "$validation": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "The name of the grant or funding.",
+            "type": "string"
+          },
+          "identifier": {
+            "description": "The funding or grant id",
+            "type": "string"
+          },
+          "url": {
+            "description": "URL of the grant or funding award.",
+            "type": "string",
+            "format": "uri"
+          },
+          "funder": {
+            "description": "The organization(s) that supported (sponsored) the grant through some kind of financial contribution.",
+            "oneOf": [
+              {
+                "$ref": "#/definitions/baseOrgObject"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/baseOrgObject"
+                }
+              }
+            ]
+          },
+          "recipient": {
+            "description": "The person or organization to whom or to which the grant was awarded",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/basePersonObject"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/basePersonObject"
+                }
+              },
+              {
+                "$ref": "#/definitions/baseOrgObject"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/baseOrgObject"
+                }
+              }
+            ]
+          }   
+        },
+        "required": [
+          "funder"
+        ],
+        "definitions": {
+            "baseOrgObject":{
+                "description": "Affiliated Organization",
+                "@type": "outbreak:Organization",
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "description": "name of the organization",
+                    "type": "string"
+                  },
+                  "alternateName": {
+                    "description": "Alternate name or Acronym for the organization.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ]              
+            },
+            "basePersonObject":{
+                "@type": "outbreak:Person",
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "alternateName": {
+                        "type": "string"
+                    },
+                    "givenName": {
+                        "type": "string"
+                    },
+                    "familyName": {
+                        "type": "string"
+                    },
+                    "orcid": {
+                        "type": "string"
+                    },
+                    "affiliation": {
+                        "description": "consortia or other organizations with which this person is affiliated",
+                        "oneOf": [
+                          {
+                            "$ref": "#/definitions/baseOrgObject"
+                          },
+                          {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/baseOrgObject"
+                            }
+                          }
+                        ]
+                      }
+                },
+                "required": [
+                    "name"
+                ]                
+            }
+        }
       }
     },
-    {"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"The name of the monetary grant","rdfs:label":"name","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":{"@id":"outbreak:MonetaryGrant"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:identifier","@type":"rdf:Property","rdfs:comment":"The grant ID or an identifier associated with the grant","rdfs:label":"identifier","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":{"@id":"outbreak:MonetaryGrant"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:url","@type":"rdf:Property","rdfs:comment":"The url for the grant (if available)","rdfs:label":"url","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:url"},"schema:domainIncludes":{"@id":"outbreak:MonetaryGrant"},"schema:rangeIncludes":{"@id":"schema:URL"}},{"@id":"outbreak:funder","@type":"rdf:Property","rdfs:comment":"The funding organization of the grant","rdfs:label":"funder","owl:cardinality":"many","marginality":"required","rdfs:sameAs":{"@id":"schema:funder"},"schema:domainIncludes":{"@id":"outbreak:MonetaryGrant"},"schema:rangeIncludes":{"@id":"outbreak:Organization"}},{"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"The name of the funding organization","rdfs:label":"name","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":{"@id":"outbreak:Organization"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:recipient","@type":"rdf:Property","rdfs:comment":"The person or organization to whom or to which the grant was awarded","rdfs:label":"recipient","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:recipient"},"schema:domainIncludes":{"@id":"outbreak:MonetaryGrant"},"schema:rangeIncludes":[{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"}]},{"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"The name of the recipient of the grant","rdfs:label":"name","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":[{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:affiliation","@type":"rdf:Property","rdfs:comment":"The affiliation of the recipient of the grant","rdfs:label":"affiliation","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:affiliation"},"schema:domainIncludes":[{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"}],"schema:rangeIncludes":{"@id":"schema:Text"}},
     {
-      "@id": "outbreak:Analysis",
+      "@id": "outbreak:recipient",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The person or organization to whom or to which the grant was awarded",
+      "rdfs:label": "recipient",
+      "schema:domainIncludes": {
+        "@id": "outbreak:MonetaryGrant"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Person"
+        },
+        {
+          "@id": "schema:Organization"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:DataDownload",
       "@type": "rdfs:Class",
-      "rdfs:label": "Analysis",
-      "rdfs:comment": "This is the schema for describing the Analysis schema used for outbreak.info.",
+      "rdfs:comment": "This is the schema for describing the DataDownload schema used for outbreak.info.",
+      "rdfs:label": "DataDownload",
+      "rdfs:subClassOf": {
+        "@id": "schema:DataDownload"
+      }
+    },
+    {
+      "@id": "outbreak:CitationObject",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "A citation object for a resource which is cited by the subject (ie- is a derivative of the subject), related to the subject, or from which the subject was based on (ie- is derived from).",
+      "rdfs:label": "CitationObject",
       "rdfs:subClassOf": {
         "@id": "schema:CreativeWork"
       },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
+      "$validation": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "The name or title of the cited resource.",
+            "type": "string"
+          },
+          "url": {
+            "description": "URL of the cited resource.",
+            "type": "string",
+            "format": "uri"
+          },
+          "identifier": {
+            "description": "An identifier associated with the citation",
+            "type": "string"
+          },
+          "citeText": {
+            "description": "The bibliographic citation for the referenced resource as is provided",
+            "type": "string"
+          },
+          "versionDate": {
+            "description": "The version date of the resource used at the time of the creation of the citation as certain resources (protocols, datasets) may change frequently over time.",
+            "format": "date",
+            "type": "string"
+          },
+          "pmid": {
+            "description": "A pubmed identifier if available",
+            "type": "string"
+          },
+          "doi": {
+            "description": "A doi if available",
+            "type": "string"
+          },
+          "sourceType": {
+            "description": "The @type of resource",
+            "enum": [
+              "Dataset",
+              "Publication",
+              "ClinicalTrial",
+              "Analysis",
+              "Protocol",
+              "SoftwareApplication",
+              "CreativeWork"
+            ]
+          }
+        },
+        "required": [
+          "name",
+          "sourceType"
+        ]
       }
+    },
+    {
+      "@id": "outbreak:citeText",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The bibliographic citation for the referenced resource as is provided",
+      "rdfs:label": "citeText",
+      "schema:domainIncludes": {
+        "@id": "outbreak:CitationObject"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:versionDate",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The version date of the resource used at the time of the creation of the citation as certain resources (protocols, datasets) may change frequently over time.",
+      "rdfs:label": "versionDate",
+      "schema:domainIncludes": {
+        "@id": "outbreak:CitationObject"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Date"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:sourceType",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The type of resource",
+      "rdfs:label": "sourceType",
+      "schema:domainIncludes": {
+        "@id": "outbreak:CitationObject"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
     },
     {
       "@id": "outbreak:Dataset",
       "@type": "rdfs:Class",
-      "rdfs:label": "Dataset",
       "rdfs:comment": "This is the schema for describing the Dataset schema used for outbreak.info.",
+      "rdfs:label": "Dataset",
       "rdfs:subClassOf": {
         "@id": "schema:Dataset"
+      }
+    },
+    {
+      "@id": "outbreak:Correction",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing a Correction used for outbreak.info. A Correction is a specialized subclass of the CitationObject",
+      "rdfs:label": "Correction",
+      "rdfs:subClassOf": {
+        "@id": "schema:CreativeWork"
+      }
+    },
+    {
+      "@id": "outbreak:correctionType",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Type of notice or correction: (correction, retraction, expression of convern, withdrawal, erratum, update, correction/republication, preprint, peer reviewed version)",
+      "rdfs:label": "correctionType",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Correction"
       },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:Publication",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing the Publication used for outbreak.info",
+      "rdfs:label": "Publication",
+      "rdfs:subClassOf": {
+        "@id": "schema:MedicalScholarlyArticle"
+      }
+    },
+    {
+      "@id": "outbreak:journalName",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The name of the journal (or publisher if journal name not available)",
+      "rdfs:label": "journalName",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Publication"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:journalNameAbbrevation",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "abbreviated Journal Title (note, this should be autopopulated)",
+      "rdfs:label": "journalNameAbbrevation",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Publication"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:volumeNumber",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Volume number of journal in which the article was published",
+      "rdfs:label": "volumeNumber",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Publication"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:issueNumber",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Issue of journal in which the article was published",
+      "rdfs:label": "issueNumber",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Publication"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:Analysis",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing an Analysis for inclusion in outbreak.info resources",
+      "rdfs:label": "Analysis",
+      "rdfs:subClassOf": {
+        "@id": "schema:CreativeWork"
+      }
+    },
+    {
+      "@id": "outbreak:domainUrl",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The domain name or main site on which webpage or specific url can be found",
+      "rdfs:label": "domainUrl",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Analysis"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:URL"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:assumption",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Statement of assumptions / limitations of the model",
+      "rdfs:label": "assumption",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Analysis"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:analysisTechnique",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "A technique or technology used in a analysis",
+      "rdfs:label": "analysisTechnique",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Analysis"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:analysisTopic",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The underlying question, goal, or aim of the analysis",
+      "rdfs:label": "analysisTopic",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Analysis"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:Product",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing a reagent, material, sample, or some other product used in a protocol resource in outbreak.info",
+      "rdfs:label": "Product",
+      "rdfs:subClassOf": {
+        "@id": "schema:Product"
+      }
+    },
+    {
+      "@id": "outbreak:Instrument",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing an instrument used in a protocol resource listed in outbreak.info",
+      "rdfs:label": "Instrument",
+      "rdfs:subClassOf": {
+        "@id": "schema:Product"
       }
     },
     {
       "@id": "outbreak:Protocol",
       "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing the Protocols for outbreak.info Resources.",
       "rdfs:label": "Protocol",
-      "rdfs:comment": "This is the schema for describing the Protocol schema used for outbreak.info.",
       "rdfs:subClassOf": {
         "@id": "schema:HowTo"
-      },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
       }
     },
     {
-      "@id": "outbreak:Publication",
-      "@type": "rdfs:Class",
-      "rdfs:label": "Publication",
-      "rdfs:comment": "This is the schema for describing the Publication schema used for outbreak.info.",
-      "rdfs:subClassOf": {
-        "@id": "schema:ScholarlyArticle"
+      "@id": "outbreak:warning",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Precautions, warnings, and/or safety warnings associated with or highlighted by the protocol",
+      "rdfs:label": "warning",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Protocol"
       },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
-      }
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
     },
     {
-      "@id": "outbreak:ClinicalTrial",
-      "@type": "rdfs:Class",
-      "rdfs:label": "ClinicalTrial",
-      "rdfs:comment": "This is the schema for describing the ClinicalTrial schema used for outbreak.info.",
-      "rdfs:subClassOf": {
-        "@id": "schema:MedicalStudy"
+      "@id": "outbreak:correctionNote",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "statement of what was updated/changed since prior version",
+      "rdfs:label": "correctionNote",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Protocol"
       },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:protocolStatus",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The status of the protocol",
+      "rdfs:label": "protocolStatus",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Protocol"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:instrument",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "A laboratory equipment use by a person to follow one or more steps described in this Protocol",
+      "rdfs:label": "instrument",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Protocol"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "outbreak:Instrument"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:protocolSetting",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The type of 'protocol' based on setting in which it would apply",
+      "rdfs:label": "protocolSetting",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Protocol"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:protocolCategory",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The type of 'protocol' based on degree of specificity and purpose",
+      "rdfs:label": "protocolCategory",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Protocol"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:usedToGenerate",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Type of evidence/data generated by the protocol",
+      "rdfs:label": "usedToGenerate",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Protocol"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:inComplianceWith",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Guidelines or Standards to which these protocols adhere. ie- GMP, GCP, other EQUATOR guidelines. Useful for selecting protocols where certain standards/guidelines must be met",
+      "rdfs:label": "inComplianceWith",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Protocol"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    }, 
+    {
+      "@id": "outbreak:StudyEvent",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing StudyEvents, a class that describes categorical events in Clinical Trials added to outbreak.info",
+      "rdfs:label": "StudyEvent",
+      "rdfs:subClassOf": {
+        "@id": "schema:Thing"
       },
       "$validation": {
-          "$schema": "http://json-schema.org/draft-07/schema#",
-          "type": "object",
-          "properties": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "studyEventType": {
+            "description": "Type of the event status such as StudyStart, PrimaryCompletion, Completion, StudyFirstSubmit, StudyFirstSubmitQC, LastUpdateSubmit",
+            "oneOf": [
+              {
+                "enum": [
+                  "StudyStart",
+                  "PrimaryCompletion",
+                  "Completion",
+                  "StudyFirstSubmit",
+                  "StudyFirstSubmitQC",
+                  "LastUpdateSubmit"
+                ]
+              },
+              {
+                "type": "string"
+              }
+            ]
+          },
+          "studyEventDate": {
+            "description": "The corresponding/actual date of the study event (ie- the StartDate, Primary CompletionDate, CompletionDate, StudyFirstSubmitDate, StudyFirstSubmitQCDate, LastUpdateSubmitDate)",
+            "format": "date",
+            "type": "string"
+          },
+          "studyEventDateType": {
+            "description": "the type of date provided (actual, anticipated, or estimated)",
+            "oneOf": [
+              {
+                "enum": [
+                  "actual",
+                  "anticipated",
+                  "estimated"
+                ]
+              },
+              {
+                "type": "string"
+              }
+            ]
+          }
+        },
+        "required": []
+      }
+    },
+    {
+      "@id": "outbreak:studyEventType",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Type of the event status such as StudyStart, PrimaryCompletion, Completion, StudyFirstSubmit, StudyFirstSubmitQC, LastUpdateSubmit",
+      "rdfs:label": "studyEventType",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyEvent"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:studyEventDate",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The corresponding/actual date of the study event (ie- the StartDate, Primary CompletionDate, CompletionDate, StudyFirstSubmitDate, StudyFirstSubmitQCDate, LastUpdateSubmitDate)",
+      "rdfs:label": "studyEventDate",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyEvent"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Date"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:studyEventDateType",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "the type of date provided (actual, anticipated, or estimated)",
+      "rdfs:label": "studyEventDateType",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyEvent"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },  
+    {
+      "@id": "outbreak:StudyStatus",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing the status of a ClinicalTrial resource in outbreak.info",
+      "rdfs:label": "StudyStatus",
+      "rdfs:subClassOf": {
+        "@id": "schema:Thing"
+      },
+      "$validation": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "statusExpandedAccess": {
+            "description": "Flag for whether or not the study has expanded Access status",
+            "oneOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "enum": [
+                        "yes",
+                        "no",
+                        "unknown"
+                      ]
+                    }
+                  ]
+          },
+          "statusDate": {
+            "description": "The date that the status was verified. Equivalent to NCT's StatusVerifiedDate",
+            "format": "date",
+            "type": "string"
+          },
+          "enrollmentCount": {
+            "description": "The number of participants enrolled in the study",
+            "type": "integer"
+          },
+          "enrollmentType": {
+            "description": "The type of estimation used to determine the enrollmentCount (actual counts, target size, etc.)",
+            "oneOf": [
+              {
+                "enum": [
+                  "actual counts",
+                  "target size"
+                ]
+              },
+              {
+                "type": "string"
+              }
+            ]
+          },
+          "whyStopped": {
+            "description": "A brief explanation of the reason(s) why such clinical study was stopped (for a clinical study that is Suspended, Terminated, or Withdrawn prior to its planned completion as anticipated by the protocol)",
+            "type": "string"
+          },
+          "status": {
+            "description": "The recruitment status of the study",
+            "enum": [
+                "not yet recruiting",
+                "recruiting",
+                "enrolling by invitation",
+                "active",
+                "not recruiting",
+                "suspended",
+                "terminated",
+                "completed",
+                "withdrawn",
+                "unknown status"
+            ]
+          }
+        },
+        "required": [
+            "status"
+        ]
+      }
+    },
+    {
+      "@id": "outbreak:status",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The recruitment status of the study",
+      "rdfs:label": "status",
+      "rdfs:sameAs":{"@id":"schema:status"},
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyStatus"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:statusExpandedAccess",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Flag for whether or not the study has expanded Access status",
+      "rdfs:label": "statusExpandedAccess",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyStatus"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Boolean"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:statusDate",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The date that the status was verified. Equivalent to NCT's StatusVerifiedDate",
+      "rdfs:label": "statusDate",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyStatus"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Date"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:enrollmentCount",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The number of participants enrolled in the study",
+      "rdfs:label": "enrollmentCount",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyStatus"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Number"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:enrollmentType",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The type of estimation used to determine the enrollmentCount (actual counts, target size, etc.)",
+      "rdfs:label": "enrollmentType",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyStatus"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:whyStopped",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "A brief explanation of the reason(s) why such clinical study was stopped (for a clinical study that is Suspended, Terminated, or Withdrawn prior to its planned completion as anticipated by the protocol)",
+      "rdfs:label": "whyStopped",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyStatus"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:StudyDesign",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing the study design of a clinical trial/study for inclusion into outbreak.info resources",
+      "rdfs:label": "StudyDesign",
+      "rdfs:subClassOf": {
+        "@id": "schema:Thing"
+      },
+      "$validation": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "studyType": {
+            "description": "Type of human study, can be subtypes of observational study or interventional studies and may include the temporal relationship of observation period to time of participant enrollment.",
+            "enum": [
+                "interventional",
+                "observational"
+            ]
+          },
+          "phase": {
+            "description": "Stage or phase of the study in the U.S. if applicable",
+            "oneOf": [
+                    {
+                      "enum": [
+                        "Early Phase 1",
+                        "Phase 1",
+                        "Phase 2",
+                        "Phase 3",
+                        "Phase 4",
+                        "Not Applicable"
+                      ]
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "enum": [
+                          "Early Phase 1",
+                          "Phase 1",
+                          "Phase 2",
+                          "Phase 3",
+                          "Phase 4",
+                          "Not Applicable"
+                        ]
+                      }
+                    }
+                  ]
+          },
+          "phaseNumber": {
+            "description": "The number of the phase or stage of the study",
+            "oneOf": [
+                    {
+                      "enum": [
+                        "0",
+                        "1",
+                        "2",
+                        "3",
+                        "4",
+                        "Not Applicable"
+                      ]
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "enum": [
+                          "0",
+                          "1",
+                          "2",
+                          "3",
+                          "4",
+                          "Not Applicable"
+                        ]
+                      }
+                    }
+                  ]
+          },
+          "designAllocation": {
+            "description": "The method by which the study participants were allocated into groups",
+            "enum": [
+                "randomized",
+                "nonrandomized",
+                "other"
+            ]
+          },
+          "designModel": {
+            "description": "The general design of the strategy for assigning interventions to participants in a clinical intervention study OR the general design of the strategy for identifying and following up with participants during an observational study.",
+            "oneOf": [
+                {
+                    "enum": [
+                        "single group assignment",
+                        "parallel assignment",
+                        "cross-over assignment",
+                        "factorial assignment",
+                        "cohort",
+                        "case-control",
+                        "case-only",
+                        "case-cross-over",
+                        "ecologic or community studies",
+                        "family-based",
+                        "other",
+                        "retrospective",
+                        "prospective",
+                        "cross-sectional"
+                    ]
+                },
+                {
+                    "type": "array",
+                    "items": {
+                        "enum": [
+                          "single group assignment",
+                          "parallel assignment",
+                          "cross-over assignment",
+                          "factorial assignment",
+                          "cohort",
+                          "case-control",
+                          "case-only",
+                          "case-cross-over",
+                          "ecologic or community studies",
+                          "family-based",
+                          "other",
+                          "retrospective",
+                          "prospective",
+                          "cross-sectional"
+                        ]
+                    }
+                }
+            ]
+          },
+          "designPrimaryPurpose": {
+            "description": "The primary purpose of the study",
+            "enum": [
+                "treatment",
+                "prevention",
+                "diagnostic",
+                "supportive care",
+                "screening",
+                "health services research",
+                "basic science",
+                "other"
+            ]
+          },
+          "designWhoMasked": {
+            "description": "The people who do not know which participants have been assigned to which interventions",
+            "oneOf": [
+                {
+                    "enum": [
+                        "Participant",
+                        "Investigator",
+                        "Outcomes Assessor",
+                        "Care Provider"
+                    ]
+                },
+                {
+                    "type": "array",
+                    "items": {
+                        "enum": [
+                          "Participant",
+                          "Investigator",
+                          "Outcomes Assessor",
+                          "Care Provider"
+                        ]
+                    }
+                }
+            ]
+          },
+          "designStudyText": {
+            "description": "String description of the study design if structured information not available",
+            "type": "string"
+          }
+        },
+        "required": []
+      }
+    },
+    {
+      "@id": "outbreak:studyType",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Type of human study, can be subtypes of observational study or interventional studies and may include the temporal relationship of observation period to time of participant enrollment.",
+      "rdfs:label": "studyType",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyDesign"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:phase",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Stage or phase of the study in the U.S. if applicable",
+      "rdfs:label": "phase",
+      "rdfs:sameAs":{"@id":"schema:phase"},
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyDesign"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:phaseNumber",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The number of the phase or stage of the study",
+      "rdfs:label": "phaseNumber",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyDesign"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Number"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:designAllocation",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The method by which the study participants were allocated into groups",
+      "rdfs:label": "designAllocation",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyDesign"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:designModel",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The general design of the strategy for assigning interventions to participants in a clinical intervention study OR the general design of the strategy for identifying and following up with participants during an observational study",
+      "rdfs:label": "designModel",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyDesign"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:designPrimaryPurpose",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The primary purpose of the study",
+      "rdfs:label": "designPrimaryPurpose",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyDesign"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:designWhoMasked",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The people who do not know which participants have been assigned to which interventions",
+      "rdfs:label": "designWhoMasked",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyDesign"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:designStudyText",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "String description of the study design if structured information not available",
+      "rdfs:label": "designStudyText",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyDesign"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:Intervention",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "a schema to describe Interventions discussed in Clinical Studies/Trials for inclusion in outbreak.info Resources",
+      "rdfs:label": "Intervention",
+      "rdfs:subClassOf": {
+        "@id": "schema:Thing"
+      },
+      "$validation": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
             "name": {
-              "description": "Official or scientific title of the study",
+              "description": "The name of the intervention in the study",
               "type": "string"
             },
-            "alternateName": {
-              "description": "Brief title, acronyms, or public titles for the study",
-              "oneOf": [
+            "description": {
+              "description": "A description of the intervention in the study",
+              "type": "string"
+            },
+            "category": {
+              "description": "The category of an intervention in the study",
+              "enum": [
+                "drugs",
+                "medical devices",
+                "procedures",
+                "vaccines",
+                "education",
+                "behavioral modification",
+                "diet",
+                "exercise",
+                "counseling",
+                "placebo",
+                "other"
+              ]
+            }
+        },
+        "required": []
+      }
+    },
+    {
+      "@id": "outbreak:category",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The category of an intervention in the study",
+      "rdfs:label": "category",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Intervention"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:ArmGroup",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing arm groups in clinical studies/trials for inclusion in outbreak.info Resources",
+      "rdfs:label": "ArmGroup",
+      "rdfs:subClassOf": {
+        "@id": "schema:Thing"
+      },
+      "$validation": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "role": {
+            "description": "The role of the arm or factor in the study this is equivalent to the ArmType in ClinicalTrials.gov",
+            "enum": [
+                "experimental arm",
+                "active comparator arm",
+                "placebo comparator arm",
+                "sham comparator arm",
+                "no intervention arm"
+            ]
+          },
+          "intervention": {
+            "description": "The interventions (if any) in this ArmGroup",
+            "type": "array",
+            "oneOf": [
                 {
-                  "type": "string"
+                  "$ref": "#/definitions/intervention"
                 },
                 {
                   "type": "array",
                   "items": {
-                    "type": "string"
+                    "$ref": "#/definitions/intervention"
                   }
                 }
-              ]
+            ]
+          },
+          "name": {
+            "description": "The name of the arm or factor (can include a specific intervention, a placebo or even a lack of intervention, ie- 'no intervention' group)",
+            "type": "string"
+          },
+          "description": {
+            "description": "A description of the arm or factor",
+            "type": "string"
+          }
+        },
+        "required": [],
+        "definitions":{
+          "intervention": {
+              "type": "object",
+              "@type": "outbreak:Intervention",
+              "properties": {
+                "name": {
+                  "description": "The name of the intervention in the study",
+                  "type": "string"
+                },
+                "description": {
+                  "description": "A description of the intervention in the study",
+                  "type": "string"
+                },
+                "category": {
+                  "description": "The category of an intervention in the study",
+                  "enum": [
+                    "drugs",
+                    "medical devices",
+                    "procedures",
+                    "vaccines",
+                    "education",
+                    "behavioral modification",
+                    "diet",
+                    "exercise",
+                    "counseling",
+                    "placebo",
+                    "other"
+                  ]
+                }
+              }
+            }  
+        }
+      }
+    },
+    {
+      "@id": "outbreak:intervention",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The interventions (if any) in this ArmGroup",
+      "rdfs:label": "intervention",
+      "schema:domainIncludes": {
+        "@id": "outbreak:ArmGroup"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "outbreak:Intervention"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:Outcome",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing a Clinical Trial/Study Outcome for inclusion in  outbreak.info Resources",
+      "rdfs:label": "Outcome",
+      "rdfs:subClassOf": {
+        "@id": "schema:Thing"
+      },
+      "$validation": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+            "outcomeTimeFrame": {
+                "description": "The specific time point(s) and overall duration of evaluation must be specified in this section. ",
+                "type": "string"
             },
-            "identifier": {
+            "outcomeMeasure": {
+                "description": "The outcome measure for the study",
+                "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                ]
+            },
+            "outcomeType": {
+                "description": "The classification of the outcome measure as either primary, secondary, or exploratory",
+                "enum": [
+                    "primary",
+                    "secondary",
+                    "other"
+                  ]
+            }
+        },
+        "required": []
+      }
+    },
+    {
+      "@id": "outbreak:outcomeMeasure",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The outcome measure for the study",
+      "rdfs:label": "outcomeMeasure",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Outcome"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:outcomeTimeFrame",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The specific time point(s) and overall duration of evaluation must be specified in this section",
+      "rdfs:label": "outcomeTimeFrame",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Outcome"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Duration"
+        },
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:outcomeType",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The classification of the outcome measure as either primary, secondary, or exploratory",
+      "rdfs:label": "outcomeType",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Outcome"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:Eligibility",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing information about Clinical Trials/Studies eligibility criteria for inclusion in outbreak.info Resources",
+      "rdfs:label": "Eligibility",
+      "rdfs:subClassOf": {
+        "@id": "schema:Thing"
+      },
+      "$validation": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "minimumAge": {
+            "description": "the minimum age for a participant to be included in the study",
+            "type": "string"
+          },
+          "maximumAge": {
+            "description": "the maximum age for a participant to be included in the study",
+            "type": "string"
+          },
+          "criteriaText": {
+            "description": "The descriptive criteria as published for the Clinical Trial",
+            "type": "string"
+          },
+          "inclusionCriteria": {
+            "description": "criteria for inclusion in the study",
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            ]
+          },
+          "exclusionCriteria": {
+            "description": "criteria for exclusion from the study",
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            ]
+          },
+          "gender": {
+            "description": "the sex requirement to be included in the study",
+            "enum": [
+                    "male",
+                    "female",
+                    "all"
+                ]
+          },
+          "genderBased": {
+            "description": "Boolean for whether or not participation is based on gender",
+                  "type": "boolean"
+          },
+          "healthyVolunteers": {
+            "description": "Boolean to indicate whether or not healthy volunteers may be included in the study",
+            "type": "boolean"
+          },
+          "stdAge": {
+            "description": "the age category of a participant to be included in the study if a minimum and maximum age is not specified",
+            "oneOf": [
+                {
+                    "enum": [
+                        "Child (birth-17)",
+                        "Adult (18-64)",
+                        "Older Adult (65+)"
+                      ]
+                },
+                {
+                    "items": {
+                        "enum": [
+                          "Child (birth-17)",
+                          "Adult (18-64)",
+                          "Older Adult (65+)"
+                        ]
+                    }
+                }
+            ]
+          }
+        },
+        "required": []
+      }
+    },
+    {
+      "@id": "outbreak:inclusionCriteria",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "\"criteria for inclusion in the study",
+      "rdfs:label": "inclusionCriteria",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Eligibility"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:minimumAge",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "the minimum age for a participant to be included in the study",
+      "rdfs:label": "minimumAge",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Eligibility"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:maximumAge",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "the maximum age for a participant to be included in the study",
+      "rdfs:label": "maximumAge",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Eligibility"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:gender",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "the sex requirement to be included in the study",
+      "rdfs:label": "gender",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Eligibility"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:genderBased",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Boolean for whether or not participation is based on gender",
+      "rdfs:label": "genderBased",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Eligibility"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Boolean"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:healthyVolunteers",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Boolean to indicate whether or not healthy volunteers may be included in the study",
+      "rdfs:label": "healthyVolunteers",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Eligibility"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Boolean"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:stdAge",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "the age category of a participant to be included in the study if a minimum and maximum age is not specified",
+      "rdfs:label": "stdAge",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Eligibility"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:exclusionCriteria",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "criteria for exclusion from the study",
+      "rdfs:label": "exclusionCriteria",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Eligibility"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:criteriaText",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The descriptive criteria as published for the Clinical Trial",
+      "rdfs:label": "criteriaText",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Eligibility"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:StudyLocation",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing Clinical Trial/Study locations for inclusion in outbreak.info Resources",
+      "rdfs:label": "StudyLocation",
+      "rdfs:subClassOf": {
+        "@id": "schema:Place"
+      },
+      "$validation": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "studyLocation": {
+            "description": "The location of the study as listed in the resouce.",
+            "type": "string"
+          },
+          "studyLocationCity": {
+            "description": "The city in which the facility used for the study is located",
+            "type": "string"
+          },
+          "studyLocationState": {
+            "description": "The state or province in which the facility used for the study is located",
+            "type": "string"
+          },
+          "studyLocationCountry": {
+            "description": "The country in which the facility used for the study is located",
+            "type": "string"
+          },
+          "studyLocationStatus": {
+            "description": "The recruitment status of the study at the specific study site",
+            "enum": [
+                "not yet recruiting",
+                "recruiting",
+                "enrolling by invitation",
+                "active",
+                "not recruiting",
+                "suspended",
+                "terminated",
+                "completed",
+                "withdrawn",
+                "unknown status"
+            ]
+          }
+        },
+        "required": []
+      }
+    },
+    {
+      "@id": "outbreak:studyLocation",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The location of the study",
+      "rdfs:label": "studyLocation",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyLocation"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Place"
+        },
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:studyLocationCity",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The city in which the facility used for the study is located",
+      "rdfs:label": "studyLocationCity",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyLocation"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:City"
+        },
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:studyLocationState",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The state or province in which the facility used for the study is located",
+      "rdfs:label": "studyLocationState",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyLocation"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:State"
+        },
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:studyLocationCountry",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The country in which the facility used for the study is located",
+      "rdfs:label": "studyLocationCountry",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyLocation"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Country"
+        },
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:studyLocationStatus",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The recruitment status of the study at the specific study site",
+      "rdfs:label": "studyLocationStatus",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyLocation"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+{
+      "@id": "outbreak:ClinicalTrial",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing the Clinical Trials and other medical studies used for outbreak.info Resources",
+      "rdfs:label": "ClinicalTrial",
+      "rdfs:subClassOf": {
+        "@id": "schema:MedicalStudy"
+      },
+      "$validation": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "Official or scientific title of the study",
+            "type": "string"
+          },
+          "alternateName": {
+            "description": "Brief title, acronyms, or public titles for the study",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            ]
+          },
+          "identifier": {
               "description": "Registration number or identifier assigned to the study",
               "oneOf": [
                 {
@@ -245,8 +2015,8 @@
                   }
                 }
               ]
-            },
-            "identifierSource": {
+          },
+          "identifierSource": {
               "description": "Source of identifier assignment or type of identifier (NCTid, China CTRid, EudraCT Number, etc.)",
               "oneOf": [
                 {
@@ -259,26 +2029,26 @@
                   }
                 }
               ]
-            },
-            "abstract": {
-              "description": "A brief summary of the study",
-              "type": "string"
-            },
-            "description": {
-              "description": "A description of the study or the stated purpose of the study",
-              "type": "string"
-            },
-            "dateCreated": {
-              "description": "Date the record was created",
-              "format": "date",
-              "type": "string"
-            },
-            "datePublished": {
-              "description": "Date the record was published",
-              "format": "date",
-              "type": "string"
-            },
-            "dateModified": {
+          },
+          "abstract": {
+            "description": "A brief summary of the study",
+            "type": "string"
+          },            
+          "description": {
+            "description": "A description of the study or the stated purpose of the study",
+            "type": "string"
+          },
+          "dateCreated": {
+            "description": "Date the record was created",
+            "format": "date",
+            "type": "string"
+          },
+          "datePublished": {
+            "description": "Date the record was published",
+            "format": "date",
+            "type": "string"
+          },
+          "dateModified": {
               "description": "LastUpdatePostDate",
               "oneOf": [
                 {
@@ -293,16 +2063,16 @@
                   }
                 }
               ]
-            },
-            "dateModifiedType": {
+          },
+          "dateModifiedType": {
               "description": "LastUpdatePostDateType",
               "enum": [
                 "actual",
                 "anticipated",
                 "estimated"
               ]
-            },
-            "healthCondition": {
+          },
+          "healthCondition": {
               "description": "The health condition or disease being studied",
               "oneOf": [
                 {
@@ -315,8 +2085,8 @@
                   }
                 }
               ]
-            },
-            "healthConditionIidentifier": {
+          },
+          "healthConditionIdentifier": {
               "description": "Ontological or controlled vocabulary identifier for the health condition or disease",
               "oneOf": [
                 {
@@ -329,8 +2099,8 @@
                   }
                 }
               ]
-            },
-            "keywords": {
+          },
+          "keywords": {
               "description": "keywords",
               "oneOf": [
                 {
@@ -343,8 +2113,8 @@
                   }
                 }
               ]
-            },
-            "topicCategory": {
+          },
+          "topicCategory": {
               "description": "Applicable outbreak.info category",
               "oneOf": [
                 {
@@ -426,144 +2196,144 @@
                 }
               ]
 
-            },
-            "hasResults": {
-              "description": "Binary for if the clinical trial has published any results",
-              "type": "boolean"
-            },
-            "url": {
-              "description": "url where the study can be found",
-              "format": "uri",
-              "type": "string"
-            },
-            "author": {
-              "description": "The study's author, this includes ResponsiblePartyInvestigator, Contacts, and OverallOfficials",
-              "oneOf": [
-                {
+          },
+          "hasResults": {
+            "description": "Boolean for if the clinical trial has published any results",
+            "type": "boolean"
+          },
+          "url": {
+            "description": "url where the study can be found",
+            "type": "string",
+            "format": "uri"
+          },
+          "author": {
+            "description": "The study's author, this includes ResponsiblePartyInvestigator, Contacts, and OverallOfficials",
+            "oneOf": [
+              {
+                "$ref": "#/definitions/person"
+              },
+              {
+                "type": "array",
+                "items": {
                   "$ref": "#/definitions/person"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/person"
-                  }
                 }
-              ]
-            },
-            "funding": {
-              "description": "Funding, sponsorship, and collaborations for the study.",
-              "oneOf": [
-                {
+              }
+            ]
+          },
+          "funding": {
+            "description": "Funding, sponsorship, and collaborations for the study.",
+            "oneOf": [
+              {
+                "$ref": "#/definitions/funding"
+              },
+              {
+                "type": "array",
+                "items": {
                   "$ref": "#/definitions/funding"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/funding"
-                  }
                 }
-              ]
-            },
-            "studyEvent": {
-              "description": "an event status such as StudyStart, PrimaryCompletion, Completion, StudyFirstSubmit, StudyFirstSubmitQC, LastUpdateSubmit",
-              "oneOf": [
-                {
+              }
+            ]
+          },
+          "studyEvent": {
+            "description": "an event status such as StudyStart, PrimaryCompletion, Completion, StudyFirstSubmit, StudyFirstSubmitQC, LastUpdateSubmit",
+            "oneOf": [
+              {
+                "$ref": "#/definitions/studyevent"
+              },
+              {
+                "type": "array",
+                "items": {
                   "$ref": "#/definitions/studyevent"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/studyevent"
-                  }
                 }
-              ]
-            },
-            "studyStatus": {
-              "description": "The status of the study",
-              "oneOf": [
-                {
+              }
+            ]
+          },
+          "studyStatus": {
+            "description": "The status of the study",
+            "oneOf": [
+              {
+                "$ref": "#/definitions/studystatus"
+              },
+              {
+                "type": "array",
+                "items": {
                   "$ref": "#/definitions/studystatus"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/studystatus"
-                  }
                 }
-              ]
-            },
-            "studyDesign": {
-              "description": "The general design of the study",
-              "oneOf": [
-                {
+              }
+            ]
+          },
+          "studyDesign": {
+            "description": "The general design of the study",
+            "oneOf": [
+              {
+                "$ref": "#/definitions/studydesign"
+              },
+              {
+                "type": "array",
+                "items": {
                   "$ref": "#/definitions/studydesign"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/studydesign"
-                  }
                 }
-              ]
-            },
-            "armGroup": {
-              "description": "The arm or factor of an interventional study",
-              "oneOf": [
-                {
+              }
+            ]
+          },
+          "armGroup": {
+            "description": "The arm or factor of an interventional study",
+            "oneOf": [
+              {
+                "$ref": "#/definitions/armgroup"
+              },
+              {
+                "type": "array",
+                "items": {
                   "$ref": "#/definitions/armgroup"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/armgroup"
-                  }
                 }
-              ]
-            },
-            "outcome": {
-              "description": "The outcome (expected or actual) of a study",
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/outcome"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/outcome"
-                  }
-                }
-              ]
-            },
-            "eligibilityCriteria": {
-              "description": "eligibility criteria",
-              "oneOf": [
-                {
+              }
+            ]
+          },
+          "eligibilityCriteria": {
+            "description": "eligibility criteria",
+            "oneOf": [
+              {
+                "$ref": "#/definitions/eligibility"
+              },
+              {
+                "type": "array",
+                "items": {
                   "$ref": "#/definitions/eligibility"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/eligibility"
-                  }
                 }
-              ]
-            },
-            "studyLocation": {
-              "description": "The location of the study",
-              "oneOf": [
-                {
+              }
+            ]
+          },
+          "studyLocation": {
+            "description": "The location in which the study is taking/took place.",
+            "oneOf": [
+              {
+                "$ref": "#/definitions/studylocation"
+              },
+              {
+                "type": "array",
+                "items": {
                   "$ref": "#/definitions/studylocation"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/studylocation"
-                  }
                 }
-              ]
-            },
-            "citedBy": {
-              "description": "other articles or resources that cite this clinical trial",
+              }
+            ]
+          },
+          "outcome": {
+            "description": "Expected or actual outcomes of the study.",
+            "oneOf": [
+              {
+                "$ref": "#/definitions/outcomeObject"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/outcomeObject"
+                }
+              }
+            ]
+          },
+          "citedBy": {
+              "description": "Associated guidelines, protocols, publications, etc. that include, adapt, modify, expand, etc. this clinical trial/study",
               "oneOf": [
                 {
                   "$ref": "#/definitions/citation"
@@ -575,9 +2345,9 @@
                   }
                 }
               ]
-            },
-            "isBasedOn": {
-              "description": "Associated datasets, software, protocols, etc. used by the work described in this clinical study (includes study protocol documents, data analysis plans, reference publications. etc)",
+          },
+          "isBasedOn": {
+              "description": "Associated resource (guidelines, protocols, publications, etc.) from which this clinical trial/study was derived",
               "oneOf": [
                 {
                   "$ref": "#/definitions/citation"
@@ -589,9 +2359,9 @@
                   }
                 }
               ]
-            },
-            "isRelatedTo": {
-              "description": "Other resources related to, but not a derivative of nor derived from this analysis",
+          },
+          "isRelatedTo": {
+              "description": "Other resources related to, but not a derivative of nor derived from this clinical trial/study",
               "oneOf": [
                 {
                   "$ref": "#/definitions/citation"
@@ -603,9 +2373,9 @@
                   }
                 }
               ]
-            },
-            "curatedBy": {
-            "description": "The source from which this Clinical Study was identified for inclusion into Outbreak.info. Provides provenance for a resource which was curated by another.",
+          },
+          "curatedBy": {
+            "description": "The source from which this clinical trial/study was identified for inclusion into Outbreak.info. Provides provenance for a resource which was curated by another.",
             "anyOf": [{
                 "$ref": "#/definitions/citation"
               },
@@ -635,26 +2405,48 @@
               }
             ]
           },
-            "curationDate":{
+          "curationDate":{
             "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
             "type": "string",
             "format": "date"
-          }
           },
-          "required": [
-            "name",
-            "url",
-            "description",
-            "identifier",
-            "identifierSource",
-            "healthCondition",
-            "funding",
-            "author"
-          ],
-          "definitions": {
-            "baseOrgObject":{
+          "evaluations":{
+              "description": "Reviews, Ratings, or other types of evaluations on this resource",
+              "anyOf":[
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/reviewObject"
+                }
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/ratingObject"
+                }
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/aggregateRatingObject"
+                }
+              }
+            ]
+            } 
+        },
+        "required": [
+          "identifierSource",
+          "funding",
+          "author",
+          "healthCondition",
+          "description",
+          "identifier",
+          "name"
+        ],
+        "definitions": {
+          "baseOrgObject":{
             "description": "A barebones Organization object to work around recursion issues in DDE",
-            "@type": "Organization",
+            "@type": "outbreak:Organization",
             "type": "object",
             "properties": {
               "name": {
@@ -664,15 +2456,32 @@
               "alternateName": {
                 "description": "Alternate name or Acronym for the organization.",
                 "type": "string"
-              }
+              },
+              "role": {
+                  "description": "LeadSponsor, funder, collaborator",
+                  "enum": [
+                    "lead/primary Sponsor", 
+                    "funder",
+                    "collaborator"
+                  ]
+                },
+              "class": {
+                  "description": "The type of organization",
+                  "enum": [
+                    "U.S. National Institutes of Health", 
+                    "Other U.S. Federal agencies", 
+                    "Industry", 
+                    "All others"
+                  ]
+                }
             },
             "required": [
               "name"
             ]              
           }, 
-            "person": {
+          "person": {
               "description": "Reusable person definition",
-              "@type": "Person",
+              "@type": "outbreak:Person",
               "type": "object",
               "properties": {
                 "name": {
@@ -699,15 +2508,29 @@
                       }
                     }
                   ]
+                },
+                "role": {
+                    "description": "authorship, sponsorship, or other contribution role played by the person or organization in the creation of this resource",
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    ]
                 }
               },
               "required": [
                 "name"
               ]
-            },
-            "memberObject": {
+          },
+          "memberObject": {
               "description": "Reusable person definition accounting for recursion issues in DDE",
-              "@type": "Person",
+              "@type": "outbreak:Person",
               "type": "object",
               "properties": {
                 "name": {
@@ -734,15 +2557,29 @@
                       }
                     }
                   ]
+                },
+                "role": {
+                    "description": "authorship, sponsorship, or other contribution role played by the person or organization in the creation of this resource",
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    ]
                 }
               },
               "required": [
                 "name"
               ]
-            },
-            "organization": {
+          },
+          "organization": {
             "description": "Reusable organization definition",
-            "@type": "Organization",
+            "@type": "outbreak:Organization",
             "type": "object",
             "properties": {
               "name": {
@@ -789,9 +2626,9 @@
               "name"
             ]
           },
-            "funding": {
+          "funding": {
                 "type": "object",
-                "@type": "MonetaryGrant",
+                "@type": "outbreak:MonetaryGrant",
                 "description": "Information about funding or sponsorship support",
                 "properties": {
                   "name": {
@@ -821,9 +2658,9 @@
                   "funder"
                 ]
           },
-            "studyevent": {
+          "studyevent": {
               "type": "object",
-              "@type": "Thing",
+              "@type": "outbreak:StudyEvent",
               "description": "an event status such as StudyStart, PrimaryCompletion, Completion, StudyFirstSubmit, StudyFirstSubmitQC, LastUpdateSubmit",
               "properties": {
                 "studyEventDate": {
@@ -853,10 +2690,10 @@
                   ]
                 }
               }
-            },
-            "studystatus": {
+          },
+          "studystatus": {
               "type": "object",
-              "@type": "Thing",
+              "@type": "outbreak:StudyStatus",
               "properties": {
                 "enrollmentCount": {
                   "description": "The number of participants enrolled in the study",
@@ -912,10 +2749,10 @@
               "required": [
                 "status"
               ]
-            },
-            "studydesign": {
+          },
+          "studydesign": {
               "type": "object",
-              "@type":"Thing",
+              "@type":"outbreak:StudyDesign",
               "properties": {
                 "designStudyText": {
                   "description": "String description of the study design if structured information not available",
@@ -1074,11 +2911,11 @@
                   ]
                 }
               }
-            },
-            "studylocation": {
+          },
+          "studylocation": {
               "description": "The study sites or the location of the study",
               "type": "object",
-              "@type": "Place",
+              "@type": "outbreak:StudyLocation",
               "properties": {
                 "studyLocation": {
                   "description": "The location of the study as listed in the resouce.",
@@ -1112,10 +2949,10 @@
                   ]
                 }
               }
-            },
-            "intervention": {
+          },
+          "intervention": {
               "type": "object",
-              "@type": "Thing",
+              "@type": "outbreak:Intervention",
               "properties": {
                 "name": {
                   "description": "The name of the intervention in the study",
@@ -1142,10 +2979,10 @@
                   ]
                 }
               }
-            },
-            "armgroup": {
+          },
+          "armgroup": {
               "type": "object",
-              "@type": "Thing",
+              "@type": "outbreak:ArmGroup",
               "properties": {
                 "name": {
                   "description": "The name of the arm or factor (can include a specific intervention, a placebo or even a lack of intervention, ie- 'no intervention' group)",
@@ -1181,10 +3018,10 @@
                   ]
                 }
               }
-            },
-            "outcome": {
+          },
+          "outcomeObject": {
               "type": "object",
-              "@type": "Thing",
+              "@type": "outbreak:Outcome",
               "properties": {
                 "outcomeTimeFrame": {
                   "description": "The specific time point(s) and overall duration of evaluation must be specified in this section. ",
@@ -1213,10 +3050,10 @@
                   ]
                 }
               }
-            },
-            "eligibility": {
+          },
+          "eligibility": {
               "type": "object",
-              "@type": "Thing",
+              "@type": "outbreak:Eligibility",
               "properties": {
                 "minimumAge": {
                   "description": "the minimum age for a participant to be included in the study",
@@ -1297,9 +3134,9 @@
                 }
               }
             },
-            "citation": {
-            "description": "A citation object for a resource which is cited by the clinical trial (ie- is a derivative of the clinical trial) , related to the clinical trial, or from which the clinical trial was based on (ie- is derived from).",
-            "@type": "Thing",
+          "citation": {
+            "description": "A citation object for a resource which is cited by the clinical trial/study (ie- is a derivative of the clinical trial/study), related to the clinical trial/study, or from which the clinical trial/study was based on (ie- is derived from).",
+            "@type": "outbreak:CitationObject",
             "type": "object",
             "properties": {
               "name": {
@@ -1318,7 +3155,7 @@
                 "description": "A doi if available",
                 "type": "string"
               },
-              "type": {
+              "sourceType": {
                 "description": "The type of resource",
                 "enum": [
                   "Dataset",
@@ -1327,7 +3164,7 @@
                   "Analysis",
                   "Protocol", 
                   "SoftwareApplication",
-                  "Other"
+                  "CreativeWork"
                   ]
               },
               "url": {
@@ -1347,31 +3184,720 @@
             },
             "required": [
               "name",
-              "type"
+              "sourceType"
+            ]
+          },
+          "reviewObject": {
+            "description": "A review or descriptive evaluation of the resource",
+            "@type": "Review",
+            "type": "object",
+            "properties": {
+              "name": {
+                    "type": "string",
+                    "description": "The name of the review"
+                  },
+              "reviewAspect":{
+                    "description": "This Review or Rating is relevant to this part or facet of the itemReviewed",
+                    "type": "string"
+                  },
+              "reviewBody": {
+                      "description": "The actual body of the review.",
+                      "type": "string"
+                  },
+              "reviewRating": {
+                "description": "The rating given in this review",
+                    "$ref": "#/definitions/ratingObject"      
+                },
+              "author": {
+                    "description": "The author of this content or rating.",
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/person"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/person"
+                      }
+                      },
+                      {
+                        "$ref": "#/definitions/organization"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/organization"
+                      }
+                }
+              ]
+            },
+              "curationDate":{
+                    "description": "The date this evaluation was added into outbreak.info, or was updated in outbreak.info.",
+                    "type": "string",
+                    "format": "date"
+                  }
+                },
+              "required": [
+              ]
+            },
+          "ratingObject": {
+            "description": "A rating or categorical evaluation of the resource",
+            "@type": "Rating",
+            "type": "object",
+            "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "The name of the rating"
+                  },
+                  "ratingExplanation": {
+                    "type": "string",
+                    "description": "An explanation of the rating"    
+                  },
+                  "ratingValue": {
+                    "type": "string",
+                    "description": "The rating for the content."
+                  },
+                  "reviewAspect": {
+                    "type": "string",
+                    "description": "This Review or Rating is relevant to this part or facet of the itemReviewed"
+                  },
+                  "author": {
+                    "description": "The author of this content or rating.",
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/person"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/person"
+                      }
+                      },
+                      {
+                        "$ref": "#/definitions/organization"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/organization"
+                      }
+                }
+              ]
+            },
+                  "curationDate":{
+                    "description": "The date this evaluation was added into outbreak.info, or was updated in outbreak.info.",
+                    "type": "string",
+                    "format": "date"
+                  }
+                },
+            "required": [
+            ]
+          },
+          "aggregateRatingObject": {
+            "description": "A cumulative evaluation of the resource",
+            "@type": "AggregateRating",
+            "type": "object",
+            "properties": {
+                "name": {
+                "type": "string",
+                "description": "The name of the aggregate rating"
+                },
+                "ratingValue": {
+                    "type": "string",
+                    "description": "The rating for the content."
+                },
+                "reviewAspect":{
+                  "description": "This Review or Rating is relevant to this part or facet of the itemReviewed",
+                  "type": "string"
+                },
+                "author": {
+                    "description": "The author of this content or rating.",
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/person"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/person"
+                      }
+                      },
+                      {
+                        "$ref": "#/definitions/organization"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/organization"
+                      }
+                }
+              ]
+            },
+                "curationDate": {
+                    "description": "The date this evaluation was added into outbreak.info, or was updated in outbreak.info.",
+                    "type": "string",
+                    "format": "date"
+                  },
+                "reviews": {
+                  "oneOf": [
+                      {
+                        "$ref": "#/definitions/reviewObject"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/reviewObject"
+                        }
+                      }
+                      
+                  ]
+                },
+                "ratings": {
+                  "oneOf": [
+                      {
+                        "$ref": "#/definitions/ratingObject"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/ratingObject"
+                        }
+                      }
+                      
+                  ]
+                }
+                },
+            "required": [
             ]
           }
           }
-        }
+      }
     },
-    {"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"Official or scientific title of the study","rdfs:label":"name","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":{"@id":"outbreak:ClinicalTrial"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:alternateName","@type":"rdf:Property","rdfs:comment":"Brief title, acronyms, or public titles for the study","rdfs:label":"alternateName","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:alternateName"},"schema:domainIncludes":{"@id":"outbreak:ClinicalTrial"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:identifier","@type":"rdf:Property","rdfs:comment":"Registration number or identifier assigned to the study","rdfs:label":"identifier","owl:cardinality":"many","marginality":"required","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":{"@id":"outbreak:ClinicalTrial"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:identifierSource","@type":"rdf:Property","rdfs:comment":"Source of identifier assignment or type of identifier (NCTid, China CTRid, EudraCT Number, etc.)","rdfs:label":"identifierSource","owl:cardinality":"many","marginality":"required","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":{"@id":"outbreak:ClinicalTrial"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:url","@type":"rdf:Property","rdfs:comment":"url where the study can be found","rdfs:label":"url","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:url"},"schema:domainIncludes":{"@id":"outbreak:ClinicalTrial"},"schema:rangeIncludes":{"@id":"schema:URL"}},
-    {"@id":"outbreak:abstract","@type":"rdf:Property","rdfs:comment":"A brief summary of the study","rdfs:label":"abstract","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:abstract"},"schema:domainIncludes":{"@id":"outbreak:ClinicalTrial"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:description","@type":"rdf:Property","rdfs:comment":"A description of the study or the stated purpose of the study","rdfs:label":"description","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:description"},"schema:domainIncludes":{"@id":"outbreak:ClinicalTrial"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:dateCreated","@type":"rdf:Property","rdfs:comment":"Date the record was created","rdfs:label":"dateCreated","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:dateCreated"},"schema:domainIncludes":{"@id":"outbreak:ClinicalTrial"},"schema:rangeIncludes":{"@id":"schema:Date"}},{"@id":"outbreak:datePublished","@type":"rdf:Property","rdfs:comment":"Date the record was published","rdfs:label":"datePublished","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:datePublished"},"schema:domainIncludes":{"@id":"outbreak:ClinicalTrial"},"schema:rangeIncludes":{"@id":"schema:Date"}},{"@id":"outbreak:dateModified","@type":"rdf:Property","rdfs:comment":"LastUpdatePostDate","rdfs:label":"dateModified","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:dateModified"},"schema:domainIncludes":{"@id":"outbreak:ClinicalTrial"},"schema:rangeIncludes":{"@id":"schema:Date"}},{"@id":"outbreak:dateModifiedType","@type":"rdf:Property","rdfs:comment":"LastUpdatePostDateType","rdfs:label":"dateModifiedType","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:addtionalType"},"schema:domainIncludes":{"@id":"outbreak:ClinicalTrial"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:healthCondition","@type":"rdf:Property","rdfs:comment":"The health condition or disease being studied","rdfs:label":"healthCondition","owl:cardinality":"many","marginality":"required","rdfs:sameAs":{"@id":"schema:MedicalCondition"},"schema:domainIncludes":{"@id":"outbreak:ClinicalTrial"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:healthConditionIidentifier","@type":"rdf:Property","rdfs:comment":"Ontological or controlled vocabulary identifier for the health condition or disease","rdfs:label":"healthConditionIidentifier","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:MedicalCode"},"schema:domainIncludes":{"@id":"outbreak:ClinicalTrial"},"schema:rangeIncludes":{"@id":"schema:Text"}}, {"@id":"outbreak:keywords","@type":"rdf:Property","rdfs:comment":"keywords","rdfs:label":"keywords","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:keywords"},"schema:domainIncludes":{"@id":"outbreak:ClinicalTrial"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:topicCategory","@type":"rdf:Property","rdfs:comment":"Applicable outbreak.info category","rdfs:label":"topicCategory","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:about"},"schema:domainIncludes":{"@id":"outbreak:ClinicalTrial"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:hasResults","@type":"rdf:Property","rdfs:comment":"Binary for if the clinical trial has published any results","rdfs:label":"hasResults","owl:cardinality":"one","marginality":"optional","schema:domainIncludes":{"@id":"outbreak:ClinicalTrial"},"schema:rangeIncludes":{"@id":"schema:Boolean"}},
-    {"@id":"outbreak:author","@type":"rdf:Property","rdfs:comment":"The study's author, this includes ResponsiblePartyInvestigator, Contacts, and OverallOfficials","rdfs:label":"author","owl:cardinality":"many","marginality":"required","rdfs:sameAs":{"@id":"schema:author"},"schema:domainIncludes":{"@id":"outbreak:ClinicalTrial"},"schema:rangeIncludes":[{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"}]},{"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"The name of the study author as it appears in the registery. May include values from the following NCT fields: ResponsiblePartyInvestigatorFullName, OverallOfficialName, ContactName","rdfs:label":"name","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":{"@id":"outbreak:Person"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:givenName","@type":"rdf:Property","rdfs:comment":"The given name of the study author","rdfs:label":"givenName","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:givenName"},"schema:domainIncludes":{"@id":"outbreak:Person"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:familyName","@type":"rdf:Property","rdfs:comment":"The family name of the study author","rdfs:label":"familyName","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:familyName"},"schema:domainIncludes":{"@id":"outbreak:Person"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:affiliation","@type":"rdf:Property","rdfs:comment":"Affiliation associated with the study author","rdfs:label":"affiliation","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:affiliation"},"schema:domainIncludes":{"@id":"outbreak:Organization"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:role","@type":"rdf:Property","rdfs:comment":"The role of this particular author in this study, this includes roles such as ResponsibleParty, Contacts, values of OverallOfficialRole, Investigator","rdfs:label":"role","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":{"@id":"outbreak:Person"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:funding","@type":"rdf:Property","rdfs:comment":"A sponsor, funder, or collaborator for the study. ","rdfs:label":"funding","owl:cardinality":"many","marginality":"required","rdfs:sameAs":{"@id":"outbreak:MonetaryGrant"},"schema:domainIncludes":{"@id":"outbreak:ClinicalTrial"},"schema:rangeIncludes":{"@id":"outbreak:MonetaryGrant"}},{"@id":"outbreak:funder","@type":"rdf:Property","rdfs:comment":"The funder of the analysis","rdfs:label":"funder","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:funder"},"schema:domainIncludes":{"@id":"outbreak:MonetaryGrant"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"The name of the sponsoring or funding organization","rdfs:label":"name","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":{"@id":"outbreak:Organization"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:class","@type":"rdf:Property","rdfs:comment":"The type of organization","rdfs:label":"class","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:addtionalType"},"schema:domainIncludes":{"@id":"outbreak:Organization"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:role","@type":"rdf:Property","rdfs:comment":"LeadSponsor, funder, collaborator","rdfs:label":"role","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":{"@id":"outbreak:Organization"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:studyEvent","@type":"rdf:Property","rdfs:comment":"an event status such as StudyStart, PrimaryCompletion, Completion, StudyFirstSubmit, StudyFirstSubmitQC, LastUpdateSubmit","rdfs:label":"studyEvent","owl:cardinality":"many","marginality":"recommended","schema:domainIncludes":{"@id":"outbreak:ClinicalTrial"},"schema:rangeIncludes":{"@id":"outbreak:StudyEvent"}},{"@id":"outbreak:studyEventType","@type":"rdf:Property","rdfs:comment":"Type of the event status such as StudyStart, PrimaryCompletion, Completion, StudyFirstSubmit, StudyFirstSubmitQC, LastUpdateSubmit","rdfs:label":"studyEventType","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":{"@id":"outbreak:StudyEvent"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:studyEventDate","@type":"rdf:Property","rdfs:comment":"StartDate, Primary CompletionDate, CompletionDate, StudyFirstSubmitDate, StudyFirstSubmitQCDate, LastUpdateSubmitDate","rdfs:label":"studyEventDate","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:temporal"},"schema:domainIncludes":{"@id":"outbreak:StudyEvent"},"schema:rangeIncludes":{"@id":"schema:Date"}},{"@id":"outbreak:studyEventDateType","@type":"rdf:Property","rdfs:comment":"the type of date provided (actual, anticipated, or estimated)","rdfs:label":"studyEventDateType","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:addtionalType"},"schema:domainIncludes":{"@id":"outbreak:StudyEvent"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:studyStatus","@type":"rdf:Property","rdfs:comment":"The status of the study","rdfs:label":"studyStatus","owl:cardinality":"one","marginality":"recommended","schema:domainIncludes":{"@id":"outbreak:ClinicalTrial"},"schema:rangeIncludes":{"@id":"outbreak:StudyStatus"}},{"@id":"outbreak:status","@type":"rdf:Property","rdfs:comment":"The recruitment status of the study","rdfs:label":"status","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"outbreak:status"},"schema:domainIncludes":{"@id":"outbreak:StudyStatus"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:statusExpandedAccess","@type":"rdf:Property","rdfs:comment":"Flag for whether or not the study has expanded Access status","rdfs:label":"statusExpandedAccess","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"outbreak:statusExpandedAccess"},"schema:domainIncludes":{"@id":"outbreak:StudyStatus"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:statusDate","@type":"rdf:Property","rdfs:comment":"The date that the status was verified. Equivalent to NCT's StatusVerifiedDate","rdfs:label":"statusDate","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"outbreak:statusDate"},"schema:domainIncludes":{"@id":"outbreak:StudyStatus"},"schema:rangeIncludes":{"@id":"schema:Date"}},{"@id":"outbreak:enrollmentCount","@type":"rdf:Property","rdfs:comment":"The number of participants enrolled in the study","rdfs:label":"enrollmentCount","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"outbreak:enrollmentCount"},"schema:domainIncludes":{"@id":"outbreak:StudyStatus"},"schema:rangeIncludes":{"@id":"schema:Number"}},{"@id":"outbreak:enrollmentType","@type":"rdf:Property","rdfs:comment":"The type of estimation used to determine the enrollmentCount (actual counts, target size, etc.)","rdfs:label":"enrollmentType","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"outbreak:enrollmentType"},"schema:domainIncludes":{"@id":"outbreak:StudyStatus"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:whyStopped","@type":"rdf:Property","rdfs:comment":"A brief explanation of the reason(s) why such clinical study was stopped (for a clinical study that is \"Suspended,\" \"Terminated,\" or \"Withdrawn\" prior to its planned completion as anticipated by the protocol)","rdfs:label":"whyStopped","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:description"},"schema:domainIncludes":{"@id":"outbreak:StudyStatus"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:studyDesign","@type":"rdf:Property","rdfs:comment":"The general design of the study","rdfs:label":"studyDesign","owl:cardinality":"one","marginality":"recommended","schema:domainIncludes":{"@id":"outbreak:ClinicalTrial"},"schema:rangeIncludes":{"@id":"outbreak:StudyDesign"}},{"@id":"outbreak:studyType","@type":"rdf:Property","rdfs:comment":"Type of human study, can be subtypes of observational study or interventional studies","rdfs:label":"studyType","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"outbreak:studyType"},"schema:domainIncludes":{"@id":"outbreak:StudyDesign"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:phase","@type":"rdf:Property","rdfs:comment":"Stage or phase of the study in the U.S.","rdfs:label":"phase","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"outbreak:phase"},"schema:domainIncludes":{"@id":"outbreak:StudyDesign"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:phaseNumber","@type":"rdf:Property","rdfs:comment":"The number of the phase or stage of the study","rdfs:label":"phaseNumber","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":{"@id":"outbreak:StudyDesign"},"schema:rangeIncludes":{"@id":"schema:Number"}},{"@id":"outbreak:designAllocation","@type":"rdf:Property","rdfs:comment":"The method by which the study participants were allocated into groups","rdfs:label":"designAllocation","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"outbreak:designAllocation"},"schema:domainIncludes":{"@id":"outbreak:StudyDesign"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:designModel","@type":"rdf:Property","rdfs:comment":"The general design of the strategy for assigning interventions to participants in a clinical intervention study OR the general design of the strategy for identifying and following up with participants during an observational study and may include the temporal relationship of observation period to time of participant enrollment.","rdfs:label":"designModel","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"outbreak:designModel"},"schema:domainIncludes":{"@id":"outbreak:StudyDesign"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:designPrimaryPurpose","@type":"rdf:Property","rdfs:comment":"The primary purpose of the study","rdfs:label":"designPrimaryPurpose","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"outbreak:designPrimaryPurpose"},"schema:domainIncludes":{"@id":"outbreak:StudyDesign"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:designWhoMasked","@type":"rdf:Property","rdfs:comment":"The people who not know which participants have been assigned to which interventions.","rdfs:label":"designWhoMasked","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"outbreak:designWhoMasked"},"schema:domainIncludes":{"@id":"outbreak:StudyDesign"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:designStudyText","@type":"rdf:Property","rdfs:comment":"String description of the study design if structured information not available","rdfs:label":"designStudyText","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:description"},"schema:domainIncludes":{"@id":"outbreak:StudyDesign"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:armGroup","@type":"rdf:Property","rdfs:comment":"The arm or factor of an interventional study","rdfs:label":"armGroup","owl:cardinality":"many","marginality":"optional","schema:domainIncludes":{"@id":"outbreak:ClinicalTrial"},"schema:rangeIncludes":{"@id":"outbreak:ArmGroup"}},{"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"The name of the arm or factor (can include a specific intervention, a placebo or even a lack of intervention, ie- 'no intervention' group). The Group or cohort in the case of observational studies","rdfs:label":"name","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"outbreak:name"},"schema:domainIncludes":{"@id":"outbreak:ArmGroup"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:role","@type":"rdf:Property","rdfs:comment":"The role of the arm or factor in the study this is equivalent to the ArmType in ClinicalTrials.gov","rdfs:label":"role","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"outbreak:role"},"schema:domainIncludes":{"@id":"outbreak:ArmGroup"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:description","@type":"rdf:Property","rdfs:comment":"A description of the arm or factor","rdfs:label":"description","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"outbreak:description"},"schema:domainIncludes":{"@id":"outbreak:ArmGroup"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:intervention","@type":"rdf:Property","rdfs:comment":"The interventions (if any) in this ArmGroup","rdfs:label":"intervention","owl:cardinality":"many","marginality":"optional","schema:domainIncludes":{"@id":"outbreak:ArmGroup"},"schema:rangeIncludes":{"@id":"outbreak:Intervention"}},{"@id":"outbreak:category","@type":"rdf:Property","rdfs:comment":"The category of the arm or factor in the study","rdfs:label":"category","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":{"@id":"outbreak:Intervention"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"The name of the intervention in the study","rdfs:label":"name","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":{"@id":"outbreak:Intervention"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:description","@type":"rdf:Property","rdfs:comment":"A description of the intervention in the study","rdfs:label":"description","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:description"},"schema:domainIncludes":{"@id":"outbreak:Intervention"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:outcome","@type":"rdf:Property","rdfs:comment":"The outcome (expected or actual) of a study","rdfs:label":"outcome","owl:cardinality":"many","marginality":"recommended","schema:domainIncludes":{"@id":"outbreak:ClinicalTrial"},"schema:rangeIncludes":{"@id":"outbreak:Outcome"}},{"@id":"outbreak:outcomeMeasure","@type":"rdf:Property","rdfs:comment":"The outcome measure for the study","rdfs:label":"outcomeMeasure","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"outbreak:outcomeMeasure"},"schema:domainIncludes":{"@id":"outbreak:Outcome"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:outcomeTimeFrame","@type":"rdf:Property","rdfs:comment":"The specific time point(s) and overall duration of evaluation must be specified in this section. ","rdfs:label":"outcomeTimeFrame","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"outbreak:outcomeTimeFrame"},"schema:domainIncludes":{"@id":"outbreak:Outcome"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:outcomeType","@type":"rdf:Property","rdfs:comment":"The classification of the outcome measure as either primary, secondary, or exploratory","rdfs:label":"outcomeType","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"outbreak:outcomeType"},"schema:domainIncludes":{"@id":"outbreak:Outcome"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:eligibilityCriteria","@type":"rdf:Property","rdfs:comment":"eligibility criteria","rdfs:label":"eligibilityCriteria","owl:cardinality":"one","marginality":"recommended","schema:domainIncludes":{"@id":"outbreak:ClinicalTrial"},"schema:rangeIncludes":{"@id":"outbreak:Eligibility"}},{"@id":"outbreak:inclusionCriteria","@type":"rdf:Property","rdfs:comment":"criteria for inclusion in the study","rdfs:label":"inclusionCriteria","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"outbreak:inclusionCriteria"},"schema:domainIncludes":{"@id":"outbreak:Eligibility"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:minimumAge","@type":"rdf:Property","rdfs:comment":"the minimum age for a participant to be included in the study","rdfs:label":"minimumAge","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"outbreak:minimumAge"},"schema:domainIncludes":{"@id":"outbreak:Eligibility"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:maximumAge","@type":"rdf:Property","rdfs:comment":"the maximum age for a participant to be included in the study","rdfs:label":"maximumAge","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:requiredMaxAge"},"schema:domainIncludes":{"@id":"outbreak:Eligibility"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:gender","@type":"rdf:Property","rdfs:comment":"the sex requirement to be included in the study","rdfs:label":"gender","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:requiredGender"},"schema:domainIncludes":{"@id":"outbreak:Eligibility"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:genderBased","@type":"rdf:Property","rdfs:comment":"Boolean for whether or not participation is based on gender","rdfs:label":"genderBased","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"outbreak:genderBased"},"schema:domainIncludes":{"@id":"outbreak:Eligibility"},"schema:rangeIncludes":{"@id":"schema:Boolean"}},{"@id":"outbreak:healthyVolunteers","@type":"rdf:Property","rdfs:comment":"a boolean to indicate whether or not healthy volunteers may be included in the study","rdfs:label":"healthyVolunteers","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"outbreak:healthyVolunteers"},"schema:domainIncludes":{"@id":"outbreak:Eligibility"},"schema:rangeIncludes":{"@id":"schema:Boolean"}},{"@id":"outbreak:stdAge","@type":"rdf:Property","rdfs:comment":"the age category of a participant to be included in the study if a minimum and maximum age is not specified","rdfs:label":"stdAge","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"outbreak:stdAge"},"schema:domainIncludes":{"@id":"outbreak:Eligibility"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:exclusionCriteria","@type":"rdf:Property","rdfs:comment":"criteria for exclusion from the study","rdfs:label":"exclusionCriteria","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"outbreak:exclusionCriteria"},"schema:domainIncludes":{"@id":"outbreak:Eligibility"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:criteriaText","@type":"rdf:Property","rdfs:comment":"The descriptive criteria as published for the Clinical Trial","rdfs:label":"criteriaText","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"outbreak:criteriaText"},"schema:domainIncludes":{"@id":"outbreak:Eligibility"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:citedBy","@type":"rdf:Property","rdfs:comment":"other articles or resources that cite this clinical trial","rdfs:label":"citedBy","owl:cardinality":"many","marginality":"optional","owl:inverseOf":{"@id":"schema:isBasedOn"},"schema:domainIncludes":{"@id":"outbreak:ClinicalTrial"},"schema:rangeIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}]},{"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"name of the citedBy resource","rdfs:label":"name","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:type","@type":"rdf:Property","rdfs:comment":"type (publication, protocol, dataset, code, etc.) of the citedBy resource. Note that this can include ClinicalTrial results","rdfs:label":"type","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:additionalType"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:identifier","@type":"rdf:Property","rdfs:comment":"identifier (pmid, WHO protocol id, etc.) of the citedby resource","rdfs:label":"identifier","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:url","@type":"rdf:Property","rdfs:comment":"url of the cited by resource","rdfs:label":"url","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:url"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:URL"}},{"@id":"outbreak:datePublished","@type":"rdf:Property","rdfs:comment":"The date for which the other articles, resources, or results that cite this clinical trial were posted, published, or made available","rdfs:label":"datePublished","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:datePublished"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:isBasedOn","@type":"rdf:Property","rdfs:comment":"Associated datasets, software, protocols, etc. used by the work described in this clinical study (includes study protocol documents, data analysis plans, reference publications. etc)","rdfs:label":"isBasedOn","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:isBasedOn"},"schema:domainIncludes":{"@id":"outbreak:ClinicalTrial"},"schema:rangeIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}]},{"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"name of the associated dataset, software, protocols, etc used by the work described in this clinical study","rdfs:label":"name","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:type","@type":"rdf:Property","rdfs:comment":"type of the associated resource (dataset, protocols, analysis, etc.) used by the work described in this clinical study","rdfs:label":"type","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:additionalType"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:identifier","@type":"rdf:Property","rdfs:comment":"Identifier of the associated datasets, software, protocols, etc.","rdfs:label":"identifier","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:versionDate","@type":"rdf:Property","rdfs:comment":"date of the version of the associated resource used by the work described in this clinical trial","rdfs:label":"versionDate","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":[{"@id":"schema:releaseDate"},{"@id":"schema:dateModified"}],"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Date"}},{"@id":"outbreak:url","@type":"rdf:Property","rdfs:comment":"url of the associated resource used by the work described in this clinical study (includes study protocol documents, data analysis plans, etc)","rdfs:label":"url","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:url"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:URL"}},
-    {"@id":"outbreak:isRelatedTo","@type":"rdf:Property","rdfs:comment":"Other resources related to, but not a derivative of nor derived from this analysis","rdfs:label":"isRelatedTo","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:isRelatedTo"},"schema:domainIncludes":{"@id":"outbreak:ClinicalTrial"},"schema:rangeIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}]},{"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"name of related resource","rdfs:label":"name","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:type","@type":"rdf:Property","rdfs:comment":"type of related resource","rdfs:label":"type","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:additionalType"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:identifier","@type":"rdf:Property","rdfs:comment":"identifier (if available) of related resource","rdfs:label":"identifier","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:curatedBy","@type":"rdf:Property","rdfs:comment":"The source from which this clinical trial was identified for inclusion into Outbreak.info. Provides provenance for a resource which was curated by another","rdfs:label":"curatedBy","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:citation"},"schema:domainIncludes":{"@id":"outbreak:ClinicalTrial"},"schema:rangeIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}]},
-    {"@id":"outbreak:curatedBy","@type":"rdf:Property","rdfs:comment":"The source from which this dataset was identified for inclusion into Outbreak.info. Provides provenance for a resource which was curated by another","rdfs:label":"curatedBy","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:citation"},"schema:domainIncludes":{"@id":"outbreak:Dataset"},"schema:rangeIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"},{"@id":"schema:Thing"}]},
-    {"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"name of the source from which this dataset was identified for inclusion","rdfs:label":"name","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}}, 
-    {"@id":"outbreak:curationDate","@type":"rdf:Property","rdfs:comment":"The date this resource was added to outbreak.info, or the date when this resource was updated in outbreak.info","rdfs:label":"curationDate","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:releaseDate"},"schema:domainIncludes":{"@id":"outbreak:ClinicalTrial"},"schema:rangeIncludes":{"@id":"schema:Date"}}
+    {
+      "@id": "outbreak:identifierSource",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Source of identifier assignment or type of identifier (NCTid, China CTRid, EudraCT Number, etc.)",
+      "rdfs:label": "identifierSource",
+      "schema:domainIncludes": {
+        "@id": "outbreak:ClinicalTrial"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:dateModifiedType",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The type of date. Equivalent to NCT's LastUpdatePostDateType",
+      "rdfs:label": "dateModifiedType",
+      "schema:domainIncludes": {
+        "@id": "outbreak:ClinicalTrial"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:healthConditionIdentifier",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Ontological or controlled vocabulary identifier for the health condition or disease",
+      "rdfs:label": "healthConditionIdentifier",
+      "schema:domainIncludes": {
+        "@id": "outbreak:ClinicalTrial"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        },
+        {
+          "@id": "schema:DefinedTerm"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:hasResults",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Boolean for if the clinical trial has published any results",
+      "rdfs:label": "hasResults",
+      "schema:domainIncludes": {
+        "@id": "outbreak:ClinicalTrial"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Boolean"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:studyEvent",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "an event status such as StudyStart, PrimaryCompletion, Completion, StudyFirstSubmit, StudyFirstSubmitQC, LastUpdateSubmit",
+      "rdfs:label": "studyEvent",
+      "schema:domainIncludes": {
+        "@id": "outbreak:ClinicalTrial"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "outbreak:StudyEvent"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:studyStatus",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The status of the study",
+      "rdfs:label": "studyStatus",
+      "schema:domainIncludes": {
+        "@id": "outbreak:ClinicalTrial"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "outbreak:StudyStatus"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:studyDesign",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The general design of the study",
+      "rdfs:label": "studyDesign",
+      "schema:domainIncludes": {
+        "@id": "outbreak:ClinicalTrial"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "outbreak:StudyDesign"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:armGroup",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The arm or factor of an interventional study",
+      "rdfs:label": "armGroup",
+      "schema:domainIncludes": {
+        "@id": "outbreak:ClinicalTrial"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "outbreak:ArmGroup"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:outcome",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The arm or factor of an interventional study",
+      "rdfs:label": "outcome",
+      "schema:domainIncludes": {
+        "@id": "outbreak:ClinicalTrial"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "outbreak:Outcome"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:eligibilityCriteria",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "eligibility criteria",
+      "rdfs:label": "eligibilityCriteria",
+      "schema:domainIncludes": {
+        "@id": "outbreak:ClinicalTrial"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "outbreak:Eligibility"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:author",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The author of this resource, content, or rating",
+      "rdfs:label": "author",
+      "rdfs:sameAs": {"@id":"schema:author"},
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "outbreak:Person"
+        },
+        {
+          "@id": "outbreak:Organization"
+        }  
+      ]
+    },
+    {
+      "@id": "outbreak:dateCreated",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Date the record was created",
+      "rdfs:label": "dateCreated",
+      "rdfs:sameAs": {"@id":"schema:dateCreated"},
+      "schema:domainIncludes": [
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Date"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:datePublished",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Date of first broadcast/publication",
+      "rdfs:label": "datePublished",
+      "rdfs:sameAs": {"@id":"schema:datePublished"},
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Date"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:dateModified",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The date on which the CreativeWork was most recently modified or when the item's entry was modified within a DataFeed",
+      "rdfs:label": "dateModified",
+      "rdfs:sameAs": {"@id":"schema:dateModified"},
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Date"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:keywords",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "keywords for describing the record",
+      "rdfs:label": "keywords",
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:abstract",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "A short descriptive summary of the publication or study",
+      "rdfs:label": "abstract",
+      "rdfs:sameAs": {"@id":"schema:abstract"},
+      "schema:domainIncludes": [
+          {"@id": "outbreak:Publication"},
+          {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:pmid",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "A pubmed identifier if available",
+      "rdfs:label": "pmid",
+      "schema:domainIncludes": [
+          {"@id": "outbreak:CitationObject"},
+          {"@id": "outbreak:Correction"},
+          {"@id": "outbreak:Publication"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Integer"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:doi",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "A doi if available",
+      "rdfs:label": "doi",
+      "schema:domainIncludes": [
+          {"@id": "outbreak:CitationObject"},
+          {"@id": "outbreak:Correction"},
+          {"@id": "outbreak:Dataset"},
+          {"@id": "outbreak:Publication"},
+          {"@id": "outbreak:Analysis"},
+          {"@id": "outbreak:Protocol"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:funding",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Funding that supports (sponsors) the collection of this dataset through some kind of financial contribution",
+      "rdfs:label": "funding",
+      "schema:domainIncludes": [
+          {"@id": "outbreak:Dataset"},
+          {"@id": "outbreak:Publication"},
+          {"@id": "outbreak:Analysis"},
+          {"@id": "outbreak:Protocol"},
+          {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:MonetaryGrant"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:measurementTechnique",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "A technique or technology used in this resource",
+      "rdfs:label": "measurementTechnique",
+      "rdfs:sameAs": {"@id":"schema:measurementTechnique"},
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Protocol"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        },
+        {
+          "@id": "schema:DefinedTerm"
+        }  
+      ]
+    },
+    {
+      "@id": "outbreak:species",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Species(es) from which dataset has been collected",
+      "rdfs:label": "species",
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Analysis"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        },
+        {
+          "@id": "schema:DefinedTerm"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:infectiousAgent",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "infectious agents(s) which are the focus of the dataset",
+      "rdfs:label": "infectiousAgent",
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Analysis"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        },
+        {
+          "@id": "schema:DefinedTerm"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:infectiousDisease",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The disease or medical conditions caused by the infectious agent. Important as some agents may cause multiple diseases",
+      "rdfs:label": "infectiousDisease",
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Analysis"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        },
+        {
+          "@id": "schema:DefinedTerm"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:topicCategory",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Applicable outbreak.info category",
+      "rdfs:label": "topicCategory",
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+
+    {
+      "@id": "outbreak:isBasedOn",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "A citation to a resource (eg- publication, protocol, etc.) on which this resource was derived (stored as an object, not a string)",
+      "rdfs:label": "isBasedOn",
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {"@id": "outbreak:CitationObject"},
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:ClinicalTrial"},
+        {"@id": "schema:SoftwareApplication"},
+        {"@id": "schema:CreativeWork"}
+      ]
+    },
+    {
+      "@id": "outbreak:isRelatedTo",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "A citation to a resource (eg- publication, protocol, etc.) which is related to the resource but is not a derivative nor was derived from the resource (stored as an object, not a string)",
+      "rdfs:label": "isRelatedTo",
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {"@id": "outbreak:CitationObject"},
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:ClinicalTrial"},
+        {"@id": "schema:SoftwareApplication"},
+        {"@id": "schema:CreativeWork"}
+      ]
+    },
+    {
+      "@id": "outbreak:citedBy",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "A citation to a resource (eg- publication, protocol, etc.) which is derived from this resource (stored as an object, not a string)",
+      "rdfs:label": "citedBy",
+      "rdfs:sameAs":{"@id":"owl:inverseOf: outbreak:isBasedOn"},
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {"@id": "outbreak:CitationObject"},
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:ClinicalTrial"},
+        {"@id": "schema:SoftwareApplication"},
+        {"@id": "schema:CreativeWork"}
+      ]
+    },
+    {
+      "@id": "outbreak:curatedBy",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The source from which this Dataset was identified for inclusion into Outbreak.info. Provides provenance for a resource which was curated by another.",
+      "rdfs:label": "curatedBy",
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {"@id": "outbreak:Person"},
+        {"@id": "outbreak:Organization"},
+        {"@id": "outbreak:CitationObject"},
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:ClinicalTrial"},
+        {"@id": "schema:SoftwareApplication"},
+        {"@id": "schema:CreativeWork"}
+      ]
+    },
+    {
+      "@id": "outbreak:curationDate",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
+      "rdfs:label": "curationDate",
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {"@id": "schema:Date"}
+      ]
+    },
+    {
+      "@id": "outbreak:evaluations",
+      "@type": "rdf:Property",
+      "rdfs:comment":"One or more reviews, ratings, or other evaluations of this resource",
+      "rdfs:label": "evaluations",
+      "schema:domainIncludes":[
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes":[
+        {"@id": "schema:Review"},
+        {"@id": "schema:Rating"},
+        {"@id": "schema:AggregateRating"}
+      ]
+    }
   ]
 }

--- a/yaml/outbreak_ClinicalTrial.yml
+++ b/yaml/outbreak_ClinicalTrial.yml
@@ -1,315 +1,681 @@
 '@context':
-  outbreak: https://discovery.biothings.io/view/outbreak/
-  owl: http://www.w3.org/2002/07/owl/
-  rdf: http://www.w3.org/1999/02/22/-rdf-syntax-ns/
-  rdfs: http://www.w3.org/2000/01/rdf/-schema/
+  outbreak: http://discovery.biothings.io/view/
+  rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
+  rdfs: http://www.w3.org/2000/01/rdf-schema#
   schema: http://schema.org/
 '@graph':
-- '@id': outbreak:Organization
+- $validation:
+    $schema: http://json-schema.org/draft-07/schema#
+    definitions:
+      baseOrgObject:
+        '@type': outbreak:Organization
+        properties:
+          alternateName:
+            type: string
+          name:
+            type: string
+        required:
+        - name
+        type: object
+    properties:
+      affiliation:
+        description: An organization that this person is affiliated with. For example,
+          a school/university, a club, or a team.
+        oneOf:
+        - $ref: '#/definitions/baseOrgObject'
+        - items:
+            $ref: '#/definitions/baseOrgObject'
+          type: array
+      alternateName:
+        description: An alias for the person.
+        type: string
+      familyName:
+        description: Family name. In the U.S., the last name of an Person. This can
+          be used along with givenName instead of the name property.
+        type: string
+      givenName:
+        description: Given name. In the U.S., the first name of a Person. This can
+          be used along with familyName instead of the name property.
+        type: string
+      name:
+        description: The name of the person.
+        type: string
+      orcid:
+        description: the ORCID ID of the person
+        type: string
+      role:
+        description: authorship, sponsorship, or other contribution role played by
+          the person or organization in the creation of this resource
+        oneOf:
+        - type: string
+        - items:
+            type: string
+          type: array
+    required:
+    - name
+    type: object
+  '@id': outbreak:Person
   '@type': rdfs:Class
-  rdfs:comment: This is the schema for describing the Organization schema used for
-    outbreak.info.
+  rdfs:comment: This is the Person schema for describing authors and people for outbreak.info
+    resources
+  rdfs:label: Person
+  rdfs:subClassOf:
+    '@id': schema:Person
+- '@id': outbreak:orcid
+  '@type': rdfs:Property
+  rdfs:comment: the ORCID ID of the person
+  rdfs:label: orcid
+  schema:domainIncludes:
+    '@id': outbreak:Person
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- $validation:
+    $schema: http://json-schema.org/draft-07/schema#
+    definitions:
+      baseOrgObject:
+        '@type': outbreak:Organization
+        description: Affiliated Organization
+        properties:
+          alternateName:
+            description: Alternate name or Acronym for the organization.
+            type: string
+          name:
+            description: name of the organization
+            type: string
+        required:
+        - name
+        type: object
+      basePersonObject:
+        '@type': outbreak:Person
+        properties:
+          affiliation:
+            description: consortia or other organizations with which this person is
+              affiliated
+            oneOf:
+            - $ref: '#/definitions/baseOrgObject'
+            - items:
+                $ref: '#/definitions/baseOrgObject'
+              type: array
+          alternateName:
+            type: string
+          familyName:
+            type: string
+          givenName:
+            type: string
+          name:
+            type: string
+          orcid:
+            type: string
+        required:
+        - name
+        type: object
+    properties:
+      affiliation:
+        description: consortia or other organizations with which this organization
+          is affiliated
+        oneOf:
+        - $ref: '#/definitions/baseOrgObject'
+        - items:
+            $ref: '#/definitions/baseOrgObject'
+          type: array
+      alternateName:
+        description: An alias or acronym for the organization.
+        type: string
+      class:
+        description: A classification of the organization by a resource. Eg- for ClinicalTrials
+          funders, it's [U.S. National Institutes of Health, Other U.S. Federal agencies,
+          Industry, All others]
+        type: string
+      members:
+        description: Members of this organization, team, or group
+        oneOf:
+        - $ref: '#/definitions/basePersonObject'
+        - items:
+            $ref: '#/definitions/basePersonObject'
+          type: array
+      name:
+        description: The name of the organization.
+        type: string
+      role:
+        description: The role of an organization in its involvement with a resource
+        oneOf:
+        - type: string
+        - items:
+            type: string
+          type: array
+    required:
+    - name
+    type: object
+  '@id': outbreak:Organization
+  '@type': rdfs:Class
+  rdfs:comment: This is the organization schema for describing authors, funders and
+    other organizations referenced by outbreak.info resources
   rdfs:label: Organization
   rdfs:subClassOf:
     '@id': schema:Organization
-  schema:isPartOf:
-    '@id': https://discovery.biothings.io/view/outbreak/
-- '@id': outbreak:name
-  '@type': rdf:Property
-  marginality: required
-  owl:cardinality: one
-  rdfs:comment: The name of the organization, team or group
-  rdfs:label: name
-  rdfs:sameAs:
-    '@id': schema:name
-  schema:domainIncludes:
-    '@id': outbreak:Organization
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:alternateName
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: Alternative names or commonly used abbreviations for the organization,
-    team or group
-  rdfs:label: alternateName
-  rdfs:sameAs:
-    '@id': schema:alternateName
-  schema:domainIncludes:
-    '@id': outbreak:Organization
-  schema:rangeIncludes:
-    '@id': schema:Text
 - '@id': outbreak:affiliation
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: An overarching consortia, multi-institutional team or group in which
-    the organization/team/group is a member or affiliate
+  '@type': rdfs:Property
+  rdfs:comment: consortia or other organizations with which this organization is affiliated
   rdfs:label: affiliation
-  rdfs:sameAs:
-    '@id': schema:affiliation
   schema:domainIncludes:
     '@id': outbreak:Organization
   schema:rangeIncludes:
-    '@id': outbreak:Organization
-- '@id': outbreak:affiliationStatus
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The status of the organization's membership or affiliation in the
-    overarching consortial, multi-institutional team or group (current, past)
-  rdfs:label: affiliationStatus
-  rdfs:sameAs:
-    '@id': schema:additionalType
-  schema:domainIncludes:
-    '@id': outbreak:Organization
-  schema:rangeIncludes:
-    '@id': schema:Text
+  - '@id': outbreak:Organization
 - '@id': outbreak:members
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
+  '@type': rdfs:Property
   rdfs:comment: Members of this organization, team, or group
   rdfs:label: members
-  rdfs:sameAs:
-    '@id': schema:members
   schema:domainIncludes:
     '@id': outbreak:Organization
   schema:rangeIncludes:
   - '@id': outbreak:Person
-  - '@id': outbreak:Organization
-- '@id': outbreak:membershipStatus
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: Status of the members of this organization
-  rdfs:label: membershipStatus
-  rdfs:sameAs:
-    '@id': schema:additionalType
-  schema:domainIncludes:
-    '@id': outbreak:Organization
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:relatedTo
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: many
-  rdfs:comment: A resource which a person played a role
-  rdfs:label: relatedTo
-  rdfs:sameAs:
-    '@id': schema:relatedTo
-  schema:domainIncludes:
-    '@id': outbreak:Organization
-  schema:rangeIncludes:
-  - '@id': schema:CreativeWork
-  - '@id': schema:HowTo
 - '@id': outbreak:class
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: many
+  '@type': rdfs:Property
   rdfs:comment: A classification of the organization by a resource. Eg- for ClinicalTrials
-    funders, it's ["U.S. National Institutes of Health", "Other U.S. Federal agencies",
-    "Industry", "All others"]
+    funders, it's [U.S. National Institutes of Health, Other U.S. Federal agencies,
+    Industry, All others]
   rdfs:label: class
-  rdfs:sameAs:
-    '@id': schema:addtionalType
   schema:domainIncludes:
-  - '@id': schema:CreativeWork
-  - '@id': schema:HowTo
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:role
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: many
-  rdfs:comment: The role of an organization in its involvement with a resource
-  rdfs:label: role
-  rdfs:sameAs:
-    '@id': schema:additionalType
-  schema:domainIncludes:
-  - '@id': schema:CreativeWork
-  - '@id': schema:HowTo
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:Person
-  '@type': rdfs:Class
-  rdfs:comment: This is the schema for describing the Person schema used for outbreak.info.
-  rdfs:label: Person
-  rdfs:subClassOf:
-    '@id': schema:Person
-  schema:isPartOf:
-    '@id': https://discovery.biothings.io/view/outbreak/
-- '@id': outbreak:name
-  '@type': rdf:Property
-  marginality: required
-  owl:cardinality: one
-  rdfs:comment: The name of the person
-  rdfs:label: name
-  rdfs:sameAs:
-    '@id': schema:name
-  schema:domainIncludes:
-    '@id': outbreak:Person
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:alternateName
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: Alternative ways in which the person's name is included in a record
-  rdfs:label: alternateName
-  rdfs:sameAs:
-    '@id': schema:alternateName
-  schema:domainIncludes:
-    '@id': outbreak:Person
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:givenName
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The given name of the person
-  rdfs:label: givenName
-  rdfs:sameAs:
-    '@id': schema:givenName
-  schema:domainIncludes:
-    '@id': outbreak:Person
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:familyName
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The family name of the person
-  rdfs:label: familyName
-  rdfs:sameAs:
-    '@id': schema:familyName
-  schema:domainIncludes:
-    '@id': outbreak:Person
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:affiliation
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: The organization with which the person is affiliated or has membership
-    in
-  rdfs:label: affiliation
-  rdfs:sameAs:
-    '@id': schema:affiliation
-  schema:domainIncludes:
-    '@id': outbreak:Person
-  schema:rangeIncludes:
     '@id': outbreak:Organization
-- '@id': outbreak:affiliationStatus
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The status of the person's membership or affiliation in an organization,
-    team or group (current, past)
-  rdfs:label: affiliationStatus
-  rdfs:sameAs:
-    '@id': schema:addtionalType
-  schema:domainIncludes:
-    '@id': outbreak:Person
   schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:orcid
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The ORCID ID of the person
-  rdfs:label: orcid
-  rdfs:sameAs:
-    '@id': schema:identifier
-  schema:domainIncludes:
-    '@id': outbreak:Person
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:relatedTo
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: many
-  rdfs:comment: A resource which a person played a role
-  rdfs:label: relatedTo
-  rdfs:sameAs:
-    '@id': schema:relatedTo
-  schema:domainIncludes:
-    '@id': outbreak:Person
-  schema:rangeIncludes:
-  - '@id': schema:CreativeWork
-  - '@id': schema:HowTo
+  - '@id': schema:Text
 - '@id': outbreak:role
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: The role a person played in the creation of a resource
+  '@type': rdfs:Property
+  rdfs:comment: authorship, sponsorship, or other contribution role played by the
+    person or organization in the creation of this resource. In a Clinical Study/Trial
+    ArmGroup, it's equivalent to the ArmType in ClinicalTrials.gov
   rdfs:label: role
-  rdfs:sameAs:
-    '@id': schema:addtionalType
   schema:domainIncludes:
-  - '@id': schema:CreativeWork
-  - '@id': schema:HowTo
+  - '@id': outbreak:Person
+  - '@id': outbreak:Organization
+  - '@id': outbreak:ArmGroup
   schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:StudyEvent
+  - '@id': schema:Text
+- $validation:
+    $schema: http://json-schema.org/draft-07/schema#
+    definitions:
+      baseOrgObject:
+        '@type': outbreak:Organization
+        description: Affiliated Organization
+        properties:
+          alternateName:
+            description: Alternate name or Acronym for the organization.
+            type: string
+          name:
+            description: name of the organization
+            type: string
+        required:
+        - name
+        type: object
+      basePersonObject:
+        '@type': outbreak:Person
+        properties:
+          affiliation:
+            description: consortia or other organizations with which this person is
+              affiliated
+            oneOf:
+            - $ref: '#/definitions/baseOrgObject'
+            - items:
+                $ref: '#/definitions/baseOrgObject'
+              type: array
+          alternateName:
+            type: string
+          familyName:
+            type: string
+          givenName:
+            type: string
+          name:
+            type: string
+          orcid:
+            type: string
+        required:
+        - name
+        type: object
+    properties:
+      funder:
+        description: The organization(s) that supported (sponsored) the grant through
+          some kind of financial contribution.
+        oneOf:
+        - $ref: '#/definitions/baseOrgObject'
+        - items:
+            $ref: '#/definitions/baseOrgObject'
+          type: array
+      identifier:
+        description: The funding or grant id
+        type: string
+      name:
+        description: The name of the grant or funding.
+        type: string
+      recipient:
+        anyOf:
+        - $ref: '#/definitions/basePersonObject'
+        - items:
+            $ref: '#/definitions/basePersonObject'
+          type: array
+        - $ref: '#/definitions/baseOrgObject'
+        - items:
+            $ref: '#/definitions/baseOrgObject'
+          type: array
+        description: The person or organization to whom or to which the grant was
+          awarded
+      url:
+        description: URL of the grant or funding award.
+        format: uri
+        type: string
+    required:
+    - funder
+    type: object
+  '@id': outbreak:MonetaryGrant
   '@type': rdfs:Class
-  rdfs:comment: This is the schema for describing the StudyEvent schema used for outbreak.info.
+  rdfs:comment: This is the schema for describing the MonetaryGrant schema used for
+    outbreak.info
+  rdfs:label: MonetaryGrant
+  rdfs:subClassOf:
+    '@id': schema:MonetaryGrant
+- '@id': outbreak:recipient
+  '@type': rdfs:Property
+  rdfs:comment: The person or organization to whom or to which the grant was awarded
+  rdfs:label: recipient
+  schema:domainIncludes:
+    '@id': outbreak:MonetaryGrant
+  schema:rangeIncludes:
+  - '@id': schema:Person
+  - '@id': schema:Organization
+- '@id': outbreak:DataDownload
+  '@type': rdfs:Class
+  rdfs:comment: This is the schema for describing the DataDownload schema used for
+    outbreak.info.
+  rdfs:label: DataDownload
+  rdfs:subClassOf:
+    '@id': schema:DataDownload
+- $validation:
+    $schema: http://json-schema.org/draft-07/schema#
+    properties:
+      citeText:
+        description: The bibliographic citation for the referenced resource as is
+          provided
+        type: string
+      doi:
+        description: A doi if available
+        type: string
+      identifier:
+        description: An identifier associated with the citation
+        type: string
+      name:
+        description: The name or title of the cited resource.
+        type: string
+      pmid:
+        description: A pubmed identifier if available
+        type: string
+      sourceType:
+        description: The @type of resource
+        enum:
+        - Dataset
+        - Publication
+        - ClinicalTrial
+        - Analysis
+        - Protocol
+        - SoftwareApplication
+        - CreativeWork
+      url:
+        description: URL of the cited resource.
+        format: uri
+        type: string
+      versionDate:
+        description: The version date of the resource used at the time of the creation
+          of the citation as certain resources (protocols, datasets) may change frequently
+          over time.
+        format: date
+        type: string
+    required:
+    - name
+    - sourceType
+    type: object
+  '@id': outbreak:CitationObject
+  '@type': rdfs:Class
+  rdfs:comment: A citation object for a resource which is cited by the subject (ie-
+    is a derivative of the subject), related to the subject, or from which the subject
+    was based on (ie- is derived from).
+  rdfs:label: CitationObject
+  rdfs:subClassOf:
+    '@id': schema:CreativeWork
+- '@id': outbreak:citeText
+  '@type': rdfs:Property
+  rdfs:comment: The bibliographic citation for the referenced resource as is provided
+  rdfs:label: citeText
+  schema:domainIncludes:
+    '@id': outbreak:CitationObject
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:versionDate
+  '@type': rdfs:Property
+  rdfs:comment: The version date of the resource used at the time of the creation
+    of the citation as certain resources (protocols, datasets) may change frequently
+    over time.
+  rdfs:label: versionDate
+  schema:domainIncludes:
+    '@id': outbreak:CitationObject
+  schema:rangeIncludes:
+  - '@id': schema:Date
+- '@id': outbreak:sourceType
+  '@type': rdfs:Property
+  rdfs:comment: The type of resource
+  rdfs:label: sourceType
+  schema:domainIncludes:
+    '@id': outbreak:CitationObject
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:Dataset
+  '@type': rdfs:Class
+  rdfs:comment: This is the schema for describing the Dataset schema used for outbreak.info.
+  rdfs:label: Dataset
+  rdfs:subClassOf:
+    '@id': schema:Dataset
+- '@id': outbreak:Correction
+  '@type': rdfs:Class
+  rdfs:comment: This is the schema for describing a Correction used for outbreak.info.
+    A Correction is a specialized subclass of the CitationObject
+  rdfs:label: Correction
+  rdfs:subClassOf:
+    '@id': schema:CreativeWork
+- '@id': outbreak:correctionType
+  '@type': rdfs:Property
+  rdfs:comment: 'Type of notice or correction: (correction, retraction, expression
+    of convern, withdrawal, erratum, update, correction/republication, preprint, peer
+    reviewed version)'
+  rdfs:label: correctionType
+  schema:domainIncludes:
+    '@id': outbreak:Correction
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:Publication
+  '@type': rdfs:Class
+  rdfs:comment: This is the schema for describing the Publication used for outbreak.info
+  rdfs:label: Publication
+  rdfs:subClassOf:
+    '@id': schema:MedicalScholarlyArticle
+- '@id': outbreak:journalName
+  '@type': rdfs:Property
+  rdfs:comment: The name of the journal (or publisher if journal name not available)
+  rdfs:label: journalName
+  schema:domainIncludes:
+    '@id': outbreak:Publication
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:journalNameAbbrevation
+  '@type': rdfs:Property
+  rdfs:comment: abbreviated Journal Title (note, this should be autopopulated)
+  rdfs:label: journalNameAbbrevation
+  schema:domainIncludes:
+    '@id': outbreak:Publication
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:volumeNumber
+  '@type': rdfs:Property
+  rdfs:comment: Volume number of journal in which the article was published
+  rdfs:label: volumeNumber
+  schema:domainIncludes:
+    '@id': outbreak:Publication
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:issueNumber
+  '@type': rdfs:Property
+  rdfs:comment: Issue of journal in which the article was published
+  rdfs:label: issueNumber
+  schema:domainIncludes:
+    '@id': outbreak:Publication
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:Analysis
+  '@type': rdfs:Class
+  rdfs:comment: This is the schema for describing an Analysis for inclusion in outbreak.info
+    resources
+  rdfs:label: Analysis
+  rdfs:subClassOf:
+    '@id': schema:CreativeWork
+- '@id': outbreak:domainUrl
+  '@type': rdfs:Property
+  rdfs:comment: The domain name or main site on which webpage or specific url can
+    be found
+  rdfs:label: domainUrl
+  schema:domainIncludes:
+    '@id': outbreak:Analysis
+  schema:rangeIncludes:
+  - '@id': schema:URL
+- '@id': outbreak:assumption
+  '@type': rdfs:Property
+  rdfs:comment: Statement of assumptions / limitations of the model
+  rdfs:label: assumption
+  schema:domainIncludes:
+    '@id': outbreak:Analysis
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:analysisTechnique
+  '@type': rdfs:Property
+  rdfs:comment: A technique or technology used in a analysis
+  rdfs:label: analysisTechnique
+  schema:domainIncludes:
+    '@id': outbreak:Analysis
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:analysisTopic
+  '@type': rdfs:Property
+  rdfs:comment: The underlying question, goal, or aim of the analysis
+  rdfs:label: analysisTopic
+  schema:domainIncludes:
+    '@id': outbreak:Analysis
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:Product
+  '@type': rdfs:Class
+  rdfs:comment: This is the schema for describing a reagent, material, sample, or
+    some other product used in a protocol resource in outbreak.info
+  rdfs:label: Product
+  rdfs:subClassOf:
+    '@id': schema:Product
+- '@id': outbreak:Instrument
+  '@type': rdfs:Class
+  rdfs:comment: This is the schema for describing an instrument used in a protocol
+    resource listed in outbreak.info
+  rdfs:label: Instrument
+  rdfs:subClassOf:
+    '@id': schema:Product
+- '@id': outbreak:Protocol
+  '@type': rdfs:Class
+  rdfs:comment: This is the schema for describing the Protocols for outbreak.info
+    Resources.
+  rdfs:label: Protocol
+  rdfs:subClassOf:
+    '@id': schema:HowTo
+- '@id': outbreak:warning
+  '@type': rdfs:Property
+  rdfs:comment: Precautions, warnings, and/or safety warnings associated with or highlighted
+    by the protocol
+  rdfs:label: warning
+  schema:domainIncludes:
+    '@id': outbreak:Protocol
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:correctionNote
+  '@type': rdfs:Property
+  rdfs:comment: statement of what was updated/changed since prior version
+  rdfs:label: correctionNote
+  schema:domainIncludes:
+    '@id': outbreak:Protocol
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:protocolStatus
+  '@type': rdfs:Property
+  rdfs:comment: The status of the protocol
+  rdfs:label: protocolStatus
+  schema:domainIncludes:
+    '@id': outbreak:Protocol
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:instrument
+  '@type': rdfs:Property
+  rdfs:comment: A laboratory equipment use by a person to follow one or more steps
+    described in this Protocol
+  rdfs:label: instrument
+  schema:domainIncludes:
+    '@id': outbreak:Protocol
+  schema:rangeIncludes:
+  - '@id': outbreak:Instrument
+- '@id': outbreak:protocolSetting
+  '@type': rdfs:Property
+  rdfs:comment: The type of 'protocol' based on setting in which it would apply
+  rdfs:label: protocolSetting
+  schema:domainIncludes:
+    '@id': outbreak:Protocol
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:protocolCategory
+  '@type': rdfs:Property
+  rdfs:comment: The type of 'protocol' based on degree of specificity and purpose
+  rdfs:label: protocolCategory
+  schema:domainIncludes:
+    '@id': outbreak:Protocol
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:usedToGenerate
+  '@type': rdfs:Property
+  rdfs:comment: Type of evidence/data generated by the protocol
+  rdfs:label: usedToGenerate
+  schema:domainIncludes:
+    '@id': outbreak:Protocol
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:inComplianceWith
+  '@type': rdfs:Property
+  rdfs:comment: Guidelines or Standards to which these protocols adhere. ie- GMP,
+    GCP, other EQUATOR guidelines. Useful for selecting protocols where certain standards/guidelines
+    must be met
+  rdfs:label: inComplianceWith
+  schema:domainIncludes:
+    '@id': outbreak:Protocol
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- $validation:
+    $schema: http://json-schema.org/draft-07/schema#
+    properties:
+      studyEventDate:
+        description: The corresponding/actual date of the study event (ie- the StartDate,
+          Primary CompletionDate, CompletionDate, StudyFirstSubmitDate, StudyFirstSubmitQCDate,
+          LastUpdateSubmitDate)
+        format: date
+        type: string
+      studyEventDateType:
+        description: the type of date provided (actual, anticipated, or estimated)
+        oneOf:
+        - enum:
+          - actual
+          - anticipated
+          - estimated
+        - type: string
+      studyEventType:
+        description: Type of the event status such as StudyStart, PrimaryCompletion,
+          Completion, StudyFirstSubmit, StudyFirstSubmitQC, LastUpdateSubmit
+        oneOf:
+        - enum:
+          - StudyStart
+          - PrimaryCompletion
+          - Completion
+          - StudyFirstSubmit
+          - StudyFirstSubmitQC
+          - LastUpdateSubmit
+        - type: string
+    required: []
+    type: object
+  '@id': outbreak:StudyEvent
+  '@type': rdfs:Class
+  rdfs:comment: This is the schema for describing StudyEvents, a class that describes
+    categorical events in Clinical Trials added to outbreak.info
   rdfs:label: StudyEvent
   rdfs:subClassOf:
     '@id': schema:Thing
-  schema:isPartOf:
-    '@id': https://discovery.biothings.io/view/outbreak/
 - '@id': outbreak:studyEventType
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
+  '@type': rdfs:Property
   rdfs:comment: Type of the event status such as StudyStart, PrimaryCompletion, Completion,
     StudyFirstSubmit, StudyFirstSubmitQC, LastUpdateSubmit
   rdfs:label: studyEventType
-  rdfs:sameAs:
-    '@id': schema:additionalType
   schema:domainIncludes:
     '@id': outbreak:StudyEvent
   schema:rangeIncludes:
-    '@id': schema:Text
+  - '@id': schema:Text
 - '@id': outbreak:studyEventDate
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: StartDate, Primary CompletionDate, CompletionDate, StudyFirstSubmitDate,
-    StudyFirstSubmitQCDate, LastUpdateSubmitDate
+  '@type': rdfs:Property
+  rdfs:comment: The corresponding/actual date of the study event (ie- the StartDate,
+    Primary CompletionDate, CompletionDate, StudyFirstSubmitDate, StudyFirstSubmitQCDate,
+    LastUpdateSubmitDate)
   rdfs:label: studyEventDate
-  rdfs:sameAs:
-    '@id': schema:temporal
   schema:domainIncludes:
     '@id': outbreak:StudyEvent
   schema:rangeIncludes:
-    '@id': schema:Date
+  - '@id': schema:Date
 - '@id': outbreak:studyEventDateType
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
+  '@type': rdfs:Property
   rdfs:comment: the type of date provided (actual, anticipated, or estimated)
   rdfs:label: studyEventDateType
-  rdfs:sameAs:
-    '@id': schema:addtionalType
   schema:domainIncludes:
     '@id': outbreak:StudyEvent
   schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:StudyStatus
+  - '@id': schema:Text
+- $validation:
+    $schema: http://json-schema.org/draft-07/schema#
+    properties:
+      enrollmentCount:
+        description: The number of participants enrolled in the study
+        type: integer
+      enrollmentType:
+        description: The type of estimation used to determine the enrollmentCount
+          (actual counts, target size, etc.)
+        oneOf:
+        - enum:
+          - actual counts
+          - target size
+        - type: string
+      status:
+        description: The recruitment status of the study
+        enum:
+        - not yet recruiting
+        - recruiting
+        - enrolling by invitation
+        - active
+        - not recruiting
+        - suspended
+        - terminated
+        - completed
+        - withdrawn
+        - unknown status
+      statusDate:
+        description: The date that the status was verified. Equivalent to NCT's StatusVerifiedDate
+        format: date
+        type: string
+      statusExpandedAccess:
+        description: Flag for whether or not the study has expanded Access status
+        oneOf:
+        - type: boolean
+        - enum:
+          - 'yes'
+          - 'no'
+          - unknown
+      whyStopped:
+        description: A brief explanation of the reason(s) why such clinical study
+          was stopped (for a clinical study that is Suspended, Terminated, or Withdrawn
+          prior to its planned completion as anticipated by the protocol)
+        type: string
+    required:
+    - status
+    type: object
+  '@id': outbreak:StudyStatus
   '@type': rdfs:Class
-  rdfs:comment: This is the schema for describing the StudyStatus schema used for
-    outbreak.info.
+  rdfs:comment: This is the schema for describing the status of a ClinicalTrial resource
+    in outbreak.info
   rdfs:label: StudyStatus
   rdfs:subClassOf:
     '@id': schema:Thing
-  schema:isPartOf:
-    '@id': https://discovery.biothings.io/view/outbreak/
 - '@id': outbreak:status
-  '@type': rdf:Property
-  marginality: required
-  owl:cardinality: one
+  '@type': rdfs:Property
   rdfs:comment: The recruitment status of the study
   rdfs:label: status
   rdfs:sameAs:
@@ -317,587 +683,688 @@
   schema:domainIncludes:
     '@id': outbreak:StudyStatus
   schema:rangeIncludes:
-    '@id': schema:Text
+  - '@id': schema:Text
 - '@id': outbreak:statusExpandedAccess
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
+  '@type': rdfs:Property
   rdfs:comment: Flag for whether or not the study has expanded Access status
   rdfs:label: statusExpandedAccess
-  rdfs:sameAs:
-    '@id': schema:additionalType
   schema:domainIncludes:
     '@id': outbreak:StudyStatus
   schema:rangeIncludes:
-    '@id': schema:Text
+  - '@id': schema:Boolean
 - '@id': outbreak:statusDate
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
+  '@type': rdfs:Property
   rdfs:comment: The date that the status was verified. Equivalent to NCT's StatusVerifiedDate
   rdfs:label: statusDate
-  rdfs:sameAs:
-    '@id': schema:temporal
   schema:domainIncludes:
     '@id': outbreak:StudyStatus
   schema:rangeIncludes:
-    '@id': schema:Date
+  - '@id': schema:Date
 - '@id': outbreak:enrollmentCount
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
+  '@type': rdfs:Property
   rdfs:comment: The number of participants enrolled in the study
   rdfs:label: enrollmentCount
   schema:domainIncludes:
     '@id': outbreak:StudyStatus
   schema:rangeIncludes:
-    '@id': schema:Number
+  - '@id': schema:Number
 - '@id': outbreak:enrollmentType
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
+  '@type': rdfs:Property
   rdfs:comment: The type of estimation used to determine the enrollmentCount (actual
     counts, target size, etc.)
   rdfs:label: enrollmentType
-  rdfs:sameAs:
-    '@id': schema:additionalType
   schema:domainIncludes:
     '@id': outbreak:StudyStatus
   schema:rangeIncludes:
-    '@id': schema:Text
+  - '@id': schema:Text
 - '@id': outbreak:whyStopped
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
+  '@type': rdfs:Property
   rdfs:comment: A brief explanation of the reason(s) why such clinical study was stopped
-    (for a clinical study that is "Suspended," "Terminated," or "Withdrawn" prior
-    to its planned completion as anticipated by the protocol)
+    (for a clinical study that is Suspended, Terminated, or Withdrawn prior to its
+    planned completion as anticipated by the protocol)
   rdfs:label: whyStopped
-  rdfs:sameAs:
-    '@id': schema:description
   schema:domainIncludes:
     '@id': outbreak:StudyStatus
   schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:StudyDesign
+  - '@id': schema:Text
+- $validation:
+    $schema: http://json-schema.org/draft-07/schema#
+    properties:
+      designAllocation:
+        description: The method by which the study participants were allocated into
+          groups
+        enum:
+        - randomized
+        - nonrandomized
+        - other
+      designModel:
+        description: The general design of the strategy for assigning interventions
+          to participants in a clinical intervention study OR the general design of
+          the strategy for identifying and following up with participants during an
+          observational study.
+        oneOf:
+        - enum:
+          - single group assignment
+          - parallel assignment
+          - cross-over assignment
+          - factorial assignment
+          - cohort
+          - case-control
+          - case-only
+          - case-cross-over
+          - ecologic or community studies
+          - family-based
+          - other
+          - retrospective
+          - prospective
+          - cross-sectional
+        - items:
+            enum:
+            - single group assignment
+            - parallel assignment
+            - cross-over assignment
+            - factorial assignment
+            - cohort
+            - case-control
+            - case-only
+            - case-cross-over
+            - ecologic or community studies
+            - family-based
+            - other
+            - retrospective
+            - prospective
+            - cross-sectional
+          type: array
+      designPrimaryPurpose:
+        description: The primary purpose of the study
+        enum:
+        - treatment
+        - prevention
+        - diagnostic
+        - supportive care
+        - screening
+        - health services research
+        - basic science
+        - other
+      designStudyText:
+        description: String description of the study design if structured information
+          not available
+        type: string
+      designWhoMasked:
+        description: The people who do not know which participants have been assigned
+          to which interventions
+        oneOf:
+        - enum:
+          - Participant
+          - Investigator
+          - Outcomes Assessor
+          - Care Provider
+        - items:
+            enum:
+            - Participant
+            - Investigator
+            - Outcomes Assessor
+            - Care Provider
+          type: array
+      phase:
+        description: Stage or phase of the study in the U.S. if applicable
+        oneOf:
+        - enum:
+          - Early Phase 1
+          - Phase 1
+          - Phase 2
+          - Phase 3
+          - Phase 4
+          - Not Applicable
+        - items:
+            enum:
+            - Early Phase 1
+            - Phase 1
+            - Phase 2
+            - Phase 3
+            - Phase 4
+            - Not Applicable
+          type: array
+      phaseNumber:
+        description: The number of the phase or stage of the study
+        oneOf:
+        - enum:
+          - '0'
+          - '1'
+          - '2'
+          - '3'
+          - '4'
+          - Not Applicable
+        - items:
+            enum:
+            - '0'
+            - '1'
+            - '2'
+            - '3'
+            - '4'
+            - Not Applicable
+          type: array
+      studyType:
+        description: Type of human study, can be subtypes of observational study or
+          interventional studies and may include the temporal relationship of observation
+          period to time of participant enrollment.
+        enum:
+        - interventional
+        - observational
+    required: []
+    type: object
+  '@id': outbreak:StudyDesign
   '@type': rdfs:Class
-  rdfs:comment: This is the schema for describing the StudyDesign schema used for
-    outbreak.info.
+  rdfs:comment: This is the schema for describing the study design of a clinical trial/study
+    for inclusion into outbreak.info resources
   rdfs:label: StudyDesign
   rdfs:subClassOf:
     '@id': schema:Thing
-  schema:isPartOf:
-    '@id': https://discovery.biothings.io/view/outbreak/
 - '@id': outbreak:studyType
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
+  '@type': rdfs:Property
   rdfs:comment: Type of human study, can be subtypes of observational study or interventional
     studies and may include the temporal relationship of observation period to time
     of participant enrollment.
   rdfs:label: studyType
-  rdfs:sameAs:
-    '@id': schema:additionalType
   schema:domainIncludes:
     '@id': outbreak:StudyDesign
   schema:rangeIncludes:
-    '@id': schema:Text
+  - '@id': schema:Text
 - '@id': outbreak:phase
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: many
-  rdfs:comment: Stage or phase of the study in the U.S.
+  '@type': rdfs:Property
+  rdfs:comment: Stage or phase of the study in the U.S. if applicable
   rdfs:label: phase
   rdfs:sameAs:
-    '@id': schema:additionalType
+    '@id': schema:phase
   schema:domainIncludes:
     '@id': outbreak:StudyDesign
   schema:rangeIncludes:
-    '@id': schema:Text
+  - '@id': schema:Text
 - '@id': outbreak:phaseNumber
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: many
+  '@type': rdfs:Property
   rdfs:comment: The number of the phase or stage of the study
   rdfs:label: phaseNumber
-  rdfs:sameAs:
-    '@id': schema:additionalType
   schema:domainIncludes:
     '@id': outbreak:StudyDesign
   schema:rangeIncludes:
-    '@id': schema:Number
+  - '@id': schema:Number
 - '@id': outbreak:designAllocation
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
+  '@type': rdfs:Property
   rdfs:comment: The method by which the study participants were allocated into groups
   rdfs:label: designAllocation
-  rdfs:sameAs:
-    '@id': schema:additionalType
   schema:domainIncludes:
     '@id': outbreak:StudyDesign
   schema:rangeIncludes:
-    '@id': schema:Text
+  - '@id': schema:Text
 - '@id': outbreak:designModel
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: many
+  '@type': rdfs:Property
   rdfs:comment: The general design of the strategy for assigning interventions to
     participants in a clinical intervention study OR the general design of the strategy
-    for identifying and following up with participants during an observational study.
+    for identifying and following up with participants during an observational study
   rdfs:label: designModel
-  rdfs:sameAs:
-    '@id': schema:additionalType
   schema:domainIncludes:
     '@id': outbreak:StudyDesign
   schema:rangeIncludes:
-    '@id': schema:Text
+  - '@id': schema:Text
 - '@id': outbreak:designPrimaryPurpose
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
+  '@type': rdfs:Property
   rdfs:comment: The primary purpose of the study
   rdfs:label: designPrimaryPurpose
-  rdfs:sameAs:
-    '@id': schema:additionalType
   schema:domainIncludes:
     '@id': outbreak:StudyDesign
   schema:rangeIncludes:
-    '@id': schema:Text
+  - '@id': schema:Text
 - '@id': outbreak:designWhoMasked
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: The people who not know which participants have been assigned to which
-    interventions.
+  '@type': rdfs:Property
+  rdfs:comment: The people who do not know which participants have been assigned to
+    which interventions
   rdfs:label: designWhoMasked
-  rdfs:sameAs:
-    '@id': schema:additionalType
   schema:domainIncludes:
     '@id': outbreak:StudyDesign
   schema:rangeIncludes:
-    '@id': schema:Text
+  - '@id': schema:Text
 - '@id': outbreak:designStudyText
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
+  '@type': rdfs:Property
   rdfs:comment: String description of the study design if structured information not
     available
   rdfs:label: designStudyText
-  rdfs:sameAs:
-    '@id': schema:description
   schema:domainIncludes:
     '@id': outbreak:StudyDesign
   schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:Intervention
+  - '@id': schema:Text
+- $validation:
+    $schema: http://json-schema.org/draft-07/schema#
+    properties:
+      category:
+        description: The category of an intervention in the study
+        enum:
+        - drugs
+        - medical devices
+        - procedures
+        - vaccines
+        - education
+        - behavioral modification
+        - diet
+        - exercise
+        - counseling
+        - placebo
+        - other
+      description:
+        description: A description of the intervention in the study
+        type: string
+      name:
+        description: The name of the intervention in the study
+        type: string
+    required: []
+    type: object
+  '@id': outbreak:Intervention
   '@type': rdfs:Class
-  rdfs:comment: This is the schema for describing the Intervention schema used for
-    outbreak.info.
+  rdfs:comment: a schema to describe Interventions discussed in Clinical Studies/Trials
+    for inclusion in outbreak.info Resources
   rdfs:label: Intervention
   rdfs:subClassOf:
     '@id': schema:Thing
-  schema:isPartOf:
-    '@id': https://discovery.biothings.io/view/outbreak/
 - '@id': outbreak:category
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
+  '@type': rdfs:Property
   rdfs:comment: The category of an intervention in the study
   rdfs:label: category
-  rdfs:sameAs:
-    '@id': schema:additionalType
   schema:domainIncludes:
     '@id': outbreak:Intervention
   schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:name
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: The name of the intervention in the study
-  rdfs:label: name
-  rdfs:sameAs:
-    '@id': schema:name
-  schema:domainIncludes:
-    '@id': outbreak:Intervention
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:description
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: A description of the intervention in the study
-  rdfs:label: description
-  rdfs:sameAs:
-    '@id': schema:description
-  schema:domainIncludes:
-    '@id': outbreak:Intervention
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:ArmGroup
+  - '@id': schema:Text
+- $validation:
+    $schema: http://json-schema.org/draft-07/schema#
+    definitions:
+      intervention:
+        '@type': outbreak:Intervention
+        properties:
+          category:
+            description: The category of an intervention in the study
+            enum:
+            - drugs
+            - medical devices
+            - procedures
+            - vaccines
+            - education
+            - behavioral modification
+            - diet
+            - exercise
+            - counseling
+            - placebo
+            - other
+          description:
+            description: A description of the intervention in the study
+            type: string
+          name:
+            description: The name of the intervention in the study
+            type: string
+        type: object
+    properties:
+      description:
+        description: A description of the arm or factor
+        type: string
+      intervention:
+        description: The interventions (if any) in this ArmGroup
+        oneOf:
+        - $ref: '#/definitions/intervention'
+        - items:
+            $ref: '#/definitions/intervention'
+          type: array
+        type: array
+      name:
+        description: The name of the arm or factor (can include a specific intervention,
+          a placebo or even a lack of intervention, ie- 'no intervention' group)
+        type: string
+      role:
+        description: The role of the arm or factor in the study this is equivalent
+          to the ArmType in ClinicalTrials.gov
+        enum:
+        - experimental arm
+        - active comparator arm
+        - placebo comparator arm
+        - sham comparator arm
+        - no intervention arm
+    required: []
+    type: object
+  '@id': outbreak:ArmGroup
   '@type': rdfs:Class
-  rdfs:comment: This is the schema for describing the ArmGroup schema used for outbreak.info.
+  rdfs:comment: This is the schema for describing arm groups in clinical studies/trials
+    for inclusion in outbreak.info Resources
   rdfs:label: ArmGroup
   rdfs:subClassOf:
     '@id': schema:Thing
-  schema:isPartOf:
-    '@id': https://discovery.biothings.io/view/outbreak/
-- '@id': outbreak:name
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: The name of the arm or factor (can include a specific intervention,
-    a placebo or even a lack of intervention, ie- 'no intervention' group)
-  rdfs:label: name
-  rdfs:sameAs:
-    '@id': schema:name
-  schema:domainIncludes:
-    '@id': outbreak:ArmGroup
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:role
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: The role of the arm or factor in the study this is equivalent to the
-    ArmType in ClinicalTrials.gov
-  rdfs:label: role
-  rdfs:sameAs:
-    '@id': schema:additionalType
-  schema:domainIncludes:
-    '@id': outbreak:ArmGroup
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:description
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: A description of the arm or factor
-  rdfs:label: description
-  rdfs:sameAs:
-    '@id': schema:description
-  schema:domainIncludes:
-    '@id': outbreak:ArmGroup
-  schema:rangeIncludes:
-    '@id': schema:Text
 - '@id': outbreak:intervention
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: many
+  '@type': rdfs:Property
   rdfs:comment: The interventions (if any) in this ArmGroup
   rdfs:label: intervention
   schema:domainIncludes:
     '@id': outbreak:ArmGroup
   schema:rangeIncludes:
-    '@id': outbreak:Intervention
-- '@id': outbreak:category
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: The category of the arm or factor in the study
-  rdfs:label: category
-  rdfs:sameAs:
-    '@id': schema:additionalType
-  schema:domainIncludes:
-    '@id': outbreak:Intervention
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:name
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: The name of the intervention in the study
-  rdfs:label: name
-  rdfs:sameAs:
-    '@id': schema:name
-  schema:domainIncludes:
-    '@id': outbreak:Intervention
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:description
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: A description of the intervention in the study
-  rdfs:label: description
-  rdfs:sameAs:
-    '@id': schema:description
-  schema:domainIncludes:
-    '@id': outbreak:Intervention
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:Eligibility
+  - '@id': outbreak:Intervention
+- $validation:
+    $schema: http://json-schema.org/draft-07/schema#
+    properties:
+      outcomeMeasure:
+        description: The outcome measure for the study
+        oneOf:
+        - type: string
+        - items:
+            type: string
+          type: array
+      outcomeTimeFrame:
+        description: 'The specific time point(s) and overall duration of evaluation
+          must be specified in this section. '
+        type: string
+      outcomeType:
+        description: The classification of the outcome measure as either primary,
+          secondary, or exploratory
+        enum:
+        - primary
+        - secondary
+        - other
+    required: []
+    type: object
+  '@id': outbreak:Outcome
   '@type': rdfs:Class
-  rdfs:comment: This is the schema for describing the Eligibility schema used for
-    outbreak.info.
+  rdfs:comment: This is the schema for describing a Clinical Trial/Study Outcome for
+    inclusion in  outbreak.info Resources
+  rdfs:label: Outcome
+  rdfs:subClassOf:
+    '@id': schema:Thing
+- '@id': outbreak:outcomeMeasure
+  '@type': rdfs:Property
+  rdfs:comment: The outcome measure for the study
+  rdfs:label: outcomeMeasure
+  schema:domainIncludes:
+    '@id': outbreak:Outcome
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:outcomeTimeFrame
+  '@type': rdfs:Property
+  rdfs:comment: The specific time point(s) and overall duration of evaluation must
+    be specified in this section
+  rdfs:label: outcomeTimeFrame
+  schema:domainIncludes:
+    '@id': outbreak:Outcome
+  schema:rangeIncludes:
+  - '@id': schema:Duration
+  - '@id': schema:Text
+- '@id': outbreak:outcomeType
+  '@type': rdfs:Property
+  rdfs:comment: The classification of the outcome measure as either primary, secondary,
+    or exploratory
+  rdfs:label: outcomeType
+  schema:domainIncludes:
+    '@id': outbreak:Outcome
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- $validation:
+    $schema: http://json-schema.org/draft-07/schema#
+    properties:
+      criteriaText:
+        description: The descriptive criteria as published for the Clinical Trial
+        type: string
+      exclusionCriteria:
+        description: criteria for exclusion from the study
+        oneOf:
+        - type: string
+        - items:
+            type: string
+          type: array
+      gender:
+        description: the sex requirement to be included in the study
+        enum:
+        - male
+        - female
+        - all
+      genderBased:
+        description: Boolean for whether or not participation is based on gender
+        type: boolean
+      healthyVolunteers:
+        description: Boolean to indicate whether or not healthy volunteers may be
+          included in the study
+        type: boolean
+      inclusionCriteria:
+        description: criteria for inclusion in the study
+        oneOf:
+        - type: string
+        - items:
+            type: string
+          type: array
+      maximumAge:
+        description: the maximum age for a participant to be included in the study
+        type: string
+      minimumAge:
+        description: the minimum age for a participant to be included in the study
+        type: string
+      stdAge:
+        description: the age category of a participant to be included in the study
+          if a minimum and maximum age is not specified
+        oneOf:
+        - enum:
+          - Child (birth-17)
+          - Adult (18-64)
+          - Older Adult (65+)
+        - items:
+            enum:
+            - Child (birth-17)
+            - Adult (18-64)
+            - Older Adult (65+)
+    required: []
+    type: object
+  '@id': outbreak:Eligibility
+  '@type': rdfs:Class
+  rdfs:comment: This is the schema for describing information about Clinical Trials/Studies
+    eligibility criteria for inclusion in outbreak.info Resources
   rdfs:label: Eligibility
   rdfs:subClassOf:
     '@id': schema:Thing
-  schema:isPartOf:
-    '@id': https://discovery.biothings.io/view/outbreak/
 - '@id': outbreak:inclusionCriteria
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: criteria for inclusion in the study
+  '@type': rdfs:Property
+  rdfs:comment: '"criteria for inclusion in the study'
   rdfs:label: inclusionCriteria
-  rdfs:sameAs:
-    '@id': schema:qualifications
   schema:domainIncludes:
     '@id': outbreak:Eligibility
   schema:rangeIncludes:
-    '@id': schema:Text
+  - '@id': schema:Text
 - '@id': outbreak:minimumAge
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
+  '@type': rdfs:Property
   rdfs:comment: the minimum age for a participant to be included in the study
   rdfs:label: minimumAge
-  rdfs:sameAs:
-    '@id': schema:requiredMinAge
   schema:domainIncludes:
     '@id': outbreak:Eligibility
   schema:rangeIncludes:
-    '@id': schema:Text
+  - '@id': schema:Text
 - '@id': outbreak:maximumAge
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
+  '@type': rdfs:Property
   rdfs:comment: the maximum age for a participant to be included in the study
   rdfs:label: maximumAge
-  rdfs:sameAs:
-    '@id': schema:requiredMaxAge
   schema:domainIncludes:
     '@id': outbreak:Eligibility
   schema:rangeIncludes:
-    '@id': schema:Text
+  - '@id': schema:Text
 - '@id': outbreak:gender
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
+  '@type': rdfs:Property
   rdfs:comment: the sex requirement to be included in the study
   rdfs:label: gender
-  rdfs:sameAs:
-    '@id': schema:requiredGender
   schema:domainIncludes:
     '@id': outbreak:Eligibility
   schema:rangeIncludes:
-    '@id': schema:Text
+  - '@id': schema:Text
 - '@id': outbreak:genderBased
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
+  '@type': rdfs:Property
   rdfs:comment: Boolean for whether or not participation is based on gender
   rdfs:label: genderBased
   schema:domainIncludes:
     '@id': outbreak:Eligibility
   schema:rangeIncludes:
-    '@id': schema:Boolean
+  - '@id': schema:Boolean
 - '@id': outbreak:healthyVolunteers
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
+  '@type': rdfs:Property
   rdfs:comment: Boolean to indicate whether or not healthy volunteers may be included
     in the study
   rdfs:label: healthyVolunteers
-  rdfs:sameAs:
-    '@id': schema:additionalType
   schema:domainIncludes:
     '@id': outbreak:Eligibility
   schema:rangeIncludes:
-    '@id': schema:Boolean
+  - '@id': schema:Boolean
 - '@id': outbreak:stdAge
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
+  '@type': rdfs:Property
   rdfs:comment: the age category of a participant to be included in the study if a
     minimum and maximum age is not specified
   rdfs:label: stdAge
-  rdfs:sameAs:
-    '@id': schema:additionalType
   schema:domainIncludes:
     '@id': outbreak:Eligibility
   schema:rangeIncludes:
-    '@id': schema:Text
+  - '@id': schema:Text
 - '@id': outbreak:exclusionCriteria
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
+  '@type': rdfs:Property
   rdfs:comment: criteria for exclusion from the study
   rdfs:label: exclusionCriteria
-  rdfs:sameAs:
-    '@id': schema:qualifications
   schema:domainIncludes:
     '@id': outbreak:Eligibility
   schema:rangeIncludes:
-    '@id': schema:Text
+  - '@id': schema:Text
 - '@id': outbreak:criteriaText
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
+  '@type': rdfs:Property
   rdfs:comment: The descriptive criteria as published for the Clinical Trial
   rdfs:label: criteriaText
-  rdfs:sameAs:
-    '@id': schema:description
   schema:domainIncludes:
     '@id': outbreak:Eligibility
   schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:Outcome
+  - '@id': schema:Text
+- $validation:
+    $schema: http://json-schema.org/draft-07/schema#
+    properties:
+      studyLocation:
+        description: The location of the study as listed in the resouce.
+        type: string
+      studyLocationCity:
+        description: The city in which the facility used for the study is located
+        type: string
+      studyLocationCountry:
+        description: The country in which the facility used for the study is located
+        type: string
+      studyLocationState:
+        description: The state or province in which the facility used for the study
+          is located
+        type: string
+      studyLocationStatus:
+        description: The recruitment status of the study at the specific study site
+        enum:
+        - not yet recruiting
+        - recruiting
+        - enrolling by invitation
+        - active
+        - not recruiting
+        - suspended
+        - terminated
+        - completed
+        - withdrawn
+        - unknown status
+    required: []
+    type: object
+  '@id': outbreak:StudyLocation
   '@type': rdfs:Class
-  rdfs:comment: This is the schema for describing the Outcome schema used for outbreak.info.
-  rdfs:label: Outcome
-  rdfs:subClassOf:
-    '@id': schema:Thing
-  schema:isPartOf:
-    '@id': https://discovery.biothings.io/view/outbreak/
-- '@id': outbreak:outcomeMeasure
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: The outcome measure for the study
-  rdfs:label: outcomeMeasure
-  rdfs:sameAs:
-    '@id': schema:description
-  schema:domainIncludes:
-    '@id': outbreak:Outcome
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:outcomeTimeFrame
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: 'The specific time point(s) and overall duration of evaluation must
-    be specified in this section. '
-  rdfs:label: outcomeTimeFrame
-  rdfs:sameAs:
-    '@id': schema:duration
-  schema:domainIncludes:
-    '@id': outbreak:Outcome
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:outcomeType
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The classification of the outcome measure as either primary, secondary,
-    or exploratory
-  rdfs:label: outcomeType
-  rdfs:sameAs:
-    '@id': schema:additionalType
-  schema:domainIncludes:
-    '@id': outbreak:Outcome
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:StudyLocation
-  '@type': rdfs:Class
-  rdfs:comment: This is the schema for describing the StudyLocation schema used for
-    outbreak.info.
+  rdfs:comment: This is the schema for describing Clinical Trial/Study locations for
+    inclusion in outbreak.info Resources
   rdfs:label: StudyLocation
   rdfs:subClassOf:
     '@id': schema:Place
-  schema:isPartOf:
-    '@id': https://discovery.biothings.io/view/outbreak/
 - '@id': outbreak:studyLocation
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
+  '@type': rdfs:Property
   rdfs:comment: The location of the study
   rdfs:label: studyLocation
-  rdfs:sameAs:
-    '@id': schema:studyLocation
   schema:domainIncludes:
-    '@id': outbreak:ClinicalTrial
+    '@id': outbreak:StudyLocation
   schema:rangeIncludes:
-    '@id': schema:Place
+  - '@id': schema:Place
+  - '@id': schema:Text
 - '@id': outbreak:studyLocationCity
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
+  '@type': rdfs:Property
   rdfs:comment: The city in which the facility used for the study is located
   rdfs:label: studyLocationCity
-  rdfs:sameAs:
-    '@id': schema:studyLocation
   schema:domainIncludes:
-    '@id': outbreak:ClinicalTrial
+    '@id': outbreak:StudyLocation
   schema:rangeIncludes:
-    '@id': schema:City
+  - '@id': schema:City
+  - '@id': schema:Text
 - '@id': outbreak:studyLocationState
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
+  '@type': rdfs:Property
   rdfs:comment: The state or province in which the facility used for the study is
     located
   rdfs:label: studyLocationState
-  rdfs:sameAs:
-    '@id': schema:studyLocation
   schema:domainIncludes:
-    '@id': outbreak:ClinicalTrial
+    '@id': outbreak:StudyLocation
   schema:rangeIncludes:
-    '@id': schema:State
+  - '@id': schema:State
+  - '@id': schema:Text
 - '@id': outbreak:studyLocationCountry
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
+  '@type': rdfs:Property
   rdfs:comment: The country in which the facility used for the study is located
   rdfs:label: studyLocationCountry
-  rdfs:sameAs:
-    '@id': schema:studyLocation
   schema:domainIncludes:
-    '@id': outbreak:ClinicalTrial
+    '@id': outbreak:StudyLocation
   schema:rangeIncludes:
-    '@id': schema:Country
+  - '@id': schema:Country
+  - '@id': schema:Text
 - '@id': outbreak:studyLocationStatus
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
+  '@type': rdfs:Property
   rdfs:comment: The recruitment status of the study at the specific study site
   rdfs:label: studyLocationStatus
-  rdfs:sameAs:
-    '@id': schema:additionalType
   schema:domainIncludes:
-    '@id': outbreak:ClinicalTrial
+    '@id': outbreak:StudyLocation
   schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:Analysis
-  '@type': rdfs:Class
-  rdfs:comment: This is the schema for describing the Analysis schema used for outbreak.info.
-  rdfs:label: Analysis
-  rdfs:subClassOf:
-    '@id': schema:CreativeWork
-  schema:isPartOf:
-    '@id': https://discovery.biothings.io/view/outbreak/
-- '@id': outbreak:Dataset
-  '@type': rdfs:Class
-  rdfs:comment: This is the schema for describing the Dataset schema used for outbreak.info.
-  rdfs:label: Dataset
-  rdfs:subClassOf:
-    '@id': schema:Dataset
-  schema:isPartOf:
-    '@id': https://discovery.biothings.io/view/outbreak/
-- '@id': outbreak:Protocol
-  '@type': rdfs:Class
-  rdfs:comment: This is the schema for describing the Protocol schema used for outbreak.info.
-  rdfs:label: Protocol
-  rdfs:subClassOf:
-    '@id': schema:HowTo
-  schema:isPartOf:
-    '@id': https://discovery.biothings.io/view/outbreak/
-- '@id': outbreak:Publication
-  '@type': rdfs:Class
-  rdfs:comment: This is the schema for describing the Publication schema used for
-    outbreak.info.
-  rdfs:label: Publication
-  rdfs:subClassOf:
-    '@id': schema:ScholarlyArticle
-  schema:isPartOf:
-    '@id': https://discovery.biothings.io/view/outbreak/
+  - '@id': schema:Text
 - $validation:
     $schema: http://json-schema.org/draft-07/schema#
     definitions:
+      aggregateRatingObject:
+        '@type': AggregateRating
+        description: A cumulative evaluation of the resource
+        properties:
+          author:
+            anyOf:
+            - $ref: '#/definitions/person'
+            - items:
+                $ref: '#/definitions/person'
+              type: array
+            - $ref: '#/definitions/organization'
+            - items:
+                $ref: '#/definitions/organization'
+              type: array
+            description: The author of this content or rating.
+          curationDate:
+            description: The date this evaluation was added into outbreak.info, or
+              was updated in outbreak.info.
+            format: date
+            type: string
+          name:
+            description: The name of the aggregate rating
+            type: string
+          ratingValue:
+            description: The rating for the content.
+            type: string
+          ratings:
+            oneOf:
+            - $ref: '#/definitions/ratingObject'
+            - items:
+                $ref: '#/definitions/ratingObject'
+              type: array
+          reviewAspect:
+            description: This Review or Rating is relevant to this part or facet of
+              the itemReviewed
+            type: string
+          reviews:
+            oneOf:
+            - $ref: '#/definitions/reviewObject'
+            - items:
+                $ref: '#/definitions/reviewObject'
+              type: array
+        required: []
+        type: object
       armgroup:
-        '@type': Thing
+        '@type': outbreak:ArmGroup
         properties:
           description:
             description: A description of the arm or factor
@@ -924,52 +1391,82 @@
             - sham comparator arm
             - no intervention arm
         type: object
+      baseOrgObject:
+        '@type': outbreak:Organization
+        description: A barebones Organization object to work around recursion issues
+          in DDE
+        properties:
+          alternateName:
+            description: Alternate name or Acronym for the organization.
+            type: string
+          class:
+            description: The type of organization
+            enum:
+            - U.S. National Institutes of Health
+            - Other U.S. Federal agencies
+            - Industry
+            - All others
+          name:
+            description: name of the organization
+            type: string
+          role:
+            description: LeadSponsor, funder, collaborator
+            enum:
+            - lead/primary Sponsor
+            - funder
+            - collaborator
+        required:
+        - name
+        type: object
       citation:
-        '@type': CreativeWork
-        description: A citation object for a resource which is cited by the publication
-          (ie- is a derivative of the publication) , related to the publication, or
-          from which the publication was based on (ie- is derived from).
+        '@type': outbreak:CitationObject
+        description: A citation object for a resource which is cited by the clinical
+          trial/study (ie- is a derivative of the clinical trial/study), related to
+          the clinical trial/study, or from which the clinical trial/study was based
+          on (ie- is derived from).
         properties:
           citeText:
             description: The bibliographic citation for the referenced resource as
               is provided
             type: string
-          datePublished:
-            description: The date for which this content of this citation was posted,
-              published, or made available
-            format: date
-            type: string
           doi:
+            description: A doi if available
             type: string
           identifier:
+            description: An identifier associated with the citation
             type: string
           name:
-            description: name of the referenced resource
+            description: Name of or title of the citation
             type: string
           pmid:
-            type: integer
-          type:
+            description: A pubmed identifier if available
+            type: string
+          sourceType:
+            description: The type of resource
             enum:
-            - ClinicalStudy
-            - Analysis
-            - Publication
             - Dataset
+            - Publication
+            - ClinicalTrial
+            - Analysis
             - Protocol
             - SoftwareApplication
-            - Other
+            - CreativeWork
           url:
+            description: The url of the resource cited.
             format: uri
             type: string
           versionDate:
-            description: Date of the version of the resource that is referenced
+            description: The version date of the resource used at the time of the
+              creation of the citation as certain resources (protocols, datasets)
+              may change frequently over time.
             format: date
             type: string
         required:
         - name
-        - type
+        - sourceType
         type: object
       eligibility:
-        '@type': Thing
+        '@type': outbreak:Eligibility
         properties:
           criteriaText:
             description: The descriptive criteria as published for the Clinical Trial
@@ -1021,8 +1518,28 @@
                 - ' Adult (18-64)'
                 - Older Adult (65+)
         type: object
+      funding:
+        '@type': outbreak:MonetaryGrant
+        description: Information about funding or sponsorship support
+        properties:
+          funder:
+            description: the funder, sponsor, and collaborators for the study
+            oneOf:
+            - $ref: '#/definitions/organization'
+            - items:
+                $ref: '#/definitions/organization'
+              type: array
+          identifier:
+            description: Unique identifier(s) for the grant(s) used to fund the analysis
+            type: string
+          name:
+            description: The name of the monetary grant that funded/funds the analysis
+            type: string
+        required:
+        - funder
+        type: object
       intervention:
-        '@type': Thing
+        '@type': outbreak:Intervention
         properties:
           category:
             description: The category of an intervention in the study
@@ -1045,11 +1562,43 @@
             description: The name of the intervention in the study
             type: string
         type: object
+      memberObject:
+        '@type': outbreak:Person
+        description: Reusable person definition accounting for recursion issues in
+          DDE
+        properties:
+          affiliation:
+            oneOf:
+            - $ref: '#/definitions/baseOrgObject'
+            - items:
+                $ref: '#/definitions/baseOrgObject'
+              type: array
+          familyName:
+            type: string
+          givenName:
+            type: string
+          name:
+            type: string
+          orcid:
+            type: string
+          role:
+            description: authorship, sponsorship, or other contribution role played
+              by the person or organization in the creation of this resource
+            oneOf:
+            - type: string
+            - items:
+                type: string
+              type: array
+        required:
+        - name
+        type: object
       organization:
-        '@type': Organization
+        '@type': outbreak:Organization
         description: Reusable organization definition
         properties:
           affiliation:
+            $ref: '#/definitions/baseOrgObject'
+          alternateName:
             type: string
           class:
             description: The type of organization
@@ -1058,6 +1607,12 @@
             - Other U.S. Federal agencies
             - Industry
             - All others
+          members:
+            oneOf:
+            - $ref: '#/definitions/memberObject'
+            - items:
+                $ref: '#/definitions/memberObject'
+              type: array
           name:
             type: string
           role:
@@ -1069,8 +1624,8 @@
         required:
         - name
         type: object
-      outcome:
-        '@type': Thing
+      outcomeObject:
+        '@type': outbreak:Outcome
         properties:
           outcomeMeasure:
             description: The outcome measure for the study
@@ -1092,16 +1647,15 @@
             - other
         type: object
       person:
-        '@type': Person
+        '@type': outbreak:Person
         description: Reusable person definition
         properties:
           affiliation:
             oneOf:
-            - $ref: '#/definitions/organization'
+            - $ref: '#/definitions/baseOrgObject'
             - items:
-                $ref: '#/definitions/organization'
+                $ref: '#/definitions/baseOrgObject'
               type: array
-            type: array
           familyName:
             type: string
           givenName:
@@ -1111,22 +1665,88 @@
           orcid:
             type: string
           role:
-            description: The role of this particular author in this study, this includes
-              roles such as ResponsibleParty, Contacts, values of OverallOfficialRole,
-              Investigator
-            enum:
-            - responsible party
-            - principal investigator
-            - site sub-investigator
-            - study chair
-            - study director
-            - study principal investigator
-            - Contact
+            description: authorship, sponsorship, or other contribution role played
+              by the person or organization in the creation of this resource
+            oneOf:
+            - type: string
+            - items:
+                type: string
+              type: array
         required:
         - name
         type: object
+      ratingObject:
+        '@type': Rating
+        description: A rating or categorical evaluation of the resource
+        properties:
+          author:
+            anyOf:
+            - $ref: '#/definitions/person'
+            - items:
+                $ref: '#/definitions/person'
+              type: array
+            - $ref: '#/definitions/organization'
+            - items:
+                $ref: '#/definitions/organization'
+              type: array
+            description: The author of this content or rating.
+          curationDate:
+            description: The date this evaluation was added into outbreak.info, or
+              was updated in outbreak.info.
+            format: date
+            type: string
+          name:
+            description: The name of the rating
+            type: string
+          ratingExplanation:
+            description: An explanation of the rating
+            type: string
+          ratingValue:
+            description: The rating for the content.
+            type: string
+          reviewAspect:
+            description: This Review or Rating is relevant to this part or facet of
+              the itemReviewed
+            type: string
+        required: []
+        type: object
+      reviewObject:
+        '@type': Review
+        description: A review or descriptive evaluation of the resource
+        properties:
+          author:
+            anyOf:
+            - $ref: '#/definitions/person'
+            - items:
+                $ref: '#/definitions/person'
+              type: array
+            - $ref: '#/definitions/organization'
+            - items:
+                $ref: '#/definitions/organization'
+              type: array
+            description: The author of this content or rating.
+          curationDate:
+            description: The date this evaluation was added into outbreak.info, or
+              was updated in outbreak.info.
+            format: date
+            type: string
+          name:
+            description: The name of the review
+            type: string
+          reviewAspect:
+            description: This Review or Rating is relevant to this part or facet of
+              the itemReviewed
+            type: string
+          reviewBody:
+            description: The actual body of the review.
+            type: string
+          reviewRating:
+            $ref: '#/definitions/ratingObject'
+            description: The rating given in this review
+        required: []
+        type: object
       studydesign:
-        '@type': Thing
+        '@type': outbreak:StudyDesign
         properties:
           designAllocation:
             description: The method by which the study participants were allocated
@@ -1251,7 +1871,7 @@
             - observational
         type: object
       studyevent:
-        '@type': Thing
+        '@type': outbreak:StudyEvent
         description: an event status such as StudyStart, PrimaryCompletion, Completion,
           StudyFirstSubmit, StudyFirstSubmitQC, LastUpdateSubmit
         properties:
@@ -1280,7 +1900,7 @@
             type: string
         type: object
       studylocation:
-        '@type': Place
+        '@type': outbreak:StudyLocation
         description: The study sites or the location of the study
         properties:
           studyLocation:
@@ -1312,7 +1932,7 @@
             - unknown status
         type: object
       studystatus:
-        '@type': Thing
+        '@type': outbreak:StudyStatus
         properties:
           enrollmentCount:
             description: The number of participants enrolled in the study
@@ -1385,17 +2005,15 @@
             $ref: '#/definitions/person'
           type: array
       citedBy:
-        description: other articles or resources that cite this clinical trial
+        description: Associated guidelines, protocols, publications, etc. that include,
+          adapt, modify, expand, etc. this clinical trial/study
         oneOf:
         - $ref: '#/definitions/citation'
         - items:
             $ref: '#/definitions/citation'
           type: array
       curatedBy:
-        description: The source from which this Clinical Study was identified for
-          inclusion into Outbreak.info. Provides provenance for a resource which was
-          curated by another.
-        oneOf:
+        anyOf:
         - $ref: '#/definitions/citation'
         - $ref: '#/definitions/person'
         - $ref: '#/definitions/organization'
@@ -1408,6 +2026,9 @@
         - items:
             $ref: '#/definitions/citation'
           type: array
+        description: The source from which this clinical trial/study was identified
+          for inclusion into Outbreak.info. Provides provenance for a resource which
+          was curated by another.
       curationDate:
         description: The date this resource was added into outbreak.info, or was updated
           in outbreak.info.
@@ -1446,8 +2067,27 @@
         - items:
             $ref: '#/definitions/eligibility'
           type: array
+      evaluations:
+        anyOf:
+        - items:
+            $ref: '#/definitions/reviewObject'
+          type: array
+        - items:
+            $ref: '#/definitions/ratingObject'
+          type: array
+        - items:
+            $ref: '#/definitions/aggregateRatingObject'
+          type: array
+        description: Reviews, Ratings, or other types of evaluations on this resource
+      funding:
+        description: Funding, sponsorship, and collaborations for the study.
+        oneOf:
+        - $ref: '#/definitions/funding'
+        - items:
+            $ref: '#/definitions/funding'
+          type: array
       hasResults:
-        description: Binary for if the clinical trial has published any results
+        description: Boolean for if the clinical trial has published any results
         type: boolean
       healthCondition:
         description: The health condition or disease being studied
@@ -1456,7 +2096,7 @@
         - items:
             type: string
           type: array
-      healthConditionIidentifier:
+      healthConditionIdentifier:
         description: Ontological or controlled vocabulary identifier for the health
           condition or disease
         oneOf:
@@ -1480,9 +2120,16 @@
             type: string
           type: array
       isBasedOn:
-        description: Associated datasets, software, protocols, etc. used by the work
-          described in this clinical study (includes study protocol documents, data
-          analysis plans, reference publications. etc)
+        description: Associated resource (guidelines, protocols, publications, etc.)
+          from which this clinical trial/study was derived
+        oneOf:
+        - $ref: '#/definitions/citation'
+        - items:
+            $ref: '#/definitions/citation'
+          type: array
+      isRelatedTo:
+        description: Other resources related to, but not a derivative of nor derived
+          from this clinical trial/study
         oneOf:
         - $ref: '#/definitions/citation'
         - items:
@@ -1499,26 +2146,11 @@
         description: Official or scientific title of the study
         type: string
       outcome:
-        description: The outcome (expected or actual) of a study
+        description: Expected or actual outcomes of the study.
         oneOf:
-        - $ref: '#/definitions/outcome'
+        - $ref: '#/definitions/outcomeObject'
         - items:
-            $ref: '#/definitions/outcome'
-          type: array
-      relatedTo:
-        description: Other resources related to, but not a derivative of nor derived
-          from this analysis
-        oneOf:
-        - $ref: '#/definitions/citation'
-        - items:
-            $ref: '#/definitions/citation'
-          type: array
-      sponsor:
-        description: 'A sponsor, funder, or collaborator for the study. '
-        oneOf:
-        - $ref: '#/definitions/organization'
-        - items:
-            $ref: '#/definitions/organization'
+            $ref: '#/definitions/outcomeObject'
           type: array
       studyDesign:
         description: The general design of the study
@@ -1536,7 +2168,7 @@
             $ref: '#/definitions/studyevent'
           type: array
       studyLocation:
-        description: The location of the study
+        description: The location in which the study is taking/took place.
         oneOf:
         - $ref: '#/definitions/studylocation'
         - items:
@@ -1627,1234 +2259,382 @@
         format: uri
         type: string
     required:
-    - name
-    - url
+    - identifierSource
+    - funding
+    - author
+    - healthCondition
     - description
     - identifier
-    - identifierSource
-    - healthCondition
-    - sponsor
-    - author
+    - name
     type: object
   '@id': outbreak:ClinicalTrial
   '@type': rdfs:Class
-  rdfs:comment: This is the schema for describing the ClinicalTrial schema used for
-    outbreak.info.
+  rdfs:comment: This is the schema for describing the Clinical Trials and other medical
+    studies used for outbreak.info Resources
   rdfs:label: ClinicalTrial
   rdfs:subClassOf:
     '@id': schema:MedicalStudy
-  schema:isPartOf:
-    '@id': https://discovery.biothings.io/view/outbreak/
-- '@id': outbreak:name
-  '@type': rdf:Property
-  marginality: required
-  owl:cardinality: one
-  rdfs:comment: Official or scientific title of the study
-  rdfs:label: name
-  rdfs:sameAs:
-    '@id': schema:name
-  schema:domainIncludes:
-    '@id': outbreak:ClinicalTrial
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:alternateName
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: many
-  rdfs:comment: Brief title, acronyms, or public titles for the study
-  rdfs:label: alternateName
-  rdfs:sameAs:
-    '@id': schema:alternateName
-  schema:domainIncludes:
-    '@id': outbreak:ClinicalTrial
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:identifier
-  '@type': rdf:Property
-  marginality: required
-  owl:cardinality: many
-  rdfs:comment: Registration number or identifier assigned to the study
-  rdfs:label: identifier
-  rdfs:sameAs:
-    '@id': schema:identifier
-  schema:domainIncludes:
-    '@id': outbreak:ClinicalTrial
-  schema:rangeIncludes:
-    '@id': schema:Text
 - '@id': outbreak:identifierSource
-  '@type': rdf:Property
-  marginality: required
-  owl:cardinality: many
+  '@type': rdfs:Property
   rdfs:comment: Source of identifier assignment or type of identifier (NCTid, China
     CTRid, EudraCT Number, etc.)
   rdfs:label: identifierSource
-  rdfs:sameAs:
-    '@id': schema:additionalType
   schema:domainIncludes:
     '@id': outbreak:ClinicalTrial
   schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:url
-  '@type': rdf:Property
-  marginality: required
-  owl:cardinality: one
-  rdfs:comment: url where the study can be found
-  rdfs:label: url
-  rdfs:sameAs:
-    '@id': schema:url
-  schema:domainIncludes:
-    '@id': outbreak:ClinicalTrial
-  schema:rangeIncludes:
-    '@id': schema:URL
-- '@id': outbreak:abstract
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: A brief summary of the study
-  rdfs:label: abstract
-  rdfs:sameAs:
-    '@id': schema:abstract
-  schema:domainIncludes:
-    '@id': outbreak:ClinicalTrial
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:description
-  '@type': rdf:Property
-  marginality: required
-  owl:cardinality: one
-  rdfs:comment: A description of the study or the stated purpose of the study
-  rdfs:label: description
-  rdfs:sameAs:
-    '@id': schema:description
-  schema:domainIncludes:
-    '@id': outbreak:ClinicalTrial
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:dateCreated
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: Date the record was created
-  rdfs:label: dateCreated
-  rdfs:sameAs:
-    '@id': schema:dateCreated
-  schema:domainIncludes:
-    '@id': outbreak:ClinicalTrial
-  schema:rangeIncludes:
-    '@id': schema:Date
-- '@id': outbreak:datePublished
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: Date the record was published
-  rdfs:label: datePublished
-  rdfs:sameAs:
-    '@id': schema:datePublished
-  schema:domainIncludes:
-    '@id': outbreak:ClinicalTrial
-  schema:rangeIncludes:
-    '@id': schema:Date
-- '@id': outbreak:dateModified
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: LastUpdatePostDate
-  rdfs:label: dateModified
-  rdfs:sameAs:
-    '@id': schema:dateModified
-  schema:domainIncludes:
-    '@id': outbreak:ClinicalTrial
-  schema:rangeIncludes:
-    '@id': schema:Date
+  - '@id': schema:Text
 - '@id': outbreak:dateModifiedType
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: LastUpdatePostDateType
+  '@type': rdfs:Property
+  rdfs:comment: The type of date. Equivalent to NCT's LastUpdatePostDateType
   rdfs:label: dateModifiedType
-  rdfs:sameAs:
-    '@id': schema:addtionalType
   schema:domainIncludes:
     '@id': outbreak:ClinicalTrial
   schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:healthCondition
-  '@type': rdf:Property
-  marginality: required
-  owl:cardinality: many
-  rdfs:comment: The health condition or disease being studied
-  rdfs:label: healthCondition
-  rdfs:sameAs:
-    '@id': schema:MedicalCondition
-  schema:domainIncludes:
-    '@id': outbreak:ClinicalTrial
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:healthConditionIidentifier
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
+  - '@id': schema:Text
+- '@id': outbreak:healthConditionIdentifier
+  '@type': rdfs:Property
   rdfs:comment: Ontological or controlled vocabulary identifier for the health condition
     or disease
-  rdfs:label: healthConditionIidentifier
-  rdfs:sameAs:
-    '@id': schema:MedicalCode
+  rdfs:label: healthConditionIdentifier
   schema:domainIncludes:
     '@id': outbreak:ClinicalTrial
   schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:keywords
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: keywords
-  rdfs:label: keywords
-  rdfs:sameAs:
-    '@id': schema:keywords
-  schema:domainIncludes:
-    '@id': outbreak:ClinicalTrial
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:topicCategory
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: Applicable outbreak.info category
-  rdfs:label: topicCategory
-  rdfs:sameAs:
-    '@id': schema:about
-  schema:domainIncludes:
-    '@id': outbreak:ClinicalTrial
-  schema:rangeIncludes:
-    '@id': schema:Text
+  - '@id': schema:Text
+  - '@id': schema:DefinedTerm
 - '@id': outbreak:hasResults
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: Binary for if the clinical trial has published any results
+  '@type': rdfs:Property
+  rdfs:comment: Boolean for if the clinical trial has published any results
   rdfs:label: hasResults
   schema:domainIncludes:
     '@id': outbreak:ClinicalTrial
   schema:rangeIncludes:
-    '@id': schema:Boolean
-- '@id': outbreak:author
-  '@type': rdf:Property
-  marginality: required
-  owl:cardinality: many
-  rdfs:comment: The study's author, this includes ResponsiblePartyInvestigator, Contacts,
-    and OverallOfficials
-  rdfs:label: author
-  rdfs:sameAs:
-    '@id': schema:author
-  schema:domainIncludes:
-    '@id': outbreak:ClinicalTrial
-  schema:rangeIncludes:
-  - '@id': outbreak:Person
-  - '@id': outbreak:Organization
-- '@id': outbreak:name
-  '@type': rdf:Property
-  marginality: required
-  owl:cardinality: one
-  rdfs:comment: 'The name of the study author as it appears in the registery. May
-    include values from the following NCT fields: ResponsiblePartyInvestigatorFullName,
-    OverallOfficialName, ContactName'
-  rdfs:label: name
-  rdfs:sameAs:
-    '@id': schema:name
-  schema:domainIncludes:
-    '@id': outbreak:Person
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:givenName
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The given name of the study author
-  rdfs:label: givenName
-  rdfs:sameAs:
-    '@id': schema:givenName
-  schema:domainIncludes:
-    '@id': outbreak:Person
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:familyName
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The family name of the study author
-  rdfs:label: familyName
-  rdfs:sameAs:
-    '@id': schema:familyName
-  schema:domainIncludes:
-    '@id': outbreak:Person
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:affiliation
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: Affiliation associated with the study author
-  rdfs:label: affiliation
-  rdfs:sameAs:
-    '@id': schema:affiliation
-  schema:domainIncludes:
-    '@id': outbreak:Organization
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:role
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: The role of this particular author in this study, this includes roles
-    such as ResponsibleParty, Contacts, values of OverallOfficialRole, Investigator
-  rdfs:label: role
-  rdfs:sameAs:
-    '@id': schema:additionalType
-  schema:domainIncludes:
-    '@id': outbreak:Person
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:sponsor
-  '@type': rdf:Property
-  marginality: required
-  owl:cardinality: many
-  rdfs:comment: 'A sponsor, funder, or collaborator for the study. '
-  rdfs:label: sponsor
-  rdfs:sameAs:
-    '@id': schema:sponsor
-  schema:domainIncludes:
-    '@id': outbreak:ClinicalTrial
-  schema:rangeIncludes:
-    '@id': outbreak:Organization
-- '@id': outbreak:name
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The name of the sponsoring or funding organization
-  rdfs:label: name
-  rdfs:sameAs:
-    '@id': schema:name
-  schema:domainIncludes:
-    '@id': outbreak:Organization
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:class
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: The type of organization
-  rdfs:label: class
-  rdfs:sameAs:
-    '@id': schema:addtionalType
-  schema:domainIncludes:
-    '@id': outbreak:Organization
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:role
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: LeadSponsor, funder, collaborator
-  rdfs:label: role
-  rdfs:sameAs:
-    '@id': schema:additionalType
-  schema:domainIncludes:
-    '@id': outbreak:Organization
-  schema:rangeIncludes:
-    '@id': schema:Text
+  - '@id': schema:Boolean
 - '@id': outbreak:studyEvent
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
+  '@type': rdfs:Property
   rdfs:comment: an event status such as StudyStart, PrimaryCompletion, Completion,
     StudyFirstSubmit, StudyFirstSubmitQC, LastUpdateSubmit
   rdfs:label: studyEvent
   schema:domainIncludes:
     '@id': outbreak:ClinicalTrial
   schema:rangeIncludes:
-    '@id': outbreak:StudyEvent
-- '@id': outbreak:studyEventType
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: Type of the event status such as StudyStart, PrimaryCompletion, Completion,
-    StudyFirstSubmit, StudyFirstSubmitQC, LastUpdateSubmit
-  rdfs:label: studyEventType
-  rdfs:sameAs:
-    '@id': schema:additionalType
-  schema:domainIncludes:
-    '@id': outbreak:StudyEvent
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:studyEventDate
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: StartDate, Primary CompletionDate, CompletionDate, StudyFirstSubmitDate,
-    StudyFirstSubmitQCDate, LastUpdateSubmitDate
-  rdfs:label: studyEventDate
-  rdfs:sameAs:
-    '@id': schema:temporal
-  schema:domainIncludes:
-    '@id': outbreak:StudyEvent
-  schema:rangeIncludes:
-    '@id': schema:Date
-- '@id': outbreak:studyEventDateType
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: the type of date provided (actual, anticipated, or estimated)
-  rdfs:label: studyEventDateType
-  rdfs:sameAs:
-    '@id': schema:addtionalType
-  schema:domainIncludes:
-    '@id': outbreak:StudyEvent
-  schema:rangeIncludes:
-    '@id': schema:Text
+  - '@id': outbreak:StudyEvent
 - '@id': outbreak:studyStatus
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
+  '@type': rdfs:Property
   rdfs:comment: The status of the study
   rdfs:label: studyStatus
   schema:domainIncludes:
     '@id': outbreak:ClinicalTrial
   schema:rangeIncludes:
-    '@id': outbreak:StudyStatus
-- '@id': outbreak:status
-  '@type': rdf:Property
-  marginality: required
-  owl:cardinality: one
-  rdfs:comment: The recruitment status of the study
-  rdfs:label: status
-  rdfs:sameAs:
-    '@id': outbreak:status
-  schema:domainIncludes:
-    '@id': outbreak:StudyStatus
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:statusExpandedAccess
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: Flag for whether or not the study has expanded Access status
-  rdfs:label: statusExpandedAccess
-  rdfs:sameAs:
-    '@id': outbreak:statusExpandedAccess
-  schema:domainIncludes:
-    '@id': outbreak:StudyStatus
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:statusDate
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The date that the status was verified. Equivalent to NCT's StatusVerifiedDate
-  rdfs:label: statusDate
-  rdfs:sameAs:
-    '@id': outbreak:statusDate
-  schema:domainIncludes:
-    '@id': outbreak:StudyStatus
-  schema:rangeIncludes:
-    '@id': schema:Date
-- '@id': outbreak:enrollmentCount
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The number of participants enrolled in the study
-  rdfs:label: enrollmentCount
-  rdfs:sameAs:
-    '@id': outbreak:enrollmentCount
-  schema:domainIncludes:
-    '@id': outbreak:StudyStatus
-  schema:rangeIncludes:
-    '@id': schema:Number
-- '@id': outbreak:enrollmentType
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The type of estimation used to determine the enrollmentCount (actual
-    counts, target size, etc.)
-  rdfs:label: enrollmentType
-  rdfs:sameAs:
-    '@id': outbreak:enrollmentType
-  schema:domainIncludes:
-    '@id': outbreak:StudyStatus
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:whyStopped
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: A brief explanation of the reason(s) why such clinical study was stopped
-    (for a clinical study that is "Suspended," "Terminated," or "Withdrawn" prior
-    to its planned completion as anticipated by the protocol)
-  rdfs:label: whyStopped
-  rdfs:sameAs:
-    '@id': schema:description
-  schema:domainIncludes:
-    '@id': outbreak:StudyStatus
-  schema:rangeIncludes:
-    '@id': schema:Text
+  - '@id': outbreak:StudyStatus
 - '@id': outbreak:studyDesign
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
+  '@type': rdfs:Property
   rdfs:comment: The general design of the study
   rdfs:label: studyDesign
   schema:domainIncludes:
     '@id': outbreak:ClinicalTrial
   schema:rangeIncludes:
-    '@id': outbreak:StudyDesign
-- '@id': outbreak:studyType
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: Type of human study, can be subtypes of observational study or interventional
-    studies
-  rdfs:label: studyType
-  rdfs:sameAs:
-    '@id': outbreak:studyType
-  schema:domainIncludes:
-    '@id': outbreak:StudyDesign
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:phase
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: many
-  rdfs:comment: Stage or phase of the study in the U.S.
-  rdfs:label: phase
-  rdfs:sameAs:
-    '@id': outbreak:phase
-  schema:domainIncludes:
-    '@id': outbreak:StudyDesign
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:phaseNumber
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: many
-  rdfs:comment: The number of the phase or stage of the study
-  rdfs:label: phaseNumber
-  rdfs:sameAs:
-    '@id': schema:additionalType
-  schema:domainIncludes:
-    '@id': outbreak:StudyDesign
-  schema:rangeIncludes:
-    '@id': schema:Number
-- '@id': outbreak:designAllocation
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The method by which the study participants were allocated into groups
-  rdfs:label: designAllocation
-  rdfs:sameAs:
-    '@id': outbreak:designAllocation
-  schema:domainIncludes:
-    '@id': outbreak:StudyDesign
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:designModel
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: The general design of the strategy for assigning interventions to
-    participants in a clinical intervention study OR the general design of the strategy
-    for identifying and following up with participants during an observational study
-    and may include the temporal relationship of observation period to time of participant
-    enrollment.
-  rdfs:label: designModel
-  rdfs:sameAs:
-    '@id': outbreak:designModel
-  schema:domainIncludes:
-    '@id': outbreak:StudyDesign
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:designPrimaryPurpose
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: The primary purpose of the study
-  rdfs:label: designPrimaryPurpose
-  rdfs:sameAs:
-    '@id': outbreak:designPrimaryPurpose
-  schema:domainIncludes:
-    '@id': outbreak:StudyDesign
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:designWhoMasked
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: The people who not know which participants have been assigned to which
-    interventions.
-  rdfs:label: designWhoMasked
-  rdfs:sameAs:
-    '@id': outbreak:designWhoMasked
-  schema:domainIncludes:
-    '@id': outbreak:StudyDesign
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:designStudyText
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: String description of the study design if structured information not
-    available
-  rdfs:label: designStudyText
-  rdfs:sameAs:
-    '@id': schema:description
-  schema:domainIncludes:
-    '@id': outbreak:StudyDesign
-  schema:rangeIncludes:
-    '@id': schema:Text
+  - '@id': outbreak:StudyDesign
 - '@id': outbreak:armGroup
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: many
+  '@type': rdfs:Property
   rdfs:comment: The arm or factor of an interventional study
   rdfs:label: armGroup
   schema:domainIncludes:
     '@id': outbreak:ClinicalTrial
   schema:rangeIncludes:
-    '@id': outbreak:ArmGroup
-- '@id': outbreak:name
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: The name of the arm or factor (can include a specific intervention,
-    a placebo or even a lack of intervention, ie- 'no intervention' group). The Group
-    or cohort in the case of observational studies
-  rdfs:label: name
-  rdfs:sameAs:
-    '@id': outbreak:name
-  schema:domainIncludes:
-    '@id': outbreak:ArmGroup
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:role
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: The role of the arm or factor in the study this is equivalent to the
-    ArmType in ClinicalTrials.gov
-  rdfs:label: role
-  rdfs:sameAs:
-    '@id': outbreak:role
-  schema:domainIncludes:
-    '@id': outbreak:ArmGroup
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:description
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: A description of the arm or factor
-  rdfs:label: description
-  rdfs:sameAs:
-    '@id': outbreak:description
-  schema:domainIncludes:
-    '@id': outbreak:ArmGroup
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:intervention
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: many
-  rdfs:comment: The interventions (if any) in this ArmGroup
-  rdfs:label: intervention
-  schema:domainIncludes:
-    '@id': outbreak:ArmGroup
-  schema:rangeIncludes:
-    '@id': outbreak:Intervention
-- '@id': outbreak:category
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: The category of the arm or factor in the study
-  rdfs:label: category
-  rdfs:sameAs:
-    '@id': schema:additionalType
-  schema:domainIncludes:
-    '@id': outbreak:Intervention
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:name
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: The name of the intervention in the study
-  rdfs:label: name
-  rdfs:sameAs:
-    '@id': schema:name
-  schema:domainIncludes:
-    '@id': outbreak:Intervention
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:description
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: A description of the intervention in the study
-  rdfs:label: description
-  rdfs:sameAs:
-    '@id': schema:description
-  schema:domainIncludes:
-    '@id': outbreak:Intervention
-  schema:rangeIncludes:
-    '@id': schema:Text
+  - '@id': outbreak:ArmGroup
 - '@id': outbreak:outcome
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: The outcome (expected or actual) of a study
+  '@type': rdfs:Property
+  rdfs:comment: The arm or factor of an interventional study
   rdfs:label: outcome
   schema:domainIncludes:
     '@id': outbreak:ClinicalTrial
   schema:rangeIncludes:
-    '@id': outbreak:Outcome
-- '@id': outbreak:outcomeMeasure
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: The outcome measure for the study
-  rdfs:label: outcomeMeasure
-  rdfs:sameAs:
-    '@id': outbreak:outcomeMeasure
-  schema:domainIncludes:
-    '@id': outbreak:Outcome
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:outcomeTimeFrame
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: 'The specific time point(s) and overall duration of evaluation must
-    be specified in this section. '
-  rdfs:label: outcomeTimeFrame
-  rdfs:sameAs:
-    '@id': outbreak:outcomeTimeFrame
-  schema:domainIncludes:
-    '@id': outbreak:Outcome
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:outcomeType
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The classification of the outcome measure as either primary, secondary,
-    or exploratory
-  rdfs:label: outcomeType
-  rdfs:sameAs:
-    '@id': outbreak:outcomeType
-  schema:domainIncludes:
-    '@id': outbreak:Outcome
-  schema:rangeIncludes:
-    '@id': schema:Text
+  - '@id': outbreak:Outcome
 - '@id': outbreak:eligibilityCriteria
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
+  '@type': rdfs:Property
   rdfs:comment: eligibility criteria
   rdfs:label: eligibilityCriteria
   schema:domainIncludes:
     '@id': outbreak:ClinicalTrial
   schema:rangeIncludes:
-    '@id': outbreak:Eligibility
-- '@id': outbreak:inclusionCriteria
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: criteria for inclusion in the study
-  rdfs:label: inclusionCriteria
+  - '@id': outbreak:Eligibility
+- '@id': outbreak:author
+  '@type': rdfs:Property
+  rdfs:comment: The author of this resource, content, or rating
+  rdfs:label: author
   rdfs:sameAs:
-    '@id': outbreak:inclusionCriteria
+    '@id': schema:author
   schema:domainIncludes:
-    '@id': outbreak:Eligibility
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:minimumAge
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: the minimum age for a participant to be included in the study
-  rdfs:label: minimumAge
-  rdfs:sameAs:
-    '@id': outbreak:minimumAge
-  schema:domainIncludes:
-    '@id': outbreak:Eligibility
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:maximumAge
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: the maximum age for a participant to be included in the study
-  rdfs:label: maximumAge
-  rdfs:sameAs:
-    '@id': schema:requiredMaxAge
-  schema:domainIncludes:
-    '@id': outbreak:Eligibility
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:gender
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: the sex requirement to be included in the study
-  rdfs:label: gender
-  rdfs:sameAs:
-    '@id': schema:requiredGender
-  schema:domainIncludes:
-    '@id': outbreak:Eligibility
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:genderBased
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: Boolean for whether or not participation is based on gender
-  rdfs:label: genderBased
-  rdfs:sameAs:
-    '@id': outbreak:genderBased
-  schema:domainIncludes:
-    '@id': outbreak:Eligibility
-  schema:rangeIncludes:
-    '@id': schema:Boolean
-- '@id': outbreak:healthyVolunteers
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: a boolean to indicate whether or not healthy volunteers may be included
-    in the study
-  rdfs:label: healthyVolunteers
-  rdfs:sameAs:
-    '@id': outbreak:healthyVolunteers
-  schema:domainIncludes:
-    '@id': outbreak:Eligibility
-  schema:rangeIncludes:
-    '@id': schema:Boolean
-- '@id': outbreak:stdAge
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: the age category of a participant to be included in the study if a
-    minimum and maximum age is not specified
-  rdfs:label: stdAge
-  rdfs:sameAs:
-    '@id': outbreak:stdAge
-  schema:domainIncludes:
-    '@id': outbreak:Eligibility
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:exclusionCriteria
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: criteria for exclusion from the study
-  rdfs:label: exclusionCriteria
-  rdfs:sameAs:
-    '@id': outbreak:exclusionCriteria
-  schema:domainIncludes:
-    '@id': outbreak:Eligibility
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:criteriaText
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The descriptive criteria as published for the Clinical Trial
-  rdfs:label: criteriaText
-  rdfs:sameAs:
-    '@id': outbreak:criteriaText
-  schema:domainIncludes:
-    '@id': outbreak:Eligibility
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:citedBy
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: many
-  owl:inverseOf:
-    '@id': schema:isBasedOn
-  rdfs:comment: other articles or resources that cite this clinical trial
-  rdfs:label: citedBy
-  schema:domainIncludes:
-    '@id': outbreak:ClinicalTrial
-  schema:rangeIncludes:
-  - '@id': outbreak:ClinicalTrial
   - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
   - '@id': outbreak:Dataset
   - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-- '@id': outbreak:name
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: name of the citedBy resource
-  rdfs:label: name
+  - '@id': outbreak:Publication
+  - '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': outbreak:Person
+  - '@id': outbreak:Organization
+- '@id': outbreak:dateCreated
+  '@type': rdfs:Property
+  rdfs:comment: Date the record was created
+  rdfs:label: dateCreated
   rdfs:sameAs:
-    '@id': schema:name
+    '@id': schema:dateCreated
   schema:domainIncludes:
   - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
   schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:type
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: type (publication, protocol, dataset, code, etc.) of the citedBy resource.
-    Note that this can include ClinicalTrial results
-  rdfs:label: type
-  rdfs:sameAs:
-    '@id': schema:additionalType
-  schema:domainIncludes:
-  - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:identifier
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: identifier (pmid, WHO protocol id, etc.) of the citedby resource
-  rdfs:label: identifier
-  rdfs:sameAs:
-    '@id': schema:identifier
-  schema:domainIncludes:
-  - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:url
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: url of the cited by resource
-  rdfs:label: url
-  rdfs:sameAs:
-    '@id': schema:url
-  schema:domainIncludes:
-  - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-  schema:rangeIncludes:
-    '@id': schema:URL
+  - '@id': schema:Date
 - '@id': outbreak:datePublished
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: The date for which the other articles, resources, or results that
-    cite this clinical trial were posted, published, or made available
+  '@type': rdfs:Property
+  rdfs:comment: Date of first broadcast/publication
   rdfs:label: datePublished
   rdfs:sameAs:
     '@id': schema:datePublished
   schema:domainIncludes:
-  - '@id': outbreak:ClinicalTrial
   - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
   - '@id': outbreak:Dataset
   - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
+  - '@id': outbreak:Publication
+  - '@id': outbreak:ClinicalTrial
   schema:rangeIncludes:
-    '@id': schema:Text
+  - '@id': schema:Date
+- '@id': outbreak:dateModified
+  '@type': rdfs:Property
+  rdfs:comment: The date on which the CreativeWork was most recently modified or when
+    the item's entry was modified within a DataFeed
+  rdfs:label: dateModified
+  rdfs:sameAs:
+    '@id': schema:dateModified
+  schema:domainIncludes:
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Protocol
+  - '@id': outbreak:Publication
+  - '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': schema:Date
+- '@id': outbreak:keywords
+  '@type': rdfs:Property
+  rdfs:comment: keywords for describing the record
+  rdfs:label: keywords
+  schema:domainIncludes:
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Protocol
+  - '@id': outbreak:Publication
+  - '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:abstract
+  '@type': rdfs:Property
+  rdfs:comment: A short descriptive summary of the publication or study
+  rdfs:label: abstract
+  rdfs:sameAs:
+    '@id': schema:abstract
+  schema:domainIncludes:
+  - '@id': outbreak:Publication
+  - '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:pmid
+  '@type': rdfs:Property
+  rdfs:comment: A pubmed identifier if available
+  rdfs:label: pmid
+  schema:domainIncludes:
+  - '@id': outbreak:CitationObject
+  - '@id': outbreak:Correction
+  - '@id': outbreak:Publication
+  schema:rangeIncludes:
+  - '@id': schema:Integer
+- '@id': outbreak:doi
+  '@type': rdfs:Property
+  rdfs:comment: A doi if available
+  rdfs:label: doi
+  schema:domainIncludes:
+  - '@id': outbreak:CitationObject
+  - '@id': outbreak:Correction
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Publication
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Protocol
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:funding
+  '@type': rdfs:Property
+  rdfs:comment: Funding that supports (sponsors) the collection of this dataset through
+    some kind of financial contribution
+  rdfs:label: funding
+  schema:domainIncludes:
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Publication
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Protocol
+  - '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': schema:MonetaryGrant
+- '@id': outbreak:measurementTechnique
+  '@type': rdfs:Property
+  rdfs:comment: A technique or technology used in this resource
+  rdfs:label: measurementTechnique
+  rdfs:sameAs:
+    '@id': schema:measurementTechnique
+  schema:domainIncludes:
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Protocol
+  schema:rangeIncludes:
+  - '@id': schema:Text
+  - '@id': schema:DefinedTerm
+- '@id': outbreak:species
+  '@type': rdfs:Property
+  rdfs:comment: Species(es) from which dataset has been collected
+  rdfs:label: species
+  schema:domainIncludes:
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Analysis
+  schema:rangeIncludes:
+  - '@id': schema:Text
+  - '@id': schema:DefinedTerm
+- '@id': outbreak:infectiousAgent
+  '@type': rdfs:Property
+  rdfs:comment: infectious agents(s) which are the focus of the dataset
+  rdfs:label: infectiousAgent
+  schema:domainIncludes:
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Analysis
+  schema:rangeIncludes:
+  - '@id': schema:Text
+  - '@id': schema:DefinedTerm
+- '@id': outbreak:infectiousDisease
+  '@type': rdfs:Property
+  rdfs:comment: The disease or medical conditions caused by the infectious agent.
+    Important as some agents may cause multiple diseases
+  rdfs:label: infectiousDisease
+  schema:domainIncludes:
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Analysis
+  schema:rangeIncludes:
+  - '@id': schema:Text
+  - '@id': schema:DefinedTerm
+- '@id': outbreak:topicCategory
+  '@type': rdfs:Property
+  rdfs:comment: Applicable outbreak.info category
+  rdfs:label: topicCategory
+  schema:domainIncludes:
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Publication
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Protocol
+  - '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': schema:Text
 - '@id': outbreak:isBasedOn
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: many
-  rdfs:comment: Associated datasets, software, protocols, etc. used by the work described
-    in this clinical study (includes study protocol documents, data analysis plans,
-    reference publications. etc)
+  '@type': rdfs:Property
+  rdfs:comment: A citation to a resource (eg- publication, protocol, etc.) on which
+    this resource was derived (stored as an object, not a string)
   rdfs:label: isBasedOn
-  rdfs:sameAs:
-    '@id': schema:isBasedOn
   schema:domainIncludes:
-    '@id': outbreak:ClinicalTrial
-  schema:rangeIncludes:
-  - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
   - '@id': outbreak:Dataset
+  - '@id': outbreak:Publication
+  - '@id': outbreak:Analysis
   - '@id': outbreak:Protocol
+  - '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': outbreak:CitationObject
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Publication
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Protocol
+  - '@id': outbreak:ClinicalTrial
   - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-- '@id': outbreak:name
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: name of the associated dataset, software, protocols, etc used by the
-    work described in this clinical study
-  rdfs:label: name
-  rdfs:sameAs:
-    '@id': schema:name
+  - '@id': schema:CreativeWork
+- '@id': outbreak:isRelatedTo
+  '@type': rdfs:Property
+  rdfs:comment: A citation to a resource (eg- publication, protocol, etc.) which is
+    related to the resource but is not a derivative nor was derived from the resource
+    (stored as an object, not a string)
+  rdfs:label: isRelatedTo
   schema:domainIncludes:
-  - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
   - '@id': outbreak:Dataset
+  - '@id': outbreak:Publication
+  - '@id': outbreak:Analysis
   - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
+  - '@id': outbreak:ClinicalTrial
   schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:type
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: type of the associated resource (dataset, protocols, analysis, etc.)
-    used by the work described in this clinical study
-  rdfs:label: type
+  - '@id': outbreak:CitationObject
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Publication
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Protocol
+  - '@id': outbreak:ClinicalTrial
+  - '@id': schema:SoftwareApplication
+  - '@id': schema:CreativeWork
+- '@id': outbreak:citedBy
+  '@type': rdfs:Property
+  rdfs:comment: A citation to a resource (eg- publication, protocol, etc.) which is
+    derived from this resource (stored as an object, not a string)
+  rdfs:label: citedBy
   rdfs:sameAs:
-    '@id': schema:additionalType
+    '@id': 'owl:inverseOf: outbreak:isBasedOn'
   schema:domainIncludes:
-  - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
   - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:identifier
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: Identifier of the associated datasets, software, protocols, etc.
-  rdfs:label: identifier
-  rdfs:sameAs:
-    '@id': schema:identifier
-  schema:domainIncludes:
-  - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
   - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:versionDate
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: date of the version of the associated resource used by the work described
-    in this clinical trial
-  rdfs:label: versionDate
-  rdfs:sameAs:
-  - '@id': schema:releaseDate
-  - '@id': schema:dateModified
-  schema:domainIncludes:
-  - '@id': outbreak:ClinicalTrial
   - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
   - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-  schema:rangeIncludes:
-    '@id': schema:Date
-- '@id': outbreak:url
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: url of the associated resource used by the work described in this
-    clinical study (includes study protocol documents, data analysis plans, etc)
-  rdfs:label: url
-  rdfs:sameAs:
-    '@id': schema:url
-  schema:domainIncludes:
   - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
+  schema:rangeIncludes:
+  - '@id': outbreak:CitationObject
   - '@id': outbreak:Dataset
+  - '@id': outbreak:Publication
+  - '@id': outbreak:Analysis
   - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-  schema:rangeIncludes:
-    '@id': schema:URL
-- '@id': outbreak:relatedTo
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: many
-  rdfs:comment: Other resources related to, but not a derivative of nor derived from
-    this analysis
-  rdfs:label: relatedTo
-  rdfs:sameAs:
-    '@id': schema:relatedTo
-  schema:domainIncludes:
-    '@id': outbreak:ClinicalTrial
-  schema:rangeIncludes:
   - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
   - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-- '@id': outbreak:name
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: name of related resource
-  rdfs:label: name
-  rdfs:sameAs:
-    '@id': schema:name
-  schema:domainIncludes:
-  - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:type
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: type of related resource
-  rdfs:label: type
-  rdfs:sameAs:
-    '@id': schema:additionalType
-  schema:domainIncludes:
-  - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:identifier
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: identifier (if available) of related resource
-  rdfs:label: identifier
-  rdfs:sameAs:
-    '@id': schema:identifier
-  schema:domainIncludes:
-  - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-  schema:rangeIncludes:
-    '@id': schema:Text
+  - '@id': schema:CreativeWork
 - '@id': outbreak:curatedBy
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The source from which this Analysis was identified for inclusion into
-    Outbreak.info. Provides provenance for a resource which was curated by another
+  '@type': rdfs:Property
+  rdfs:comment: The source from which this Dataset was identified for inclusion into
+    Outbreak.info. Provides provenance for a resource which was curated by another.
   rdfs:label: curatedBy
-  rdfs:sameAs:
-    '@id': schema:citation
   schema:domainIncludes:
-    '@id': outbreak:ClinicalTrial
-  schema:rangeIncludes:
-  - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
   - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-- '@id': outbreak:name
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: name of the source from which this Analysis was identified for inclusion
-  rdfs:label: name
-  rdfs:sameAs:
-    '@id': schema:name
-  schema:domainIncludes:
-  - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
   - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:url
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The corresponding url for the item in the source from which this Analysis
-    was identified (if available)
-  rdfs:label: url
-  rdfs:sameAs:
-    '@id': schema:url
-  schema:domainIncludes:
-  - '@id': outbreak:ClinicalTrial
   - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
   - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:versionDate
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: The last date when items were pulled from the source
-  rdfs:label: versionDate
-  rdfs:sameAs:
-    '@id': schema:releaseDate
-  schema:domainIncludes:
   - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
   schema:rangeIncludes:
-    '@id': schema:Date
+  - '@id': outbreak:Person
+  - '@id': outbreak:Organization
+  - '@id': outbreak:CitationObject
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Publication
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Protocol
+  - '@id': outbreak:ClinicalTrial
+  - '@id': schema:SoftwareApplication
+  - '@id': schema:CreativeWork
 - '@id': outbreak:curationDate
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The date this resource was added to outbreak.info, or the date when
-    this resource was updated in outbreak.info
+  '@type': rdfs:Property
+  rdfs:comment: The date this resource was added into outbreak.info, or was updated
+    in outbreak.info.
   rdfs:label: curationDate
-  rdfs:sameAs:
-    '@id': schema:releaseDate
   schema:domainIncludes:
-    '@id': outbreak:ClinicalTrial
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Publication
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Protocol
+  - '@id': outbreak:ClinicalTrial
   schema:rangeIncludes:
-    '@id': schema:Date
-'@id': https://discovery.biothings.io/view/outbreak/
+  - '@id': schema:Date
+- '@id': outbreak:evaluations
+  '@type': rdf:Property
+  rdfs:comment: One or more reviews, ratings, or other evaluations of this resource
+  rdfs:label: evaluations
+  schema:domainIncludes:
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Publication
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Protocol
+  - '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': schema:Review
+  - '@id': schema:Rating
+  - '@id': schema:AggregateRating

--- a/yaml/outbreak_Dataset.json
+++ b/yaml/outbreak_Dataset.json
@@ -1,111 +1,643 @@
 {
   "@context": {
-    "outbreak": "https://discovery.biothings.io/view/outbreak/",
-    "owl": "http://www.w3.org/2002/07/owl/",
-    "rdf": "http://www.w3.org/1999/02/22/-rdf-syntax-ns/",
-    "rdfs": "http://www.w3.org/2000/01/rdf/-schema/",
-    "schema": "http://schema.org/"
+    "schema": "http://schema.org/",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "outbreak": "http://discovery.biothings.io/view/"
   },
-  "@id": "https://discovery.biothings.io/view/outbreak/",
   "@graph": [
-    {
-      "@id": "outbreak:Organization",
-      "@type": "rdfs:Class",
-      "rdfs:label": "Organization",
-      "rdfs:comment": "This is the schema for describing the Organization schema used for outbreak.info.",
-      "rdfs:subClassOf": {
-        "@id": "schema:Organization"
-      },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
-      }
-    },
-    {"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"The name of the organization, team or group","rdfs:label":"name","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":{"@id":"outbreak:Organization"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:alternateName","@type":"rdf:Property","rdfs:comment":"Alternative names or commonly used abbreviations for the organization, team or group","rdfs:label":"alternateName","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:alternateName"},"schema:domainIncludes":{"@id":"outbreak:Organization"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:affiliation","@type":"rdf:Property","rdfs:comment":"An overarching consortia, multi-institutional team or group in which the organization\/team\/group is a member or affiliate","rdfs:label":"affiliation","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:affiliation"},"schema:domainIncludes":{"@id":"outbreak:Organization"},"schema:rangeIncludes":{"@id":"outbreak:Organization"}},{"@id":"outbreak:affiliationStatus","@type":"rdf:Property","rdfs:comment":"The status of the organization's membership or affiliation in the overarching consortial, multi-institutional team or group (current, past)","rdfs:label":"affiliationStatus","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":{"@id":"outbreak:Organization"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:members","@type":"rdf:Property","rdfs:comment":"Members of this organization, team, or group","rdfs:label":"members","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:members"},"schema:domainIncludes":{"@id":"outbreak:Organization"},"schema:rangeIncludes":[{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"}]},{"@id":"outbreak:membershipStatus","@type":"rdf:Property","rdfs:comment":"Status of the members of this organization","rdfs:label":"membershipStatus","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":{"@id":"outbreak:Organization"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:isRelatedTo","@type":"rdf:Property","rdfs:comment":"A resource which a person played a role","rdfs:label":"isRelatedTo","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:isRelatedTo"},"schema:domainIncludes":{"@id":"outbreak:Organization"},"schema:rangeIncludes":[{"@id":"schema:CreativeWork"},{"@id":"schema:HowTo"}]},{"@id":"outbreak:class","@type":"rdf:Property","rdfs:comment":"A classification of the organization by a resource. Eg- for ClinicalTrials funders, it's [\"U.S. National Institutes of Health\", \"Other U.S. Federal agencies\", \"Industry\", \"All others\"]","rdfs:label":"class","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:addtionalType"},"schema:domainIncludes":[{"@id":"schema:CreativeWork"},{"@id":"schema:HowTo"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:role","@type":"rdf:Property","rdfs:comment":"The role of an organization in its involvement with a resource","rdfs:label":"role","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":[{"@id":"schema:CreativeWork"},{"@id":"schema:HowTo"}],"schema:rangeIncludes":{"@id":"schema:Text"}},
     {
       "@id": "outbreak:Person",
       "@type": "rdfs:Class",
+      "rdfs:comment": "This is the Person schema for describing authors and people for outbreak.info resources",
       "rdfs:label": "Person",
-      "rdfs:comment": "This is the schema for describing the Person schema used for outbreak.info.",
       "rdfs:subClassOf": {
         "@id": "schema:Person"
-      },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
-      }
-    },
-    {"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"The name of the person","rdfs:label":"name","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":{"@id":"outbreak:Person"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:alternateName","@type":"rdf:Property","rdfs:comment":"Alternative ways in which the person's name is included in a record","rdfs:label":"alternateName","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:alternateName"},"schema:domainIncludes":{"@id":"outbreak:Person"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:givenName","@type":"rdf:Property","rdfs:comment":"The given name of the person","rdfs:label":"givenName","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:givenName"},"schema:domainIncludes":{"@id":"outbreak:Person"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:familyName","@type":"rdf:Property","rdfs:comment":"The family name of the person","rdfs:label":"familyName","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:familyName"},"schema:domainIncludes":{"@id":"outbreak:Person"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:affiliation","@type":"rdf:Property","rdfs:comment":"The organization with which the person is affiliated or has membership in","rdfs:label":"affiliation","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:affiliation"},"schema:domainIncludes":{"@id":"outbreak:Person"},"schema:rangeIncludes":{"@id":"outbreak:Organization"}},{"@id":"outbreak:affiliationStatus","@type":"rdf:Property","rdfs:comment":"The status of the person's membership or affiliation in an organization, team or group (current, past)","rdfs:label":"affiliationStatus","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:addtionalType"},"schema:domainIncludes":{"@id":"outbreak:Person"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:orcid","@type":"rdf:Property","rdfs:comment":"The ORCID ID of the person","rdfs:label":"orcid","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":{"@id":"outbreak:Person"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:isRelatedTo","@type":"rdf:Property","rdfs:comment":"A resource which a person played a role","rdfs:label":"isRelatedTo","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:isRelatedTo"},"schema:domainIncludes":{"@id":"outbreak:Person"},"schema:rangeIncludes":[{"@id":"schema:CreativeWork"},{"@id":"schema:HowTo"}]},{"@id":"outbreak:role","@type":"rdf:Property","rdfs:comment":"The role a person played in the creation of a resource","rdfs:label":"role","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:addtionalType"},"schema:domainIncludes":[{"@id":"schema:CreativeWork"},{"@id":"schema:HowTo"}],"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {
-      "@id": "outbreak:DataDownload",
-      "@type": "rdfs:Class",
-      "rdfs:label": "DataDownload",
-      "rdfs:comment": "This is the schema for describing the DataDownload schema used for outbreak.info.",
-      "rdfs:subClassOf": {
-        "@id": "schema:DataDownload"
-      },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
-      }
-    },
-    {"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"The name of the download if available","rdfs:label":"name","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":{"@id":"outbreak:DataDownload"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:contentUrl","@type":"rdf:Property","rdfs:comment":"Link to the location where the dataset can be found, ideally a permanent URL","rdfs:label":"contentUrl","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:distribution"},"schema:domainIncludes":{"@id":"outbreak:DataDownload"},"schema:rangeIncludes":{"@id":"schema:URL"}},{"@id":"outbreak:dateModified","@type":"rdf:Property","rdfs:comment":"Date which the particular DataDownload (file) has been changed","rdfs:label":"dateModified","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:dateModified"},"schema:domainIncludes":{"@id":"outbreak:DataDownload"},"schema:rangeIncludes":{"@id":"schema:Date"}},
-    {
-      "@id": "outbreak:MonetaryGrant",
-      "@type": "rdfs:Class",
-      "rdfs:label": "MonetaryGrant",
-      "rdfs:comment": "This is the schema for describing the MonetaryGrant schema used for outbreak.info.",
-      "rdfs:subClassOf": {
-        "@id": "schema:MonetaryGrant"
-      },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
-      }
-    },
-    {"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"The name of the monetary grant","rdfs:label":"name","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":{"@id":"outbreak:MonetaryGrant"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:identifier","@type":"rdf:Property","rdfs:comment":"The grant ID or an identifier associated with the grant","rdfs:label":"identifier","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":{"@id":"outbreak:MonetaryGrant"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:url","@type":"rdf:Property","rdfs:comment":"The url for the grant (if available)","rdfs:label":"url","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:url"},"schema:domainIncludes":{"@id":"outbreak:MonetaryGrant"},"schema:rangeIncludes":{"@id":"schema:URL"}},{"@id":"outbreak:funder","@type":"rdf:Property","rdfs:comment":"The funding organization of the grant","rdfs:label":"funder","owl:cardinality":"many","marginality":"required","rdfs:sameAs":{"@id":"schema:funder"},"schema:domainIncludes":{"@id":"outbreak:MonetaryGrant"},"schema:rangeIncludes":{"@id":"outbreak:Organization"}},{"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"The name of the funding organization","rdfs:label":"name","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":{"@id":"outbreak:Organization"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:recipient","@type":"rdf:Property","rdfs:comment":"The person or organization to whom or to which the grant was awarded","rdfs:label":"recipient","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:recipient"},"schema:domainIncludes":{"@id":"outbreak:MonetaryGrant"},"schema:rangeIncludes":[{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"}]},{"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"The name of the recipient of the grant","rdfs:label":"name","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":[{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:affiliation","@type":"rdf:Property","rdfs:comment":"The affiliation of the recipient of the grant","rdfs:label":"affiliation","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:affiliation"},"schema:domainIncludes":[{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"}],"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {
-      "@id": "outbreak:Analysis",
-      "@type": "rdfs:Class",
-      "rdfs:label": "Analysis",
-      "rdfs:comment": "This is the schema for describing the Analysis schema used for outbreak.info.",
-      "rdfs:subClassOf": {
-        "@id": "schema:CreativeWork"
-      },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
-      }
-    },
-    {
-      "@id": "outbreak:Dataset",
-      "@type": "rdfs:Class",
-      "rdfs:label": "Dataset",
-      "rdfs:comment": "This is the schema for describing the Dataset schema used for outbreak.info.",
-      "rdfs:subClassOf": {
-        "@id": "schema:Dataset"
-      },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
       },
       "$validation": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
         "properties": {
           "name": {
-            "description": "Descriptive name of the dataset",
+            "description": "The name of the person.",
+            "type": "string"
+          },
+          "alternateName": {
+            "description": "An alias for the person.",
+            "type": "string"
+          },
+          "familyName": {
+            "description": "Family name. In the U.S., the last name of an Person. This can be used along with givenName instead of the name property.",
+            "type": "string"
+          },
+          "givenName": {
+            "description": "Given name. In the U.S., the first name of a Person. This can be used along with familyName instead of the name property.",
+            "type": "string"
+          },
+          "affiliation": {
+            "description": "An organization that this person is affiliated with. For example, a school/university, a club, or a team.",
+            "oneOf": [
+              {
+                "$ref": "#/definitions/baseOrgObject"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/baseOrgObject"
+                }
+              }
+            ]
+          },
+          "orcid": {
+            "description": "the ORCID ID of the person",
+            "type": "string"
+          },
+          "role": {
+            "description": "authorship, sponsorship, or other contribution role played by the person or organization in the creation of this resource",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            ]
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "definitions":{
+            "baseOrgObject": {
+                "@type": "outbreak:Organization",
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "alternateName": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ]   
+            }
+        }
+      }
+    },
+    {
+      "@id": "outbreak:orcid",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "the ORCID ID of the person",
+      "rdfs:label": "orcid",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Person"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:Organization",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the organization schema for describing authors, funders and other organizations referenced by outbreak.info resources",
+      "rdfs:label": "Organization",
+      "rdfs:subClassOf": {
+        "@id": "schema:Organization"
+      },
+      "$validation": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "The name of the organization.",
+            "type": "string"
+          },
+          "alternateName": {
+            "description": "An alias or acronym for the organization.",
+            "type": "string"
+          },
+          "affiliation": {
+            "description": "consortia or other organizations with which this organization is affiliated",
+            "oneOf": [
+              {
+                "$ref": "#/definitions/baseOrgObject"
+              },
+              {
+                "type": "array",
+                "items": {
+                    "$ref": "#/definitions/baseOrgObject"
+                }
+              }
+            ]
+          },
+          "class": {
+            "description": "A classification of the organization by a resource. Eg- for ClinicalTrials funders, it's [U.S. National Institutes of Health, Other U.S. Federal agencies, Industry, All others]",
+            "type": "string"
+          },
+          "role": {
+            "description": "The role of an organization in its involvement with a resource",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+              }
+            ]
+          },
+          "members": {
+            "description": "Members of this organization, team, or group",
+            "oneOf": [
+              {
+                "$ref": "#/definitions/basePersonObject"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/basePersonObject"
+                }
+              }
+            ]
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "definitions": {
+            "baseOrgObject":{
+                "description": "Affiliated Organization",
+                "@type": "outbreak:Organization",
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "description": "name of the organization",
+                    "type": "string"
+                  },
+                  "alternateName": {
+                    "description": "Alternate name or Acronym for the organization.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ]              
+            },
+            "basePersonObject":{
+                "@type": "outbreak:Person",
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "alternateName": {
+                        "type": "string"
+                    },
+                    "givenName": {
+                        "type": "string"
+                    },
+                    "familyName": {
+                        "type": "string"
+                    },
+                    "orcid": {
+                        "type": "string"
+                    },
+                    "affiliation": {
+                        "description": "consortia or other organizations with which this person is affiliated",
+                        "oneOf": [
+                          {
+                            "$ref": "#/definitions/baseOrgObject"
+                          },
+                          {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/baseOrgObject"
+                            }
+                          }
+                        ]
+                      }
+                },
+                "required": [
+                    "name"
+                ]                
+            }
+        }
+      }
+    },
+    {
+      "@id": "outbreak:affiliation",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "consortia or other organizations with which this organization is affiliated",
+      "rdfs:label": "affiliation",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Organization"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "outbreak:Organization"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:members",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Members of this organization, team, or group",
+      "rdfs:label": "members",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Organization"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "outbreak:Person"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:class",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "A classification of the organization by a resource. Eg- for ClinicalTrials funders, it's [U.S. National Institutes of Health, Other U.S. Federal agencies, Industry, All others]",
+      "rdfs:label": "class",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Organization"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:role",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "authorship, sponsorship, or other contribution role played by the person or organization in the creation of this resource. In a Clinical Study/Trial ArmGroup, it's equivalent to the ArmType in ClinicalTrials.gov",
+      "rdfs:label": "role",
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Person"},
+        {"@id": "outbreak:Organization"},
+        {"@id": "outbreak:ArmGroup"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:MonetaryGrant",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing the MonetaryGrant schema used for outbreak.info",
+      "rdfs:label": "MonetaryGrant",
+      "rdfs:subClassOf": {
+        "@id": "schema:MonetaryGrant"
+      },
+      "$validation": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "The name of the grant or funding.",
+            "type": "string"
+          },
+          "identifier": {
+            "description": "The funding or grant id",
+            "type": "string"
+          },
+          "url": {
+            "description": "URL of the grant or funding award.",
+            "type": "string",
+            "format": "uri"
+          },
+          "funder": {
+            "description": "The organization(s) that supported (sponsored) the grant through some kind of financial contribution.",
+            "oneOf": [
+              {
+                "$ref": "#/definitions/baseOrgObject"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/baseOrgObject"
+                }
+              }
+            ]
+          },
+          "recipient": {
+            "description": "The person or organization to whom or to which the grant was awarded",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/basePersonObject"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/basePersonObject"
+                }
+              },
+              {
+                "$ref": "#/definitions/baseOrgObject"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/baseOrgObject"
+                }
+              }
+            ]
+          }   
+        },
+        "required": [
+          "funder"
+        ],
+        "definitions": {
+            "baseOrgObject":{
+                "description": "Affiliated Organization",
+                "@type": "outbreak:Organization",
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "description": "name of the organization",
+                    "type": "string"
+                  },
+                  "alternateName": {
+                    "description": "Alternate name or Acronym for the organization.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ]              
+            },
+            "basePersonObject":{
+                "@type": "outbreak:Person",
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "alternateName": {
+                        "type": "string"
+                    },
+                    "givenName": {
+                        "type": "string"
+                    },
+                    "familyName": {
+                        "type": "string"
+                    },
+                    "orcid": {
+                        "type": "string"
+                    },
+                    "affiliation": {
+                        "description": "consortia or other organizations with which this person is affiliated",
+                        "oneOf": [
+                          {
+                            "$ref": "#/definitions/baseOrgObject"
+                          },
+                          {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/baseOrgObject"
+                            }
+                          }
+                        ]
+                      }
+                },
+                "required": [
+                    "name"
+                ]                
+            }
+        }
+      }
+    },
+    {
+      "@id": "outbreak:recipient",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The person or organization to whom or to which the grant was awarded",
+      "rdfs:label": "recipient",
+      "schema:domainIncludes": {
+        "@id": "outbreak:MonetaryGrant"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Person"
+        },
+        {
+          "@id": "schema:Organization"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:DataDownload",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing the DataDownload schema used for outbreak.info.",
+      "rdfs:label": "DataDownload",
+      "rdfs:subClassOf": {
+        "@id": "schema:DataDownload"
+      },
+      "$validation": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "The name of the distribution.",
+            "type": "string"
+          },
+          "contentUrl": {
+            "description": "Actual url of the data file.",
+            "type": "string",
+            "format": "uri"
+          },
+          "dateModified": {
+            "description": "The date on which the distribution was most recently modified or when the item's entry was modified within a DataFeed.",
+            "format": "date",
+            "type": "string"
+          }
+        },
+        "required": [
+          "contentUrl",
+          "dateModified"
+        ]
+      }
+    },
+    {
+      "@id": "outbreak:CitationObject",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "A citation object for a resource which is cited by the subject (ie- is a derivative of the subject), related to the subject, or from which the subject was based on (ie- is derived from).",
+      "rdfs:label": "CitationObject",
+      "rdfs:subClassOf": {
+        "@id": "schema:CreativeWork"
+      },
+      "$validation": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "The name or title of the cited resource.",
+            "type": "string"
+          },
+          "url": {
+            "description": "URL of the cited resource.",
+            "type": "string",
+            "format": "uri"
+          },
+          "identifier": {
+            "description": "An identifier associated with the citation",
+            "type": "string"
+          },
+          "citeText": {
+            "description": "The bibliographic citation for the referenced resource as is provided",
+            "type": "string"
+          },
+          "versionDate": {
+            "description": "The version date of the resource used at the time of the creation of the citation as certain resources (protocols, datasets) may change frequently over time.",
+            "format": "date",
+            "type": "string"
+          },
+          "pmid": {
+            "description": "A pubmed identifier if available",
+            "type": "string"
+          },
+          "doi": {
+            "description": "A doi if available",
+            "type": "string"
+          },
+          "sourceType": {
+            "description": "The @type of resource",
+            "enum": [
+              "Dataset",
+              "Publication",
+              "ClinicalTrial",
+              "Analysis",
+              "Protocol",
+              "SoftwareApplication",
+              "CreativeWork"
+            ]
+          }
+        },
+        "required": [
+          "name",
+          "sourceType"
+        ]
+      }
+    },
+    {
+      "@id": "outbreak:citeText",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The bibliographic citation for the referenced resource as is provided",
+      "rdfs:label": "citeText",
+      "schema:domainIncludes": {
+        "@id": "outbreak:CitationObject"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:versionDate",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The version date of the resource used at the time of the creation of the citation as certain resources (protocols, datasets) may change frequently over time.",
+      "rdfs:label": "versionDate",
+      "schema:domainIncludes": {
+        "@id": "outbreak:CitationObject"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Date"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:sourceType",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The type of resource",
+      "rdfs:label": "sourceType",
+      "schema:domainIncludes": {
+        "@id": "outbreak:CitationObject"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:Dataset",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing the Dataset schema used for outbreak.info.",
+      "rdfs:label": "Dataset",
+      "rdfs:subClassOf": {
+        "@id": "schema:Dataset"
+      },
+      "$validation": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "Descriptive name of the dataset.",
             "type": "string"
           },
           "description": {
-            "description": "Longer description of what is contained in the dataset",
+            "description": "Longer description of what is contained in the dataset.",
             "type": "string"
           },
-          "datePublished": {
-              "description": "PublicationDate of the analysis online if available",
-              "format": "date",
-              "type": "string"
-            },
-          "dateModified": {
-              "description": "Most recent date for which the analysis model itself was updated",
-              "format": "date",
-              "type": "string"
+          "doi": {
+            "description": "The DOI for the dataset if available",
+            "type": "string"
           },
+          "identifier": {
+            "description": "An identifier for the dataset, preferably a doi",
+            "type": "string"
+          },
+          "species": {
+            "description": "Species(es) from which dataset has been collected",
+            "oneOf": [{
+                "$ref": "#/definitions/speciesControlledVocabulary"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/speciesControlledVocabulary"
+                }
+              }
+            ]
+          },
+          "infectiousAgent": {
+            "description": "infectious agents(s) which are the focus of the dataset",
+            "oneOf": [{
+                "$ref": "#/definitions/miscControlledVocabulary"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/miscControlledVocabulary"
+                }
+              }
+            ]
+          },
+          "infectiousDisease": {
+              "description": "The disease or medical conditions caused by the infectious agent. Important as some agents may cause multiple diseases",
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/diseaseVocabulary"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/diseaseVocabulary"
+                  }
+                }
+              ]
+            },
           "measurementTechnique": {
             "description": "A technique or technology used in a Dataset, corresponding to the method used for measuring the corresponding variable(s).",
             "oneOf": [{
@@ -131,14 +663,6 @@
                 }
               }
             ]
-          },
-          "identifier": {
-            "description": "identifier for the dataset",
-            "type": "string"
-          },
-          "doi": {
-            "description": "The DOI for the dataset if available",
-            "type": "string"
           },
           "author": {
             "description": "Name of the author or organization that created the dataset.  Note: schema.org/author and schema.org/organization have additional fields that can provide more information about the author/organization, if desired.",
@@ -189,55 +713,60 @@
               }
             ]
           },
-          "license": {
-            "description": "A license document that applies to this content, typically indicated by URL.",
-            "type": "string",
-            "format": "uri"
+          "dateModified": {
+            "description": "The date on which the CreativeWork was most recently modified or when the item's entry was modified within a DataFeed.",
+            "format": "date",
+            "type": "string"
           },
-          "species": {
-            "description": "Species(es) from which dataset has been collected",
-            "oneOf": [{
-                "$ref": "#/definitions/speciesControlledVocabulary"
-              },
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/definitions/speciesControlledVocabulary"
-                }
-              }
-            ]
+          "datePublished": {
+            "description": "Date of first broadcast/publication.",
+            "format": "date",
+            "type": "string"
           },
-          "infectiousAgent": {
-            "description": "infectious agents(s) which are the focus of the dataset",
-            "oneOf": [{
-                "$ref": "#/definitions/miscControlledVocabulary"
-              },
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/definitions/miscControlledVocabulary"
-                }
-              }
-            ]
-          },
-          "infectiousDisease": {
-              "description": "The disease or medical conditions caused by the infectious agent. Important as some agents may cause multiple diseases",
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/diseaseVocabulary"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/diseaseVocabulary"
-                  }
-                }
-              ]
-            },
           "topicCategory": {
-              "description": "Applicable outbreak.info category",
-              "oneOf": [
-                {
+            "description": "Applicable outbreak.info category",
+            "oneOf": [
+              {
+                "enum": [
+                  "Clinical",
+                  "Case Descriptions",
+                  "Risk Factors",
+                  "Diagnosis",
+                  "Symptoms",
+                  "Rapid Diagnostics",
+                  "Antibody Detection",
+                  "Virus Detection",
+                  "Testing Prevalence",
+                  "Pathology/Radiology",
+                  "Forecasting",
+                  "Mechanism",
+                  "Virus Factors",
+                  "Host Factors",
+                  "Immunological Response",
+                  "Mechanism of Infection",
+                  "Mechanism of Transmission",
+                  "Prevention",
+                  "Public Health Interventions",
+                  "Individual Prevention",
+                  "Transmission",
+                  "Host/Intermediate Reservoirs",
+                  "Viral Shedding / Persistence",
+                  "Treatment",
+                  "Vaccines",
+                  "Pharmaceutical Treatments",
+                  "Medical Care",
+                  "Repurposing",
+                  "Biologics",
+                  "Behavioral Research",
+                  "Epidemiology",
+                  "Classical Epidemiology",
+                  "Molecular Epidemiology",
+                  "Information Sciences"
+                ]
+              },
+              {
+                "type": "array",
+                "items": {
                   "enum": [
                     "Clinical",
                     "Case Descriptions",
@@ -271,60 +800,25 @@
                     "Behavioral Research",
                     "Epidemiology",
                     "Classical Epidemiology",
-                    "Molecular Epidemiology"
+                    "Molecular Epidemiology",
+                    "Information Sciences"
                   ]
-                },
-                {
-                  "type": "array",
-                  "items": {
-                      "enum": [
-                        "Clinical",
-                        "Case Descriptions",
-                        "Risk Factors",
-                        "Diagnosis",
-                        "Symptoms",
-                        "Rapid Diagnostics",
-                        "Antibody Detection",
-                        "Virus Detection",
-                        "Testing Prevalence",
-                        "Pathology/Radiology",
-                        "Forecasting",
-                        "Mechanism",
-                        "Virus Factors",
-                        "Host Factors",
-                        "Immunological Response",
-                        "Mechanism of Infection",
-                        "Mechanism of Transmission",
-                        "Prevention",
-                        "Public Health Interventions",
-                        "Individual Prevention",
-                        "Transmission",
-                        "Host/Intermediate Reservoirs",
-                        "Viral Shedding / Persistence",
-                        "Treatment",
-                        "Vaccines",
-                        "Pharmaceutical Treatments",
-                        "Medical Care",
-                        "Repurposing",
-                        "Biologics",
-                        "Behavioral Research",
-                        "Epidemiology",
-                        "Classical Epidemiology",
-                        "Molecular Epidemiology"
-                      ]
-                  }
                 }
-              ]
-            },
+              }
+            ]
+          },
           "keywords": {
-            "description": "A list of keywords associated with this dataset",
+            "description": "Keywords or tags used to describe this content. Multiple entries in a keywords list are typically delimited by commas.",
             "oneOf": [
-                {"type":"string"},
-                {"type":"array",
-                 "items":{
-                     "type":"string"
-                 }
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
                 }
+              }
             ]
           },
           "isBasedOn": {
@@ -401,18 +895,45 @@
             "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
             "type": "string",
             "format": "date"
-          }
+          },
+          "license": {
+            "description": "A license document that applies to this content, typically indicated by URL.",
+            "type": "string"
+          },
+          "evaluations":{
+              "description": "Reviews, Ratings, or other types of evaluations on this resource",
+              "anyOf":[
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/reviewObject"
+                }
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/ratingObject"
+                }
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/aggregateRatingObject"
+                }
+              }
+            ]
+            }
         },
         "required": [
-          "name",
-          "description",
           "author",
-          "identifier"
+          "description",
+          "identifier",
+          "name"
         ],
         "definitions": {
           "controlledVocabulary": {
             "description": "collection of vocabulary terms defined in ontologies",
-            "@type": "CreativeWork",
+            "@type": "DefinedTerm",
             "type": "string",
             "vocabulary": {
               "ontology": ["efo", "ncit","obi"],
@@ -423,7 +944,7 @@
           },
           "miscControlledVocabulary": {
             "description": "collection of vocabulary terms defined in ontologies",
-            "@type": "CreativeWork",
+            "@type": "DefinedTerm",
             "type": "string",
             "vocabulary": {
               "ontology": ["ncbitaxon"],
@@ -433,7 +954,7 @@
           },
           "speciesControlledVocabulary": {
             "description": "collection of vocabulary terms defined in ontologies",
-            "@type": "CreativeWork",
+            "@type": "DefinedTerm",
             "type": "string",
             "vocabulary": {
               "ontology": ["ncbitaxon"],
@@ -443,7 +964,7 @@
           },
           "diseaseVocabulary": {
             "description": "collection of vocabulary terms defined in ontologies",
-            "@type": "CreativeWork",
+            "@type": "DefinedTerm",
             "type": "string",
             "vocabulary": {
               "ontology": ["mondo"],
@@ -453,7 +974,7 @@
           },
           "moreControlledVocabulary": {
               "definition": "collection of vocabulary terms defined in ontologies",
-              "@type": "CreativeWork",
+              "@type": "DefinedTerm",
               "type": "string",
               "strict": false,
               "vocabulary": {
@@ -473,7 +994,7 @@
           },
           "datadownload": {
             "description": "A dataset in downloadable form.",
-            "@type": "DataDownload",
+            "@type": "outbreak:DataDownload",
             "type": "object",
             "properties": {
               "name": {
@@ -493,9 +1014,9 @@
               "contentUrl"
             ]
           },
-          "baseOrgObject":{
+          "baseOrgObject": {
             "description": "A barebones Organization object to work around recursion issues in DDE",
-            "@type": "Organization",
+            "@type": "outbreak:Organization",
             "type": "object",
             "properties": {
               "name": {
@@ -513,7 +1034,7 @@
           }, 
           "person": {
               "description": "Reusable person definition",
-              "@type": "Person",
+              "@type": "outbreak:Person",
               "type": "object",
               "properties": {
                 "name": {
@@ -548,7 +1069,7 @@
             },
           "memberObject": {
               "description": "Reusable person definition accounting for recursion issues in DDE",
-              "@type": "Person",
+              "@type": "outbreak:Person",
               "type": "object",
               "properties": {
                 "name": {
@@ -583,7 +1104,7 @@
             },
           "organization": {
             "description": "Reusable organization definition",
-            "@type": "Organization",
+            "@type": "outbreak:Organization",
             "type": "object",
             "properties": {
               "name": {
@@ -615,7 +1136,7 @@
           },
           "funding": {
             "type": "object",
-            "@type": "MonetaryGrant",
+            "@type": "outbreak:MonetaryGrant",
             "description": "Information about funding support",
             "properties": {
               "name": {
@@ -652,7 +1173,7 @@
           },
           "citation": {
             "description": "A citation object for a resource which is cited by the dataset (ie- is a derivative of the dataset) , related to the dataset, or from which the dataset was based on (ie- is derived from).",
-            "@type": "Thing",
+            "@type": "outbreak:CitationObject",
             "type": "object",
             "properties": {
               "name": {
@@ -671,7 +1192,7 @@
                 "description": "A doi if available",
                 "type": "string"
               },
-              "type": {
+              "sourceType": {
                 "description": "The type of resource",
                 "enum": [
                   "Dataset",
@@ -680,7 +1201,7 @@
                   "Analysis",
                   "Protocol", 
                   "SoftwareApplication",
-                  "Other"
+                  "CreativeWork"
                   ]
               },
               "url": {
@@ -700,62 +1221,1603 @@
             },
             "required": [
               "name",
-              "type"
+              "sourceType"
+            ]
+          },
+          "reviewObject": {
+            "description": "A review or descriptive evaluation of the resource",
+            "@type": "Review",
+            "type": "object",
+            "properties": {
+              "name": {
+                    "type": "string",
+                    "description": "The name of the review"
+                  },
+              "reviewAspect":{
+                    "description": "This Review or Rating is relevant to this part or facet of the itemReviewed",
+                    "type": "string"
+                  },
+              "reviewBody": {
+                      "description": "The actual body of the review.",
+                      "type": "string"
+                  },
+              "reviewRating": {
+                "description": "The rating given in this review",
+                    "$ref": "#/definitions/ratingObject"      
+                },
+              "author": {
+                    "description": "The author of this content or rating.",
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/person"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/person"
+                      }
+                      },
+                      {
+                        "$ref": "#/definitions/organization"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/organization"
+                      }
+                }
+              ]
+            },
+              "curationDate":{
+                    "description": "The date this evaluation was added into outbreak.info, or was updated in outbreak.info.",
+                    "type": "string",
+                    "format": "date"
+                  }
+                },
+              "required": [
+              ]
+            },
+          "ratingObject": {
+                "description": "A rating or categorical evaluation of the resource",
+                "@type": "Rating",
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "The name of the rating"
+                  },
+                  "ratingExplanation": {
+                    "type": "string",
+                    "description": "An explanation of the rating"    
+                  },
+                  "ratingValue": {
+                    "type": "string",
+                    "description": "The rating for the content."
+                  },
+                  "reviewAspect": {
+                    "type": "string",
+                    "description": "This Review or Rating is relevant to this part or facet of the itemReviewed"
+                  },
+                  "author": {
+                    "description": "The author of this content or rating.",
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/person"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/person"
+                      }
+                      },
+                      {
+                        "$ref": "#/definitions/organization"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/organization"
+                      }
+                }
+              ]
+            },
+                  "curationDate":{
+                    "description": "The date this evaluation was added into outbreak.info, or was updated in outbreak.info.",
+                    "type": "string",
+                    "format": "date"
+                  }
+                },
+                "required": [
+                ]
+            },
+          "aggregateRatingObject": {
+              "description": "A cumulative evaluation of the resource",
+              "@type": "AggregateRating",
+              "type": "object",
+              "properties": {
+                "name": {
+                "type": "string",
+                "description": "The name of the aggregate rating"
+                },
+                "ratingValue": {
+                    "type": "string",
+                    "description": "The rating for the content."
+                },
+                "reviewAspect":{
+                  "description": "This Review or Rating is relevant to this part or facet of the itemReviewed",
+                  "type": "string"
+                },
+                "author": {
+                    "description": "The author of this content or rating.",
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/person"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/person"
+                      }
+                      },
+                      {
+                        "$ref": "#/definitions/organization"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/organization"
+                      }
+                }
+              ]
+            },
+                "curationDate": {
+                    "description": "The date this evaluation was added into outbreak.info, or was updated in outbreak.info.",
+                    "type": "string",
+                    "format": "date"
+                  },
+                "reviews": {
+                  "anyOf": [
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/reviewObject"
+                        }
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/ratingObject"
+                        }
+                      }
+                      
+                  ]
+                }
+                },
+            "required": [
             ]
           }
         }
       }
     },
-    {"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"Short, descriptive title for the dataset","rdfs:label":"name","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":{"@id":"outbreak:Dataset"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:description","@type":"rdf:Property","rdfs:comment":"Longer description of what was contained in the dataset. For example, dataset fields, ...","rdfs:label":"description","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:description"},"schema:domainIncludes":{"@id":"outbreak:Dataset"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:datePublished","@type":"rdf:Property","rdfs:comment":"PublicationDate of the dataset online if available","rdfs:label":"datePublished","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:datePublished"},"schema:domainIncludes":{"@id":"outbreak:Analysis"},"schema:rangeIncludes":{"@id":"schema:Date"}},{"@id":"outbreak:dateModified","@type":"rdf:Property","rdfs:comment":"Most recent date for which the dataset was updated","rdfs:label":"dateModified","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:dateModified"},"schema:domainIncludes":{"@id":"outbreak:Analysis"},"schema:rangeIncludes":{"@id":"schema:Date"}},
-    {"@id":"outbreak:measurementTechnique","@type":"rdf:Property","rdfs:comment":"Measurement technique(s) used in collecting the dataset, e.g. RNA sequencing","rdfs:label":"measurementTechnique","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:measurementTechnique"},"schema:domainIncludes":{"@id":"outbreak:Dataset"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:variableMeasured","@type":"rdf:Property","rdfs:comment":"The factors or variables measured in the dataset","rdfs:label":"variableMeasured","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:variableMeasured"},"schema:domainIncludes":{"@id":"outbreak:Dataset"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:author","@type":"rdf:Property","rdfs:comment":"person, people, or organization that created the dataset","rdfs:label":"author","owl:cardinality":"many","marginality":"required","rdfs:sameAs":{"@id":"schema:author"},"schema:domainIncludes":{"@id":"outbreak:Dataset"},"schema:rangeIncludes":[{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"}]},{"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"The name of the author as provided by the resource","rdfs:label":"name","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":[{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:affiliation","@type":"rdf:Property","rdfs:comment":"The author's affiliation(s)","rdfs:label":"affiliation","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:affiliation"},"schema:domainIncludes":[{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"}],"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:distribution","@type":"rdf:Property","rdfs:comment":"Available downloads of the dataset","rdfs:label":"distribution","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:DataDownload"},"schema:domainIncludes":{"@id":"outbreak:Dataset"},"schema:rangeIncludes":{"@id":"outbreak:DataDownload"}},
-    {"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"The name of the download if available","rdfs:label":"name","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":{"@id":"outbreak:DataDownload"},"schema:rangeIncludes":{"@id":"schema:Text"}},  
-    {"@id":"outbreak:contentUrl","@type":"rdf:Property","rdfs:comment":"Link to the location where the dataset can be found, ideally a permanent URL","rdfs:label":"contentUrl","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:contentUrl"},"schema:domainIncludes":{"@id":"outbreak:DataDownload"},"schema:rangeIncludes":{"@id":"schema:URL"}},{"@id":"outbreak:dateModified","@type":"rdf:Property","rdfs:comment":"Date which the particular DataDownload (file) has been changed","rdfs:label":"dateModified","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:dateModified"},"schema:domainIncludes":{"@id":"outbreak:DataDownload"},"schema:rangeIncludes":{"@id":"schema:Date"}},
-    {"@id":"outbreak:funding","@type":"rdf:Property","rdfs:comment":"Funding for the generation of the dataset","rdfs:label":"funding","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"outbreak:MonetaryGrant"},"schema:domainIncludes":{"@id":"outbreak:Dataset"},"schema:rangeIncludes":{"@id":"outbreak:MonetaryGrant"}},{"@id":"outbreak:funder","@type":"rdf:Property","rdfs:comment":"Name of the funding organization ofr the dataset. Note: schema.org\/funder and schema.org\/Grant have additional fields that can provide more information about the funding organization, if desired","rdfs:label":"funder","owl:cardinality":"many","marginality":"required","rdfs:sameAs":{"@id":"schema:funder"},"schema:domainIncludes":{"@id":"outbreak:MonetaryGrant"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:identifier","@type":"rdf:Property","rdfs:comment":"The identifier of the grant (if available)","rdfs:label":"identifier","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":{"@id":"outbreak:MonetaryGrant"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:species","@type":"rdf:Property","rdfs:comment":"Species(es) from which dataset has been collected","rdfs:label":"species","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":{"@id":"outbreak:Dataset"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:infectiousAgent","@type":"rdf:Property","rdfs:comment":"The actual infectious agent, such as a specific bacterium","rdfs:label":"infectiousAgent","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:infectiousAgent"},"schema:domainIncludes":{"@id":"outbreak:Dataset"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:infectiousDisease","@type":"rdf:Property","rdfs:comment":"The infectious disease or medical condition caused by the infectious agent, such as a Covid-19","rdfs:label":"infectiousDisease","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:code"},"schema:domainIncludes":{"@id":"outbreak:Dataset"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:identifier","@type":"rdf:Property","rdfs:comment":"Unique identifier for the dataset","rdfs:label":"identifier","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":{"@id":"outbreak:Dataset"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:doi","@type":"rdf:Property","rdfs:comment":"DOI for the dataset if available","rdfs:label":"doi","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":{"@id":"outbreak:Dataset"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:license","@type":"rdf:Property","rdfs:comment":"License associated with re-use of the dataset","rdfs:label":"license","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:license"},"schema:domainIncludes":{"@id":"outbreak:Dataset"},"schema:rangeIncludes":{"@id":"schema:URL"}},
-    {"@id":"outbreak:citedBy","@type":"rdf:Property","rdfs:comment":"Associated resource (protocols, publications, etc.) that utilized or was derived from this dataset.","rdfs:label":"citedBy","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"owl:inverseOf: schema:isBasedOn"},"schema:domainIncludes":{"@id":"outbreak:Dataset"},"schema:rangeIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}]},{"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"name of the resource (publication, protocol, etc.) utilize or was derived from this dataset","rdfs:label":"name","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:type","@type":"rdf:Property","rdfs:comment":"type of resource which utilized or was derived from this dataset","rdfs:label":"type","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:additionalType"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:identifier","@type":"rdf:Property","rdfs:comment":"identifier for this resource which utilized or was derived from this dataset","rdfs:label":"identifier","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:isBasedOn","@type":"rdf:Property","rdfs:comment":"Associated resource (guidelines, protocols, publications, etc.) from which this dataset was derived","rdfs:label":"isBasedOn","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:isBasedOn"},"schema:domainIncludes":{"@id":"outbreak:Dataset"},"schema:rangeIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}]},{"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"name of the associated resource from which this dataset was derived","rdfs:label":"name","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:type","@type":"rdf:Property","rdfs:comment":"Type of resource (publication, analysis, ClinicalTrial, dataset, etc.) from which this dataset was derived","rdfs:label":"type","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:additionalType"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:identifier","@type":"rdf:Property","rdfs:comment":"Identifier for the resource","rdfs:label":"identifier","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:versionDate","@type":"rdf:Property","rdfs:comment":"date of the version of the resource from which this dataset was derived. Note this is NOT the same as dateModified, as the dataset may be based on an earlier 'dateModified' than is what is available from the resource","rdfs:label":"versionDate","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:releaseDate"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Date"}},{"@id":"outbreak:isRelatedTo","@type":"rdf:Property","rdfs:comment":"Other resources related to, but not a derivative of nor derived from this dataset","rdfs:label":"isRelatedTo","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:isRelatedTo"},"schema:domainIncludes":{"@id":"outbreak:Dataset"},"schema:rangeIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}]},{"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"name of related resource","rdfs:label":"name","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:type","@type":"rdf:Property","rdfs:comment":"type of related resource","rdfs:label":"type","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:additionalType"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:identifier","@type":"rdf:Property","rdfs:comment":"identifier (if available) of related resource","rdfs:label":"identifier","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:topicCategory","@type":"rdf:Property","rdfs:comment":"Applicable outbreak.info category","rdfs:label":"topicCategory","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:about"},"schema:domainIncludes":{"@id":"outbreak:Dataset"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:keywords","@type":"rdf:Property","rdfs:comment":"keywords","rdfs:label":"keywords","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:keywords"},"schema:domainIncludes":{"@id":"outbreak:Dataset"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:curatedBy","@type":"rdf:Property","rdfs:comment":"The source from which this dataset was identified for inclusion into Outbreak.info. Provides provenance for a resource which was curated by another","rdfs:label":"curatedBy","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:citation"},"schema:domainIncludes":{"@id":"outbreak:Dataset"},"schema:rangeIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"},{"@id":"schema:Thing"}]},
-    {"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"name of the source from which this dataset was identified for inclusion","rdfs:label":"name","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:curationDate","@type":"rdf:Property","rdfs:comment":"The date this resource was added to outbreak.info, or the date when this resource was updated in outbreak.info","rdfs:label":"curationDate","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:releaseDate"},"schema:domainIncludes":{"@id":"outbreak:Dataset"},"schema:rangeIncludes":{"@id":"schema:Date"}},
     {
-      "@id": "outbreak:Protocol",
+      "@id": "outbreak:Correction",
       "@type": "rdfs:Class",
-      "rdfs:label": "Protocol",
-      "rdfs:comment": "This is the schema for describing the Protocol schema used for outbreak.info.",
+      "rdfs:comment": "This is the schema for describing a Correction used for outbreak.info. A Correction is a specialized subclass of the CitationObject",
+      "rdfs:label": "Correction",
       "rdfs:subClassOf": {
-        "@id": "schema:HowTo"
-      },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
+        "@id": "schema:CreativeWork"
       }
+    },
+    {
+      "@id": "outbreak:correctionType",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Type of notice or correction: (correction, retraction, expression of convern, withdrawal, erratum, update, correction/republication, preprint, peer reviewed version)",
+      "rdfs:label": "correctionType",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Correction"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
     },
     {
       "@id": "outbreak:Publication",
       "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing the Publication used for outbreak.info",
       "rdfs:label": "Publication",
-      "rdfs:comment": "This is the schema for describing the Publication schema used for outbreak.info.",
       "rdfs:subClassOf": {
-        "@id": "schema:ScholarlyArticle"
-      },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
+        "@id": "schema:MedicalScholarlyArticle"
       }
     },
     {
+      "@id": "outbreak:journalName",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The name of the journal (or publisher if journal name not available)",
+      "rdfs:label": "journalName",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Publication"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:journalNameAbbrevation",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "abbreviated Journal Title (note, this should be autopopulated)",
+      "rdfs:label": "journalNameAbbrevation",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Publication"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:volumeNumber",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Volume number of journal in which the article was published",
+      "rdfs:label": "volumeNumber",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Publication"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:issueNumber",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Issue of journal in which the article was published",
+      "rdfs:label": "issueNumber",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Publication"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:Analysis",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing an Analysis for inclusion in outbreak.info resources",
+      "rdfs:label": "Analysis",
+      "rdfs:subClassOf": {
+        "@id": "schema:CreativeWork"
+      }
+        },
+    {
+      "@id": "outbreak:domainUrl",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The domain name or main site on which webpage or specific url can be found",
+      "rdfs:label": "domainUrl",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Analysis"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:URL"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:assumption",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Statement of assumptions / limitations of the model",
+      "rdfs:label": "assumption",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Analysis"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:analysisTechnique",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "A technique or technology used in a analysis",
+      "rdfs:label": "analysisTechnique",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Analysis"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:analysisTopic",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The underlying question, goal, or aim of the analysis",
+      "rdfs:label": "analysisTopic",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Analysis"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:Product",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing a reagent, material, sample, or some other product used in a protocol resource in outbreak.info",
+      "rdfs:label": "Product",
+      "rdfs:subClassOf": {
+        "@id": "schema:Product"
+      }
+    },
+    {
+      "@id": "outbreak:Instrument",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing an instrument used in a protocol resource listed in outbreak.info",
+      "rdfs:label": "Instrument",
+      "rdfs:subClassOf": {
+        "@id": "schema:Product"
+      }
+    },
+    {
+      "@id": "outbreak:Protocol",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing the Protocols for outbreak.info Resources.",
+      "rdfs:label": "Protocol",
+      "rdfs:subClassOf": {
+        "@id": "schema:HowTo"
+      }
+    },
+    {
+      "@id": "outbreak:warning",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Precautions, warnings, and/or safety warnings associated with or highlighted by the protocol",
+      "rdfs:label": "warning",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Protocol"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:correctionNote",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "statement of what was updated/changed since prior version",
+      "rdfs:label": "correctionNote",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Protocol"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:protocolStatus",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The status of the protocol",
+      "rdfs:label": "protocolStatus",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Protocol"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:instrument",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "A laboratory equipment use by a person to follow one or more steps described in this Protocol",
+      "rdfs:label": "instrument",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Protocol"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "outbreak:Instrument"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:protocolSetting",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The type of 'protocol' based on setting in which it would apply",
+      "rdfs:label": "protocolSetting",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Protocol"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:protocolCategory",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The type of 'protocol' based on degree of specificity and purpose",
+      "rdfs:label": "protocolCategory",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Protocol"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:usedToGenerate",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Type of evidence/data generated by the protocol",
+      "rdfs:label": "usedToGenerate",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Protocol"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:inComplianceWith",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Guidelines or Standards to which these protocols adhere. ie- GMP, GCP, other EQUATOR guidelines. Useful for selecting protocols where certain standards/guidelines must be met",
+      "rdfs:label": "inComplianceWith",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Protocol"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    }, 
+    {
+      "@id": "outbreak:StudyEvent",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing StudyEvents, a class that describes categorical events in Clinical Trials added to outbreak.info",
+      "rdfs:label": "StudyEvent",
+      "rdfs:subClassOf": {
+        "@id": "schema:Thing"
+      }
+    },
+    {
+      "@id": "outbreak:studyEventType",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Type of the event status such as StudyStart, PrimaryCompletion, Completion, StudyFirstSubmit, StudyFirstSubmitQC, LastUpdateSubmit",
+      "rdfs:label": "studyEventType",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyEvent"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:studyEventDate",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The corresponding/actual date of the study event (ie- the StartDate, Primary CompletionDate, CompletionDate, StudyFirstSubmitDate, StudyFirstSubmitQCDate, LastUpdateSubmitDate)",
+      "rdfs:label": "studyEventDate",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyEvent"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Date"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:studyEventDateType",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "the type of date provided (actual, anticipated, or estimated)",
+      "rdfs:label": "studyEventDateType",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyEvent"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },  
+    {
+      "@id": "outbreak:StudyStatus",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing the status of a ClinicalTrial resource in outbreak.info",
+      "rdfs:label": "StudyStatus",
+      "rdfs:subClassOf": {
+        "@id": "schema:Thing"
+      }
+    },
+    {
+      "@id": "outbreak:status",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The recruitment status of the study",
+      "rdfs:label": "status",
+      "rdfs:sameAs":{"@id":"schema:status"},
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyStatus"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:statusExpandedAccess",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Flag for whether or not the study has expanded Access status",
+      "rdfs:label": "statusExpandedAccess",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyStatus"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Boolean"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:statusDate",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The date that the status was verified. Equivalent to NCT's StatusVerifiedDate",
+      "rdfs:label": "statusDate",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyStatus"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Date"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:enrollmentCount",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The number of participants enrolled in the study",
+      "rdfs:label": "enrollmentCount",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyStatus"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Number"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:enrollmentType",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The type of estimation used to determine the enrollmentCount (actual counts, target size, etc.)",
+      "rdfs:label": "enrollmentType",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyStatus"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:whyStopped",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "A brief explanation of the reason(s) why such clinical study was stopped (for a clinical study that is Suspended, Terminated, or Withdrawn prior to its planned completion as anticipated by the protocol)",
+      "rdfs:label": "whyStopped",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyStatus"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:StudyDesign",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing the study design of a clinical trial/study for inclusion into outbreak.info resources",
+      "rdfs:label": "StudyDesign",
+      "rdfs:subClassOf": {
+        "@id": "schema:Thing"
+      }
+    },
+    {
+      "@id": "outbreak:studyType",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Type of human study, can be subtypes of observational study or interventional studies and may include the temporal relationship of observation period to time of participant enrollment.",
+      "rdfs:label": "studyType",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyDesign"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:phase",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Stage or phase of the study in the U.S. if applicable",
+      "rdfs:label": "phase",
+      "rdfs:sameAs":{"@id":"schema:phase"},
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyDesign"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:phaseNumber",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The number of the phase or stage of the study",
+      "rdfs:label": "phaseNumber",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyDesign"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Number"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:designAllocation",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The method by which the study participants were allocated into groups",
+      "rdfs:label": "designAllocation",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyDesign"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:designModel",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The general design of the strategy for assigning interventions to participants in a clinical intervention study OR the general design of the strategy for identifying and following up with participants during an observational study",
+      "rdfs:label": "designModel",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyDesign"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:designPrimaryPurpose",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The primary purpose of the study",
+      "rdfs:label": "designPrimaryPurpose",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyDesign"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:designWhoMasked",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The people who do not know which participants have been assigned to which interventions",
+      "rdfs:label": "designWhoMasked",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyDesign"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:designStudyText",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "String description of the study design if structured information not available",
+      "rdfs:label": "designStudyText",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyDesign"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:Intervention",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "a schema to describe Interventions discussed in Clinical Studies/Trials for inclusion in outbreak.info Resources",
+      "rdfs:label": "Intervention",
+      "rdfs:subClassOf": {
+        "@id": "schema:Thing"
+      }
+    },
+    {
+      "@id": "outbreak:category",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The category of an intervention in the study",
+      "rdfs:label": "category",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Intervention"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:ArmGroup",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing arm groups in clinical studies/trials for inclusion in outbreak.info Resources",
+      "rdfs:label": "ArmGroup",
+      "rdfs:subClassOf": {
+        "@id": "schema:Thing"
+      }
+    },
+    {
+      "@id": "outbreak:intervention",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The interventions (if any) in this ArmGroup",
+      "rdfs:label": "intervention",
+      "schema:domainIncludes": {
+        "@id": "outbreak:ArmGroup"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "outbreak:Intervention"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:Outcome",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing a Clinical Trial/Study Outcome for inclusion in  outbreak.info Resources",
+      "rdfs:label": "Outcome",
+      "rdfs:subClassOf": {
+        "@id": "schema:Thing"
+      }
+    },
+    {
+      "@id": "outbreak:outcomeMeasure",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The outcome measure for the study",
+      "rdfs:label": "outcomeMeasure",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Outcome"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:outcomeTimeFrame",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The specific time point(s) and overall duration of evaluation must be specified in this section",
+      "rdfs:label": "outcomeTimeFrame",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Outcome"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Duration"
+        },
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:outcomeType",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The classification of the outcome measure as either primary, secondary, or exploratory",
+      "rdfs:label": "outcomeType",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Outcome"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:Eligibility",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing information about Clinical Trials/Studies eligibility criteria for inclusion in outbreak.info Resources",
+      "rdfs:label": "Eligibility",
+      "rdfs:subClassOf": {
+        "@id": "schema:Thing"
+      }
+    },
+    {
+      "@id": "outbreak:inclusionCriteria",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "\"criteria for inclusion in the study",
+      "rdfs:label": "inclusionCriteria",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Eligibility"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:minimumAge",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "the minimum age for a participant to be included in the study",
+      "rdfs:label": "minimumAge",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Eligibility"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:maximumAge",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "the maximum age for a participant to be included in the study",
+      "rdfs:label": "maximumAge",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Eligibility"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:gender",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "the sex requirement to be included in the study",
+      "rdfs:label": "gender",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Eligibility"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:genderBased",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Boolean for whether or not participation is based on gender",
+      "rdfs:label": "genderBased",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Eligibility"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Boolean"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:healthyVolunteers",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Boolean to indicate whether or not healthy volunteers may be included in the study",
+      "rdfs:label": "healthyVolunteers",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Eligibility"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Boolean"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:stdAge",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "the age category of a participant to be included in the study if a minimum and maximum age is not specified",
+      "rdfs:label": "stdAge",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Eligibility"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:exclusionCriteria",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "criteria for exclusion from the study",
+      "rdfs:label": "exclusionCriteria",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Eligibility"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:criteriaText",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The descriptive criteria as published for the Clinical Trial",
+      "rdfs:label": "criteriaText",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Eligibility"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:StudyLocation",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing Clinical Trial/Study locations for inclusion in outbreak.info Resources",
+      "rdfs:label": "StudyLocation",
+      "rdfs:subClassOf": {
+        "@id": "schema:Place"
+      }
+    },
+    {
+      "@id": "outbreak:studyLocation",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The location of the study",
+      "rdfs:label": "studyLocation",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyLocation"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Place"
+        },
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:studyLocationCity",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The city in which the facility used for the study is located",
+      "rdfs:label": "studyLocationCity",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyLocation"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:City"
+        },
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:studyLocationState",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The state or province in which the facility used for the study is located",
+      "rdfs:label": "studyLocationState",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyLocation"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:State"
+        },
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:studyLocationCountry",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The country in which the facility used for the study is located",
+      "rdfs:label": "studyLocationCountry",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyLocation"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Country"
+        },
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:studyLocationStatus",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The recruitment status of the study at the specific study site",
+      "rdfs:label": "studyLocationStatus",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyLocation"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+{
       "@id": "outbreak:ClinicalTrial",
       "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing the Clinical Trials and other medical studies used for outbreak.info Resources",
       "rdfs:label": "ClinicalTrial",
-      "rdfs:comment": "This is the schema for describing the ClinicalTrial schema used for outbreak.info.",
       "rdfs:subClassOf": {
         "@id": "schema:MedicalStudy"
-      },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
       }
+    },
+    {
+      "@id": "outbreak:identifierSource",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Source of identifier assignment or type of identifier (NCTid, China CTRid, EudraCT Number, etc.)",
+      "rdfs:label": "identifierSource",
+      "schema:domainIncludes": {
+        "@id": "outbreak:ClinicalTrial"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:dateModifiedType",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The type of date. Equivalent to NCT's LastUpdatePostDateType",
+      "rdfs:label": "dateModifiedType",
+      "schema:domainIncludes": {
+        "@id": "outbreak:ClinicalTrial"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:healthConditionIdentifier",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Ontological or controlled vocabulary identifier for the health condition or disease",
+      "rdfs:label": "healthConditionIdentifier",
+      "schema:domainIncludes": {
+        "@id": "outbreak:ClinicalTrial"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        },
+        {
+          "@id": "schema:DefinedTerm"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:hasResults",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Boolean for if the clinical trial has published any results",
+      "rdfs:label": "hasResults",
+      "schema:domainIncludes": {
+        "@id": "outbreak:ClinicalTrial"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Boolean"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:studyEvent",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "an event status such as StudyStart, PrimaryCompletion, Completion, StudyFirstSubmit, StudyFirstSubmitQC, LastUpdateSubmit",
+      "rdfs:label": "studyEvent",
+      "schema:domainIncludes": {
+        "@id": "outbreak:ClinicalTrial"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "outbreak:StudyEvent"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:studyStatus",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The status of the study",
+      "rdfs:label": "studyStatus",
+      "schema:domainIncludes": {
+        "@id": "outbreak:ClinicalTrial"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "outbreak:StudyStatus"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:studyDesign",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The general design of the study",
+      "rdfs:label": "studyDesign",
+      "schema:domainIncludes": {
+        "@id": "outbreak:ClinicalTrial"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "outbreak:StudyDesign"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:armGroup",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The arm or factor of an interventional study",
+      "rdfs:label": "armGroup",
+      "schema:domainIncludes": {
+        "@id": "outbreak:ClinicalTrial"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "outbreak:ArmGroup"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:outcome",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The arm or factor of an interventional study",
+      "rdfs:label": "outcome",
+      "schema:domainIncludes": {
+        "@id": "outbreak:ClinicalTrial"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "outbreak:Outcome"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:eligibilityCriteria",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "eligibility criteria",
+      "rdfs:label": "eligibilityCriteria",
+      "schema:domainIncludes": {
+        "@id": "outbreak:ClinicalTrial"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "outbreak:Eligibility"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:author",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The author of this resource, content, or rating",
+      "rdfs:label": "author",
+      "rdfs:sameAs": {"@id":"schema:author"},
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "outbreak:Person"
+        },
+        {
+          "@id": "outbreak:Organization"
+        }  
+      ]
+    },
+    {
+      "@id": "outbreak:dateCreated",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Date the record was created",
+      "rdfs:label": "dateCreated",
+      "rdfs:sameAs": {"@id":"schema:dateCreated"},
+      "schema:domainIncludes": [
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Date"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:datePublished",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Date of first broadcast/publication",
+      "rdfs:label": "datePublished",
+      "rdfs:sameAs": {"@id":"schema:datePublished"},
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Date"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:dateModified",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The date on which the CreativeWork was most recently modified or when the item's entry was modified within a DataFeed",
+      "rdfs:label": "dateModified",
+      "rdfs:sameAs": {"@id":"schema:dateModified"},
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Date"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:keywords",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "keywords for describing the record",
+      "rdfs:label": "keywords",
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:abstract",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "A short descriptive summary of the publication or study",
+      "rdfs:label": "abstract",
+      "rdfs:sameAs": {"@id":"schema:abstract"},
+      "schema:domainIncludes": [
+          {"@id": "outbreak:Publication"},
+          {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:pmid",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "A pubmed identifier if available",
+      "rdfs:label": "pmid",
+      "schema:domainIncludes": [
+          {"@id": "outbreak:CitationObject"},
+          {"@id": "outbreak:Correction"},
+          {"@id": "outbreak:Publication"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Integer"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:doi",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "A doi if available",
+      "rdfs:label": "doi",
+      "schema:domainIncludes": [
+          {"@id": "outbreak:CitationObject"},
+          {"@id": "outbreak:Correction"},
+          {"@id": "outbreak:Dataset"},
+          {"@id": "outbreak:Publication"},
+          {"@id": "outbreak:Analysis"},
+          {"@id": "outbreak:Protocol"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:funding",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Funding that supports (sponsors) the collection of this dataset through some kind of financial contribution",
+      "rdfs:label": "funding",
+      "schema:domainIncludes": [
+          {"@id": "outbreak:Dataset"},
+          {"@id": "outbreak:Publication"},
+          {"@id": "outbreak:Analysis"},
+          {"@id": "outbreak:Protocol"},
+          {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:MonetaryGrant"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:measurementTechnique",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "A technique or technology used in this resource",
+      "rdfs:label": "measurementTechnique",
+      "rdfs:sameAs": {"@id":"schema:measurementTechnique"},
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Protocol"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        },
+        {
+          "@id": "schema:DefinedTerm"
+        }  
+      ]
+    },
+    {
+      "@id": "outbreak:species",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Species(es) from which dataset has been collected",
+      "rdfs:label": "species",
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Analysis"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        },
+        {
+          "@id": "schema:DefinedTerm"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:infectiousAgent",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "infectious agents(s) which are the focus of the dataset",
+      "rdfs:label": "infectiousAgent",
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Analysis"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        },
+        {
+          "@id": "schema:DefinedTerm"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:infectiousDisease",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The disease or medical conditions caused by the infectious agent. Important as some agents may cause multiple diseases",
+      "rdfs:label": "infectiousDisease",
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Analysis"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        },
+        {
+          "@id": "schema:DefinedTerm"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:topicCategory",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Applicable outbreak.info category",
+      "rdfs:label": "topicCategory",
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+
+    {
+      "@id": "outbreak:isBasedOn",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "A citation to a resource (eg- publication, protocol, etc.) on which this resource was derived (stored as an object, not a string)",
+      "rdfs:label": "isBasedOn",
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {"@id": "outbreak:CitationObject"},
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:ClinicalTrial"},
+        {"@id": "schema:SoftwareApplication"},
+        {"@id": "schema:CreativeWork"}
+      ]
+    },
+    {
+      "@id": "outbreak:isRelatedTo",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "A citation to a resource (eg- publication, protocol, etc.) which is related to the resource but is not a derivative nor was derived from the resource (stored as an object, not a string)",
+      "rdfs:label": "isRelatedTo",
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {"@id": "outbreak:CitationObject"},
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:ClinicalTrial"},
+        {"@id": "schema:SoftwareApplication"},
+        {"@id": "schema:CreativeWork"}
+      ]
+    },
+    {
+      "@id": "outbreak:citedBy",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "A citation to a resource (eg- publication, protocol, etc.) which is derived from this resource (stored as an object, not a string)",
+      "rdfs:label": "citedBy",
+      "rdfs:sameAs":{"@id":"owl:inverseOf: outbreak:isBasedOn"},
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {"@id": "outbreak:CitationObject"},
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:ClinicalTrial"},
+        {"@id": "schema:SoftwareApplication"},
+        {"@id": "schema:CreativeWork"}
+      ]
+    },
+    {
+      "@id": "outbreak:curatedBy",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The source from which this Dataset was identified for inclusion into Outbreak.info. Provides provenance for a resource which was curated by another.",
+      "rdfs:label": "curatedBy",
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {"@id": "outbreak:Person"},
+        {"@id": "outbreak:Organization"},
+        {"@id": "outbreak:CitationObject"},
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:ClinicalTrial"},
+        {"@id": "schema:SoftwareApplication"},
+        {"@id": "schema:CreativeWork"}
+      ]
+    },
+    {
+      "@id": "outbreak:curationDate",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
+      "rdfs:label": "curationDate",
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {"@id": "schema:Date"}
+      ]
+    },
+    {
+      "@id": "outbreak:evaluations",
+      "@type": "rdf:Property",
+      "rdfs:comment":"One or more reviews, ratings, or other evaluations of this resource",
+      "rdfs:label": "evaluations",
+      "schema:domainIncludes":[
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes":[
+        {"@id": "schema:Review"},
+        {"@id": "schema:Rating"},
+        {"@id": "schema:AggregateRating"}
+      ]
     }
   ]
 }

--- a/yaml/outbreak_Dataset.yml
+++ b/yaml/outbreak_Dataset.yml
@@ -1,433 +1,494 @@
 '@context':
-  outbreak: https://discovery.biothings.io/view/outbreak/
-  owl: http://www.w3.org/2002/07/owl/
-  rdf: http://www.w3.org/1999/02/22/-rdf-syntax-ns/
-  rdfs: http://www.w3.org/2000/01/rdf/-schema/
+  outbreak: http://discovery.biothings.io/view/
+  rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
+  rdfs: http://www.w3.org/2000/01/rdf-schema#
   schema: http://schema.org/
 '@graph':
-- '@id': outbreak:Organization
+- $validation:
+    $schema: http://json-schema.org/draft-07/schema#
+    definitions:
+      baseOrgObject:
+        '@type': outbreak:Organization
+        properties:
+          alternateName:
+            type: string
+          name:
+            type: string
+        required:
+        - name
+        type: object
+    properties:
+      affiliation:
+        description: An organization that this person is affiliated with. For example,
+          a school/university, a club, or a team.
+        oneOf:
+        - $ref: '#/definitions/baseOrgObject'
+        - items:
+            $ref: '#/definitions/baseOrgObject'
+          type: array
+      alternateName:
+        description: An alias for the person.
+        type: string
+      familyName:
+        description: Family name. In the U.S., the last name of an Person. This can
+          be used along with givenName instead of the name property.
+        type: string
+      givenName:
+        description: Given name. In the U.S., the first name of a Person. This can
+          be used along with familyName instead of the name property.
+        type: string
+      name:
+        description: The name of the person.
+        type: string
+      orcid:
+        description: the ORCID ID of the person
+        type: string
+      role:
+        description: authorship, sponsorship, or other contribution role played by
+          the person or organization in the creation of this resource
+        oneOf:
+        - type: string
+        - items:
+            type: string
+          type: array
+    required:
+    - name
+    type: object
+  '@id': outbreak:Person
   '@type': rdfs:Class
-  rdfs:comment: This is the schema for describing the Organization schema used for
-    outbreak.info.
+  rdfs:comment: This is the Person schema for describing authors and people for outbreak.info
+    resources
+  rdfs:label: Person
+  rdfs:subClassOf:
+    '@id': schema:Person
+- '@id': outbreak:orcid
+  '@type': rdfs:Property
+  rdfs:comment: the ORCID ID of the person
+  rdfs:label: orcid
+  schema:domainIncludes:
+    '@id': outbreak:Person
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- $validation:
+    $schema: http://json-schema.org/draft-07/schema#
+    definitions:
+      baseOrgObject:
+        '@type': outbreak:Organization
+        description: Affiliated Organization
+        properties:
+          alternateName:
+            description: Alternate name or Acronym for the organization.
+            type: string
+          name:
+            description: name of the organization
+            type: string
+        required:
+        - name
+        type: object
+      basePersonObject:
+        '@type': outbreak:Person
+        properties:
+          affiliation:
+            description: consortia or other organizations with which this person is
+              affiliated
+            oneOf:
+            - $ref: '#/definitions/baseOrgObject'
+            - items:
+                $ref: '#/definitions/baseOrgObject'
+              type: array
+          alternateName:
+            type: string
+          familyName:
+            type: string
+          givenName:
+            type: string
+          name:
+            type: string
+          orcid:
+            type: string
+        required:
+        - name
+        type: object
+    properties:
+      affiliation:
+        description: consortia or other organizations with which this organization
+          is affiliated
+        oneOf:
+        - $ref: '#/definitions/baseOrgObject'
+        - items:
+            $ref: '#/definitions/baseOrgObject'
+          type: array
+      alternateName:
+        description: An alias or acronym for the organization.
+        type: string
+      class:
+        description: A classification of the organization by a resource. Eg- for ClinicalTrials
+          funders, it's [U.S. National Institutes of Health, Other U.S. Federal agencies,
+          Industry, All others]
+        type: string
+      members:
+        description: Members of this organization, team, or group
+        oneOf:
+        - $ref: '#/definitions/basePersonObject'
+        - items:
+            $ref: '#/definitions/basePersonObject'
+          type: array
+      name:
+        description: The name of the organization.
+        type: string
+      role:
+        description: The role of an organization in its involvement with a resource
+        oneOf:
+        - type: string
+        - items:
+            type: string
+          type: array
+    required:
+    - name
+    type: object
+  '@id': outbreak:Organization
+  '@type': rdfs:Class
+  rdfs:comment: This is the organization schema for describing authors, funders and
+    other organizations referenced by outbreak.info resources
   rdfs:label: Organization
   rdfs:subClassOf:
     '@id': schema:Organization
-  schema:isPartOf:
-    '@id': https://discovery.biothings.io/view/outbreak/
-- '@id': outbreak:name
-  '@type': rdf:Property
-  marginality: required
-  owl:cardinality: one
-  rdfs:comment: The name of the organization, team or group
-  rdfs:label: name
-  rdfs:sameAs:
-    '@id': schema:name
-  schema:domainIncludes:
-    '@id': outbreak:Organization
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:alternateName
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: Alternative names or commonly used abbreviations for the organization,
-    team or group
-  rdfs:label: alternateName
-  rdfs:sameAs:
-    '@id': schema:alternateName
-  schema:domainIncludes:
-    '@id': outbreak:Organization
-  schema:rangeIncludes:
-    '@id': schema:Text
 - '@id': outbreak:affiliation
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: An overarching consortia, multi-institutional team or group in which
-    the organization/team/group is a member or affiliate
+  '@type': rdfs:Property
+  rdfs:comment: consortia or other organizations with which this organization is affiliated
   rdfs:label: affiliation
-  rdfs:sameAs:
-    '@id': schema:affiliation
   schema:domainIncludes:
     '@id': outbreak:Organization
   schema:rangeIncludes:
-    '@id': outbreak:Organization
-- '@id': outbreak:affiliationStatus
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The status of the organization's membership or affiliation in the
-    overarching consortial, multi-institutional team or group (current, past)
-  rdfs:label: affiliationStatus
-  rdfs:sameAs:
-    '@id': schema:additionalType
-  schema:domainIncludes:
-    '@id': outbreak:Organization
-  schema:rangeIncludes:
-    '@id': schema:Text
+  - '@id': outbreak:Organization
 - '@id': outbreak:members
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
+  '@type': rdfs:Property
   rdfs:comment: Members of this organization, team, or group
   rdfs:label: members
-  rdfs:sameAs:
-    '@id': schema:members
   schema:domainIncludes:
     '@id': outbreak:Organization
   schema:rangeIncludes:
   - '@id': outbreak:Person
-  - '@id': outbreak:Organization
-- '@id': outbreak:membershipStatus
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: Status of the members of this organization
-  rdfs:label: membershipStatus
-  rdfs:sameAs:
-    '@id': schema:additionalType
-  schema:domainIncludes:
-    '@id': outbreak:Organization
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:relatedTo
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: many
-  rdfs:comment: A resource which a person played a role
-  rdfs:label: relatedTo
-  rdfs:sameAs:
-    '@id': schema:relatedTo
-  schema:domainIncludes:
-    '@id': outbreak:Organization
-  schema:rangeIncludes:
-  - '@id': schema:CreativeWork
-  - '@id': schema:HowTo
 - '@id': outbreak:class
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: many
+  '@type': rdfs:Property
   rdfs:comment: A classification of the organization by a resource. Eg- for ClinicalTrials
-    funders, it's ["U.S. National Institutes of Health", "Other U.S. Federal agencies",
-    "Industry", "All others"]
+    funders, it's [U.S. National Institutes of Health, Other U.S. Federal agencies,
+    Industry, All others]
   rdfs:label: class
-  rdfs:sameAs:
-    '@id': schema:addtionalType
   schema:domainIncludes:
-  - '@id': schema:CreativeWork
-  - '@id': schema:HowTo
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:role
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: many
-  rdfs:comment: The role of an organization in its involvement with a resource
-  rdfs:label: role
-  rdfs:sameAs:
-    '@id': schema:additionalType
-  schema:domainIncludes:
-  - '@id': schema:CreativeWork
-  - '@id': schema:HowTo
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:Person
-  '@type': rdfs:Class
-  rdfs:comment: This is the schema for describing the Person schema used for outbreak.info.
-  rdfs:label: Person
-  rdfs:subClassOf:
-    '@id': schema:Person
-  schema:isPartOf:
-    '@id': https://discovery.biothings.io/view/outbreak/
-- '@id': outbreak:name
-  '@type': rdf:Property
-  marginality: required
-  owl:cardinality: one
-  rdfs:comment: The name of the person
-  rdfs:label: name
-  rdfs:sameAs:
-    '@id': schema:name
-  schema:domainIncludes:
-    '@id': outbreak:Person
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:alternateName
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: Alternative ways in which the person's name is included in a record
-  rdfs:label: alternateName
-  rdfs:sameAs:
-    '@id': schema:alternateName
-  schema:domainIncludes:
-    '@id': outbreak:Person
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:givenName
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The given name of the person
-  rdfs:label: givenName
-  rdfs:sameAs:
-    '@id': schema:givenName
-  schema:domainIncludes:
-    '@id': outbreak:Person
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:familyName
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The family name of the person
-  rdfs:label: familyName
-  rdfs:sameAs:
-    '@id': schema:familyName
-  schema:domainIncludes:
-    '@id': outbreak:Person
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:affiliation
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: The organization with which the person is affiliated or has membership
-    in
-  rdfs:label: affiliation
-  rdfs:sameAs:
-    '@id': schema:affiliation
-  schema:domainIncludes:
-    '@id': outbreak:Person
-  schema:rangeIncludes:
     '@id': outbreak:Organization
-- '@id': outbreak:affiliationStatus
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The status of the person's membership or affiliation in an organization,
-    team or group (current, past)
-  rdfs:label: affiliationStatus
-  rdfs:sameAs:
-    '@id': schema:addtionalType
-  schema:domainIncludes:
-    '@id': outbreak:Person
   schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:orcid
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The ORCID ID of the person
-  rdfs:label: orcid
-  rdfs:sameAs:
-    '@id': schema:identifier
-  schema:domainIncludes:
-    '@id': outbreak:Person
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:relatedTo
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: many
-  rdfs:comment: A resource which a person played a role
-  rdfs:label: relatedTo
-  rdfs:sameAs:
-    '@id': schema:relatedTo
-  schema:domainIncludes:
-    '@id': outbreak:Person
-  schema:rangeIncludes:
-  - '@id': schema:CreativeWork
-  - '@id': schema:HowTo
+  - '@id': schema:Text
 - '@id': outbreak:role
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: The role a person played in the creation of a resource
+  '@type': rdfs:Property
+  rdfs:comment: authorship, sponsorship, or other contribution role played by the
+    person or organization in the creation of this resource. In a Clinical Study/Trial
+    ArmGroup, it's equivalent to the ArmType in ClinicalTrials.gov
   rdfs:label: role
-  rdfs:sameAs:
-    '@id': schema:addtionalType
   schema:domainIncludes:
-  - '@id': schema:CreativeWork
-  - '@id': schema:HowTo
+  - '@id': outbreak:Person
+  - '@id': outbreak:Organization
+  - '@id': outbreak:ArmGroup
   schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:DataDownload
+  - '@id': schema:Text
+- $validation:
+    $schema: http://json-schema.org/draft-07/schema#
+    definitions:
+      baseOrgObject:
+        '@type': outbreak:Organization
+        description: Affiliated Organization
+        properties:
+          alternateName:
+            description: Alternate name or Acronym for the organization.
+            type: string
+          name:
+            description: name of the organization
+            type: string
+        required:
+        - name
+        type: object
+      basePersonObject:
+        '@type': outbreak:Person
+        properties:
+          affiliation:
+            description: consortia or other organizations with which this person is
+              affiliated
+            oneOf:
+            - $ref: '#/definitions/baseOrgObject'
+            - items:
+                $ref: '#/definitions/baseOrgObject'
+              type: array
+          alternateName:
+            type: string
+          familyName:
+            type: string
+          givenName:
+            type: string
+          name:
+            type: string
+          orcid:
+            type: string
+        required:
+        - name
+        type: object
+    properties:
+      funder:
+        description: The organization(s) that supported (sponsored) the grant through
+          some kind of financial contribution.
+        oneOf:
+        - $ref: '#/definitions/baseOrgObject'
+        - items:
+            $ref: '#/definitions/baseOrgObject'
+          type: array
+      identifier:
+        description: The funding or grant id
+        type: string
+      name:
+        description: The name of the grant or funding.
+        type: string
+      recipient:
+        anyOf:
+        - $ref: '#/definitions/basePersonObject'
+        - items:
+            $ref: '#/definitions/basePersonObject'
+          type: array
+        - $ref: '#/definitions/baseOrgObject'
+        - items:
+            $ref: '#/definitions/baseOrgObject'
+          type: array
+        description: The person or organization to whom or to which the grant was
+          awarded
+      url:
+        description: URL of the grant or funding award.
+        format: uri
+        type: string
+    required:
+    - funder
+    type: object
+  '@id': outbreak:MonetaryGrant
+  '@type': rdfs:Class
+  rdfs:comment: This is the schema for describing the MonetaryGrant schema used for
+    outbreak.info
+  rdfs:label: MonetaryGrant
+  rdfs:subClassOf:
+    '@id': schema:MonetaryGrant
+- '@id': outbreak:recipient
+  '@type': rdfs:Property
+  rdfs:comment: The person or organization to whom or to which the grant was awarded
+  rdfs:label: recipient
+  schema:domainIncludes:
+    '@id': outbreak:MonetaryGrant
+  schema:rangeIncludes:
+  - '@id': schema:Person
+  - '@id': schema:Organization
+- $validation:
+    $schema: http://json-schema.org/draft-07/schema#
+    properties:
+      contentUrl:
+        description: Actual url of the data file.
+        format: uri
+        type: string
+      dateModified:
+        description: The date on which the distribution was most recently modified
+          or when the item's entry was modified within a DataFeed.
+        format: date
+        type: string
+      name:
+        description: The name of the distribution.
+        type: string
+    required:
+    - contentUrl
+    - dateModified
+    type: object
+  '@id': outbreak:DataDownload
   '@type': rdfs:Class
   rdfs:comment: This is the schema for describing the DataDownload schema used for
     outbreak.info.
   rdfs:label: DataDownload
   rdfs:subClassOf:
     '@id': schema:DataDownload
-  schema:isPartOf:
-    '@id': https://discovery.biothings.io/view/outbreak/
-- '@id': outbreak:contentUrl
-  '@type': rdf:Property
-  marginality: required
-  owl:cardinality: one
-  rdfs:comment: Link to the location where the dataset can be found, ideally a permanent
-    URL
-  rdfs:label: contentUrl
-  rdfs:sameAs:
-    '@id': schema:distribution
-  schema:domainIncludes:
-    '@id': outbreak:DataDownload
-  schema:rangeIncludes:
-    '@id': schema:URL
-- '@id': outbreak:dateModified
-  '@type': rdf:Property
-  marginality: required
-  owl:cardinality: one
-  rdfs:comment: Date which the particular DataDownload (file) has been changed
-  rdfs:label: dateModified
-  rdfs:sameAs:
-    '@id': schema:dateModified
-  schema:domainIncludes:
-    '@id': outbreak:DataDownload
-  schema:rangeIncludes:
-    '@id': schema:Date
-- '@id': outbreak:MonetaryGrant
+- $validation:
+    $schema: http://json-schema.org/draft-07/schema#
+    properties:
+      citeText:
+        description: The bibliographic citation for the referenced resource as is
+          provided
+        type: string
+      doi:
+        description: A doi if available
+        type: string
+      identifier:
+        description: An identifier associated with the citation
+        type: string
+      name:
+        description: The name or title of the cited resource.
+        type: string
+      pmid:
+        description: A pubmed identifier if available
+        type: string
+      sourceType:
+        description: The @type of resource
+        enum:
+        - Dataset
+        - Publication
+        - ClinicalTrial
+        - Analysis
+        - Protocol
+        - SoftwareApplication
+        - CreativeWork
+      url:
+        description: URL of the cited resource.
+        format: uri
+        type: string
+      versionDate:
+        description: The version date of the resource used at the time of the creation
+          of the citation as certain resources (protocols, datasets) may change frequently
+          over time.
+        format: date
+        type: string
+    required:
+    - name
+    - sourceType
+    type: object
+  '@id': outbreak:CitationObject
   '@type': rdfs:Class
-  rdfs:comment: This is the schema for describing the MonetaryGrant schema used for
-    outbreak.info.
-  rdfs:label: MonetaryGrant
-  rdfs:subClassOf:
-    '@id': schema:MonetaryGrant
-  schema:isPartOf:
-    '@id': https://discovery.biothings.io/view/outbreak/
-- '@id': outbreak:name
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The name of the monetary grant
-  rdfs:label: name
-  rdfs:sameAs:
-    '@id': schema:name
-  schema:domainIncludes:
-    '@id': outbreak:MonetaryGrant
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:identifier
-  '@type': rdf:Property
-  marginality: required
-  owl:cardinality: one
-  rdfs:comment: The grant ID or an identifier associated with the grant
-  rdfs:label: identifier
-  rdfs:sameAs:
-    '@id': schema:identifier
-  schema:domainIncludes:
-    '@id': outbreak:MonetaryGrant
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:url
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The url for the grant (if available)
-  rdfs:label: url
-  rdfs:sameAs:
-    '@id': schema:url
-  schema:domainIncludes:
-    '@id': outbreak:MonetaryGrant
-  schema:rangeIncludes:
-    '@id': schema:URL
-- '@id': outbreak:funder
-  '@type': rdf:Property
-  marginality: required
-  owl:cardinality: many
-  rdfs:comment: The funding organization of the grant
-  rdfs:label: funder
-  rdfs:sameAs:
-    '@id': schema:funder
-  schema:domainIncludes:
-    '@id': outbreak:MonetaryGrant
-  schema:rangeIncludes:
-    '@id': outbreak:Organization
-- '@id': outbreak:name
-  '@type': rdf:Property
-  marginality: required
-  owl:cardinality: one
-  rdfs:comment: The name of the funding organization
-  rdfs:label: name
-  rdfs:sameAs:
-    '@id': schema:name
-  schema:domainIncludes:
-    '@id': outbreak:Organization
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:recipient
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: The person or organization to whom or to which the grant was awarded
-  rdfs:label: recipient
-  rdfs:sameAs:
-    '@id': schema:recipient
-  schema:domainIncludes:
-    '@id': outbreak:MonetaryGrant
-  schema:rangeIncludes:
-  - '@id': outbreak:Person
-  - '@id': outbreak:Organization
-- '@id': outbreak:name
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The name of the recipient of the grant
-  rdfs:label: name
-  rdfs:sameAs:
-    '@id': schema:name
-  schema:domainIncludes:
-  - '@id': outbreak:Person
-  - '@id': outbreak:Organization
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:affiliation
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: The affiliation of the recipient of the grant
-  rdfs:label: affiliation
-  rdfs:sameAs:
-    '@id': schema:affiliation
-  schema:domainIncludes:
-  - '@id': outbreak:Person
-  - '@id': outbreak:Organization
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:Analysis
-  '@type': rdfs:Class
-  rdfs:comment: This is the schema for describing the Analysis schema used for outbreak.info.
-  rdfs:label: Analysis
+  rdfs:comment: A citation object for a resource which is cited by the subject (ie-
+    is a derivative of the subject), related to the subject, or from which the subject
+    was based on (ie- is derived from).
+  rdfs:label: CitationObject
   rdfs:subClassOf:
     '@id': schema:CreativeWork
-  schema:isPartOf:
-    '@id': https://discovery.biothings.io/view/outbreak/
+- '@id': outbreak:citeText
+  '@type': rdfs:Property
+  rdfs:comment: The bibliographic citation for the referenced resource as is provided
+  rdfs:label: citeText
+  schema:domainIncludes:
+    '@id': outbreak:CitationObject
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:versionDate
+  '@type': rdfs:Property
+  rdfs:comment: The version date of the resource used at the time of the creation
+    of the citation as certain resources (protocols, datasets) may change frequently
+    over time.
+  rdfs:label: versionDate
+  schema:domainIncludes:
+    '@id': outbreak:CitationObject
+  schema:rangeIncludes:
+  - '@id': schema:Date
+- '@id': outbreak:sourceType
+  '@type': rdfs:Property
+  rdfs:comment: The type of resource
+  rdfs:label: sourceType
+  schema:domainIncludes:
+    '@id': outbreak:CitationObject
+  schema:rangeIncludes:
+  - '@id': schema:Text
 - $validation:
     $schema: http://json-schema.org/draft-07/schema#
     definitions:
+      aggregateRatingObject:
+        '@type': AggregateRating
+        description: A cumulative evaluation of the resource
+        properties:
+          author:
+            anyOf:
+            - $ref: '#/definitions/person'
+            - items:
+                $ref: '#/definitions/person'
+              type: array
+            - $ref: '#/definitions/organization'
+            - items:
+                $ref: '#/definitions/organization'
+              type: array
+            description: The author of this content or rating.
+          curationDate:
+            description: The date this evaluation was added into outbreak.info, or
+              was updated in outbreak.info.
+            format: date
+            type: string
+          name:
+            description: The name of the aggregate rating
+            type: string
+          ratingValue:
+            description: The rating for the content.
+            type: string
+          reviewAspect:
+            description: This Review or Rating is relevant to this part or facet of
+              the itemReviewed
+            type: string
+          reviews:
+            anyOf:
+            - items:
+                $ref: '#/definitions/reviewObject'
+              type: array
+            - items:
+                $ref: '#/definitions/ratingObject'
+              type: array
+        required: []
+        type: object
+      baseOrgObject:
+        '@type': outbreak:Organization
+        description: A barebones Organization object to work around recursion issues
+          in DDE
+        properties:
+          alternateName:
+            description: Alternate name or Acronym for the organization.
+            type: string
+          name:
+            description: name of the organization
+            type: string
+        required:
+        - name
+        type: object
       citation:
-        '@type': ScholarlyArticle
+        '@type': outbreak:CitationObject
         description: A citation object for a resource which is cited by the dataset
           (ie- is a derivative of the dataset) , related to the dataset, or from which
           the dataset was based on (ie- is derived from).
         properties:
+          citeText:
+            description: The bibliographic citation for the referenced resource as
+              is provided
+            type: string
+          doi:
+            description: A doi if available
+            type: string
           identifier:
+            description: An identifier associated with the citation
             type: string
           name:
+            description: Name of or title of the citation
             type: string
-          type:
+          pmid:
+            description: A pubmed identifier if available
             type: string
+          sourceType:
+            description: The type of resource
+            enum:
+            - Dataset
+            - Publication
+            - ClinicalTrial
+            - Analysis
+            - Protocol
+            - SoftwareApplication
+            - CreativeWork
           url:
+            description: The url of the resource cited.
             format: uri
             type: string
           versionDate:
+            description: The version date of the resource used at the time of the
+              creation of the citation as certain resources (protocols, datasets)
+              may change frequently over time.
             format: date
             type: string
         required:
         - name
-        - type
+        - sourceType
         type: object
       controlledVocabulary:
-        '@type': CreativeWork
+        '@type': DefinedTerm
         description: collection of vocabulary terms defined in ontologies
         strict: false
         type: string
@@ -440,32 +501,43 @@
           - efo
           - ncit
           - obi
-      dataDownload:
-        '@type': DataDownload
+      datadownload:
+        '@type': outbreak:DataDownload
         description: A dataset in downloadable form.
         properties:
+          contentUrl:
+            format: uri
+            type: string
           dateModified:
             format: date
             type: string
-          url:
-            format: uri
+          name:
             type: string
         required:
         - dateModified
-        - url
+        - contentUrl
         type: object
+      diseaseVocabulary:
+        '@type': DefinedTerm
+        description: collection of vocabulary terms defined in ontologies
+        strict: false
+        type: string
+        vocabulary:
+          children_of:
+          - http://purl.obolibrary.org/obo/MONDO_0000001
+          ontology:
+          - mondo
       funding:
-        '@type': MonetaryGrant
+        '@type': outbreak:MonetaryGrant
         description: Information about funding support
         properties:
           funder:
             description: name of the funding organization
             oneOf:
-            - $ref: '#/definitions/organization'
+            - $ref: '#/definitions/baseOrgObject'
             - items:
-                $ref: '#/definitions/organization'
+                $ref: '#/definitions/baseOrgObject'
               type: array
-            type: array
           identifier:
             description: Unique identifier(s) for the grant(s) used to fund the Dataset
             type: string
@@ -474,23 +546,45 @@
             type: string
           url:
             description: award URL
+            format: uri
             type: string
         required:
         - funder
         type: object
+      memberObject:
+        '@type': outbreak:Person
+        description: Reusable person definition accounting for recursion issues in
+          DDE
+        properties:
+          affiliation:
+            oneOf:
+            - $ref: '#/definitions/baseOrgObject'
+            - items:
+                $ref: '#/definitions/baseOrgObject'
+              type: array
+          familyName:
+            type: string
+          givenName:
+            type: string
+          name:
+            type: string
+          orcid:
+            type: string
+        required:
+        - name
+        type: object
       miscControlledVocabulary:
-        '@type': CreativeWork
+        '@type': DefinedTerm
         description: collection of vocabulary terms defined in ontologies
         strict: false
         type: string
         vocabulary:
           children_of:
           - http://purl.obolibrary.org/obo/NCBITaxon_10239
-          - http://purl.obolibrary.org/obo/NCBITaxon_131567l
           ontology:
           - ncbitaxon
       moreControlledVocabulary:
-        '@type': CreativeWork
+        '@type': DefinedTerm
         definition: collection of vocabulary terms defined in ontologies
         strict: false
         type: string
@@ -506,27 +600,34 @@
           - epo
           - covid19
       organization:
-        '@type': Organization
+        '@type': outbreak:Organization
         description: Reusable organization definition
         properties:
           affiliation:
+            $ref: '#/definitions/baseOrgObject'
+          alternateName:
             type: string
+          members:
+            oneOf:
+            - $ref: '#/definitions/memberObject'
+            - items:
+                $ref: '#/definitions/memberObject'
+              type: array
           name:
             type: string
         required:
         - name
         type: object
       person:
-        '@type': Person
+        '@type': outbreak:Person
         description: Reusable person definition
         properties:
           affiliation:
             oneOf:
-            - $ref: '#/definitions/organization'
+            - $ref: '#/definitions/baseOrgObject'
             - items:
-                $ref: '#/definitions/organization'
+                $ref: '#/definitions/baseOrgObject'
               type: array
-            type: array
           familyName:
             type: string
           givenName:
@@ -538,12 +639,89 @@
         required:
         - name
         type: object
+      ratingObject:
+        '@type': Rating
+        description: A rating or categorical evaluation of the resource
+        properties:
+          author:
+            anyOf:
+            - $ref: '#/definitions/person'
+            - items:
+                $ref: '#/definitions/person'
+              type: array
+            - $ref: '#/definitions/organization'
+            - items:
+                $ref: '#/definitions/organization'
+              type: array
+            description: The author of this content or rating.
+          curationDate:
+            description: The date this evaluation was added into outbreak.info, or
+              was updated in outbreak.info.
+            format: date
+            type: string
+          name:
+            description: The name of the rating
+            type: string
+          ratingExplanation:
+            description: An explanation of the rating
+            type: string
+          ratingValue:
+            description: The rating for the content.
+            type: string
+          reviewAspect:
+            description: This Review or Rating is relevant to this part or facet of
+              the itemReviewed
+            type: string
+        required: []
+        type: object
+      reviewObject:
+        '@type': Review
+        description: A review or descriptive evaluation of the resource
+        properties:
+          author:
+            anyOf:
+            - $ref: '#/definitions/person'
+            - items:
+                $ref: '#/definitions/person'
+              type: array
+            - $ref: '#/definitions/organization'
+            - items:
+                $ref: '#/definitions/organization'
+              type: array
+            description: The author of this content or rating.
+          curationDate:
+            description: The date this evaluation was added into outbreak.info, or
+              was updated in outbreak.info.
+            format: date
+            type: string
+          name:
+            description: The name of the review
+            type: string
+          reviewAspect:
+            description: This Review or Rating is relevant to this part or facet of
+              the itemReviewed
+            type: string
+          reviewBody:
+            description: The actual body of the review.
+            type: string
+          reviewRating:
+            $ref: '#/definitions/ratingObject'
+            description: The rating given in this review
+        required: []
+        type: object
+      speciesControlledVocabulary:
+        '@type': DefinedTerm
+        description: collection of vocabulary terms defined in ontologies
+        strict: false
+        type: string
+        vocabulary:
+          children_of:
+          - http://purl.obolibrary.org/obo/NCBITaxon_131567
+          ontology:
+          - ncbitaxon
     properties:
       author:
-        description: 'Name of the author or organization that created the dataset.  Note:
-          schema.org/author and schema.org/organization have additional fields that
-          can provide more information about the author/organization, if desired.'
-        oneOf:
+        anyOf:
         - $ref: '#/definitions/person'
         - items:
             $ref: '#/definitions/person'
@@ -552,6 +730,9 @@
         - items:
             $ref: '#/definitions/organization'
           type: array
+        description: 'Name of the author or organization that created the dataset.  Note:
+          schema.org/author and schema.org/organization have additional fields that
+          can provide more information about the author/organization, if desired.'
       citedBy:
         description: A citation to a resource (eg- publication, protocol, etc.) which
           is derived from this dataset (stored as an object, not a string)
@@ -561,10 +742,7 @@
             $ref: '#/definitions/citation'
           type: array
       curatedBy:
-        description: The source from which this Dataset was identified for inclusion
-          into Outbreak.info. Provides provenance for a resource which was curated
-          by another.
-        oneOf:
+        anyOf:
         - $ref: '#/definitions/citation'
         - $ref: '#/definitions/person'
         - $ref: '#/definitions/organization'
@@ -577,24 +755,48 @@
         - items:
             $ref: '#/definitions/citation'
           type: array
+        description: The source from which this Dataset was identified for inclusion
+          into Outbreak.info. Provides provenance for a resource which was curated
+          by another.
       curationDate:
         description: The date this resource was added into outbreak.info, or was updated
           in outbreak.info.
         format: date
         type: string
-      dataDownload:
+      dateModified:
+        description: The date on which the CreativeWork was most recently modified
+          or when the item's entry was modified within a DataFeed.
+        format: date
+        type: string
+      datePublished:
+        description: Date of first broadcast/publication.
+        format: date
+        type: string
+      description:
+        description: Longer description of what is contained in the dataset.
+        type: string
+      distribution:
         description: Available downloads of the dataset.
         oneOf:
-        - $ref: '#/definitions/dataDownload'
+        - $ref: '#/definitions/datadownload'
         - items:
-            $ref: '#/definitions/dataDownload'
+            $ref: '#/definitions/datadownload'
           type: array
-      description:
-        description: Longer description of what is contained in the dataset
-        type: string
       doi:
         description: The DOI for the dataset if available
         type: string
+      evaluations:
+        anyOf:
+        - items:
+            $ref: '#/definitions/reviewObject'
+          type: array
+        - items:
+            $ref: '#/definitions/ratingObject'
+          type: array
+        - items:
+            $ref: '#/definitions/aggregateRatingObject'
+          type: array
+        description: Reviews, Ratings, or other types of evaluations on this resource
       funding:
         description: Funding that supports (sponsors) the collection of this dataset
           through some kind of financial contribution
@@ -604,7 +806,7 @@
             $ref: '#/definitions/funding'
           type: array
       identifier:
-        description: identifier for the dataset
+        description: An identifier for the dataset, preferably a doi
         type: string
       infectiousAgent:
         description: infectious agents(s) which are the focus of the dataset
@@ -612,6 +814,14 @@
         - $ref: '#/definitions/miscControlledVocabulary'
         - items:
             $ref: '#/definitions/miscControlledVocabulary'
+          type: array
+      infectiousDisease:
+        description: The disease or medical conditions caused by the infectious agent.
+          Important as some agents may cause multiple diseases
+        oneOf:
+        - $ref: '#/definitions/diseaseVocabulary'
+        - items:
+            $ref: '#/definitions/diseaseVocabulary'
           type: array
       isBasedOn:
         description: A citation to a resource (eg- publication, protocol, etc.) on
@@ -621,8 +831,18 @@
         - items:
             $ref: '#/definitions/citation'
           type: array
+      isRelatedTo:
+        description: A citation to a resource (eg- publication, protocol, etc.) which
+          is related to the dataset but is not a derivative nor was derived from the
+          dataset (stored as an object, not a string)
+        oneOf:
+        - $ref: '#/definitions/citation'
+        - items:
+            $ref: '#/definitions/citation'
+          type: array
       keywords:
-        description: A list of keywords associated with this dataset
+        description: Keywords or tags used to describe this content. Multiple entries
+          in a keywords list are typically delimited by commas.
         oneOf:
         - type: string
         - items:
@@ -631,7 +851,6 @@
       license:
         description: A license document that applies to this content, typically indicated
           by URL.
-        format: uri
         type: string
       measurementTechnique:
         description: A technique or technology used in a Dataset, corresponding to
@@ -642,23 +861,14 @@
             $ref: '#/definitions/controlledVocabulary'
           type: array
       name:
-        description: Descriptive name of the dataset
+        description: Descriptive name of the dataset.
         type: string
-      relatedTo:
-        description: A citation to a resource (eg- publication, protocol, etc.) which
-          is related to the dataset but is not a derivative nor was derived from the
-          dataset (stored as an object, not a string)
-        oneOf:
-        - $ref: '#/definitions/citation'
-        - items:
-            $ref: '#/definitions/citation'
-          type: array
       species:
         description: Species(es) from which dataset has been collected
         oneOf:
-        - $ref: '#/definitions/miscControlledVocabulary'
+        - $ref: '#/definitions/speciesControlledVocabulary'
         - items:
-            $ref: '#/definitions/miscControlledVocabulary'
+            $ref: '#/definitions/speciesControlledVocabulary'
           type: array
       topicCategory:
         description: Applicable outbreak.info category
@@ -697,6 +907,7 @@
           - Epidemiology
           - Classical Epidemiology
           - Molecular Epidemiology
+          - Information Sciences
         - items:
             enum:
             - Clinical
@@ -732,6 +943,7 @@
             - Epidemiology
             - Classical Epidemiology
             - Molecular Epidemiology
+            - Information Sciences
           type: array
       variableMeasured:
         description: A technique or technology used in a Dataset, corresponding to
@@ -742,9 +954,10 @@
             $ref: '#/definitions/moreControlledVocabulary'
           type: array
     required:
-    - name
-    - description
     - author
+    - description
+    - identifier
+    - name
     type: object
   '@id': outbreak:Dataset
   '@type': rdfs:Class
@@ -752,609 +965,928 @@
   rdfs:label: Dataset
   rdfs:subClassOf:
     '@id': schema:Dataset
-  schema:isPartOf:
-    '@id': https://discovery.biothings.io/view/outbreak/
-- '@id': outbreak:name
-  '@type': rdf:Property
-  marginality: required
-  owl:cardinality: one
-  rdfs:comment: Short, descriptive title for the dataset
-  rdfs:label: name
-  rdfs:sameAs:
-    '@id': schema:name
+- '@id': outbreak:Correction
+  '@type': rdfs:Class
+  rdfs:comment: This is the schema for describing a Correction used for outbreak.info.
+    A Correction is a specialized subclass of the CitationObject
+  rdfs:label: Correction
+  rdfs:subClassOf:
+    '@id': schema:CreativeWork
+- '@id': outbreak:correctionType
+  '@type': rdfs:Property
+  rdfs:comment: 'Type of notice or correction: (correction, retraction, expression
+    of convern, withdrawal, erratum, update, correction/republication, preprint, peer
+    reviewed version)'
+  rdfs:label: correctionType
   schema:domainIncludes:
-    '@id': outbreak:Dataset
+    '@id': outbreak:Correction
   schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:description
-  '@type': rdf:Property
-  marginality: required
-  owl:cardinality: one
-  rdfs:comment: Longer description of what was contained in the dataset. For example,
-    dataset fields, ...
-  rdfs:label: description
-  rdfs:sameAs:
-    '@id': schema:description
+  - '@id': schema:Text
+- '@id': outbreak:Publication
+  '@type': rdfs:Class
+  rdfs:comment: This is the schema for describing the Publication used for outbreak.info
+  rdfs:label: Publication
+  rdfs:subClassOf:
+    '@id': schema:MedicalScholarlyArticle
+- '@id': outbreak:journalName
+  '@type': rdfs:Property
+  rdfs:comment: The name of the journal (or publisher if journal name not available)
+  rdfs:label: journalName
   schema:domainIncludes:
-    '@id': outbreak:Dataset
+    '@id': outbreak:Publication
   schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:measurementTechnique
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: Measurement technique(s) used in collecting the dataset, e.g. RNA
-    sequencing
-  rdfs:label: measurementTechnique
-  rdfs:sameAs:
-    '@id': schema:measurementTechnique
+  - '@id': schema:Text
+- '@id': outbreak:journalNameAbbrevation
+  '@type': rdfs:Property
+  rdfs:comment: abbreviated Journal Title (note, this should be autopopulated)
+  rdfs:label: journalNameAbbrevation
   schema:domainIncludes:
-    '@id': outbreak:Dataset
+    '@id': outbreak:Publication
   schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:variableMeasured
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: The factors or variables measured in the dataset
-  rdfs:label: variableMeasured
-  rdfs:sameAs:
-    '@id': schema:variableMeasured
+  - '@id': schema:Text
+- '@id': outbreak:volumeNumber
+  '@type': rdfs:Property
+  rdfs:comment: Volume number of journal in which the article was published
+  rdfs:label: volumeNumber
   schema:domainIncludes:
-    '@id': outbreak:Dataset
+    '@id': outbreak:Publication
   schema:rangeIncludes:
-    '@id': schema:Text
+  - '@id': schema:Text
+- '@id': outbreak:issueNumber
+  '@type': rdfs:Property
+  rdfs:comment: Issue of journal in which the article was published
+  rdfs:label: issueNumber
+  schema:domainIncludes:
+    '@id': outbreak:Publication
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:Analysis
+  '@type': rdfs:Class
+  rdfs:comment: This is the schema for describing an Analysis for inclusion in outbreak.info
+    resources
+  rdfs:label: Analysis
+  rdfs:subClassOf:
+    '@id': schema:CreativeWork
+- '@id': outbreak:domainUrl
+  '@type': rdfs:Property
+  rdfs:comment: The domain name or main site on which webpage or specific url can
+    be found
+  rdfs:label: domainUrl
+  schema:domainIncludes:
+    '@id': outbreak:Analysis
+  schema:rangeIncludes:
+  - '@id': schema:URL
+- '@id': outbreak:assumption
+  '@type': rdfs:Property
+  rdfs:comment: Statement of assumptions / limitations of the model
+  rdfs:label: assumption
+  schema:domainIncludes:
+    '@id': outbreak:Analysis
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:analysisTechnique
+  '@type': rdfs:Property
+  rdfs:comment: A technique or technology used in a analysis
+  rdfs:label: analysisTechnique
+  schema:domainIncludes:
+    '@id': outbreak:Analysis
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:analysisTopic
+  '@type': rdfs:Property
+  rdfs:comment: The underlying question, goal, or aim of the analysis
+  rdfs:label: analysisTopic
+  schema:domainIncludes:
+    '@id': outbreak:Analysis
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:Product
+  '@type': rdfs:Class
+  rdfs:comment: This is the schema for describing a reagent, material, sample, or
+    some other product used in a protocol resource in outbreak.info
+  rdfs:label: Product
+  rdfs:subClassOf:
+    '@id': schema:Product
+- '@id': outbreak:Instrument
+  '@type': rdfs:Class
+  rdfs:comment: This is the schema for describing an instrument used in a protocol
+    resource listed in outbreak.info
+  rdfs:label: Instrument
+  rdfs:subClassOf:
+    '@id': schema:Product
+- '@id': outbreak:Protocol
+  '@type': rdfs:Class
+  rdfs:comment: This is the schema for describing the Protocols for outbreak.info
+    Resources.
+  rdfs:label: Protocol
+  rdfs:subClassOf:
+    '@id': schema:HowTo
+- '@id': outbreak:warning
+  '@type': rdfs:Property
+  rdfs:comment: Precautions, warnings, and/or safety warnings associated with or highlighted
+    by the protocol
+  rdfs:label: warning
+  schema:domainIncludes:
+    '@id': outbreak:Protocol
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:correctionNote
+  '@type': rdfs:Property
+  rdfs:comment: statement of what was updated/changed since prior version
+  rdfs:label: correctionNote
+  schema:domainIncludes:
+    '@id': outbreak:Protocol
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:protocolStatus
+  '@type': rdfs:Property
+  rdfs:comment: The status of the protocol
+  rdfs:label: protocolStatus
+  schema:domainIncludes:
+    '@id': outbreak:Protocol
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:instrument
+  '@type': rdfs:Property
+  rdfs:comment: A laboratory equipment use by a person to follow one or more steps
+    described in this Protocol
+  rdfs:label: instrument
+  schema:domainIncludes:
+    '@id': outbreak:Protocol
+  schema:rangeIncludes:
+  - '@id': outbreak:Instrument
+- '@id': outbreak:protocolSetting
+  '@type': rdfs:Property
+  rdfs:comment: The type of 'protocol' based on setting in which it would apply
+  rdfs:label: protocolSetting
+  schema:domainIncludes:
+    '@id': outbreak:Protocol
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:protocolCategory
+  '@type': rdfs:Property
+  rdfs:comment: The type of 'protocol' based on degree of specificity and purpose
+  rdfs:label: protocolCategory
+  schema:domainIncludes:
+    '@id': outbreak:Protocol
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:usedToGenerate
+  '@type': rdfs:Property
+  rdfs:comment: Type of evidence/data generated by the protocol
+  rdfs:label: usedToGenerate
+  schema:domainIncludes:
+    '@id': outbreak:Protocol
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:inComplianceWith
+  '@type': rdfs:Property
+  rdfs:comment: Guidelines or Standards to which these protocols adhere. ie- GMP,
+    GCP, other EQUATOR guidelines. Useful for selecting protocols where certain standards/guidelines
+    must be met
+  rdfs:label: inComplianceWith
+  schema:domainIncludes:
+    '@id': outbreak:Protocol
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:StudyEvent
+  '@type': rdfs:Class
+  rdfs:comment: This is the schema for describing StudyEvents, a class that describes
+    categorical events in Clinical Trials added to outbreak.info
+  rdfs:label: StudyEvent
+  rdfs:subClassOf:
+    '@id': schema:Thing
+- '@id': outbreak:studyEventType
+  '@type': rdfs:Property
+  rdfs:comment: Type of the event status such as StudyStart, PrimaryCompletion, Completion,
+    StudyFirstSubmit, StudyFirstSubmitQC, LastUpdateSubmit
+  rdfs:label: studyEventType
+  schema:domainIncludes:
+    '@id': outbreak:StudyEvent
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:studyEventDate
+  '@type': rdfs:Property
+  rdfs:comment: The corresponding/actual date of the study event (ie- the StartDate,
+    Primary CompletionDate, CompletionDate, StudyFirstSubmitDate, StudyFirstSubmitQCDate,
+    LastUpdateSubmitDate)
+  rdfs:label: studyEventDate
+  schema:domainIncludes:
+    '@id': outbreak:StudyEvent
+  schema:rangeIncludes:
+  - '@id': schema:Date
+- '@id': outbreak:studyEventDateType
+  '@type': rdfs:Property
+  rdfs:comment: the type of date provided (actual, anticipated, or estimated)
+  rdfs:label: studyEventDateType
+  schema:domainIncludes:
+    '@id': outbreak:StudyEvent
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:StudyStatus
+  '@type': rdfs:Class
+  rdfs:comment: This is the schema for describing the status of a ClinicalTrial resource
+    in outbreak.info
+  rdfs:label: StudyStatus
+  rdfs:subClassOf:
+    '@id': schema:Thing
+- '@id': outbreak:status
+  '@type': rdfs:Property
+  rdfs:comment: The recruitment status of the study
+  rdfs:label: status
+  rdfs:sameAs:
+    '@id': schema:status
+  schema:domainIncludes:
+    '@id': outbreak:StudyStatus
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:statusExpandedAccess
+  '@type': rdfs:Property
+  rdfs:comment: Flag for whether or not the study has expanded Access status
+  rdfs:label: statusExpandedAccess
+  schema:domainIncludes:
+    '@id': outbreak:StudyStatus
+  schema:rangeIncludes:
+  - '@id': schema:Boolean
+- '@id': outbreak:statusDate
+  '@type': rdfs:Property
+  rdfs:comment: The date that the status was verified. Equivalent to NCT's StatusVerifiedDate
+  rdfs:label: statusDate
+  schema:domainIncludes:
+    '@id': outbreak:StudyStatus
+  schema:rangeIncludes:
+  - '@id': schema:Date
+- '@id': outbreak:enrollmentCount
+  '@type': rdfs:Property
+  rdfs:comment: The number of participants enrolled in the study
+  rdfs:label: enrollmentCount
+  schema:domainIncludes:
+    '@id': outbreak:StudyStatus
+  schema:rangeIncludes:
+  - '@id': schema:Number
+- '@id': outbreak:enrollmentType
+  '@type': rdfs:Property
+  rdfs:comment: The type of estimation used to determine the enrollmentCount (actual
+    counts, target size, etc.)
+  rdfs:label: enrollmentType
+  schema:domainIncludes:
+    '@id': outbreak:StudyStatus
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:whyStopped
+  '@type': rdfs:Property
+  rdfs:comment: A brief explanation of the reason(s) why such clinical study was stopped
+    (for a clinical study that is Suspended, Terminated, or Withdrawn prior to its
+    planned completion as anticipated by the protocol)
+  rdfs:label: whyStopped
+  schema:domainIncludes:
+    '@id': outbreak:StudyStatus
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:StudyDesign
+  '@type': rdfs:Class
+  rdfs:comment: This is the schema for describing the study design of a clinical trial/study
+    for inclusion into outbreak.info resources
+  rdfs:label: StudyDesign
+  rdfs:subClassOf:
+    '@id': schema:Thing
+- '@id': outbreak:studyType
+  '@type': rdfs:Property
+  rdfs:comment: Type of human study, can be subtypes of observational study or interventional
+    studies and may include the temporal relationship of observation period to time
+    of participant enrollment.
+  rdfs:label: studyType
+  schema:domainIncludes:
+    '@id': outbreak:StudyDesign
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:phase
+  '@type': rdfs:Property
+  rdfs:comment: Stage or phase of the study in the U.S. if applicable
+  rdfs:label: phase
+  rdfs:sameAs:
+    '@id': schema:phase
+  schema:domainIncludes:
+    '@id': outbreak:StudyDesign
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:phaseNumber
+  '@type': rdfs:Property
+  rdfs:comment: The number of the phase or stage of the study
+  rdfs:label: phaseNumber
+  schema:domainIncludes:
+    '@id': outbreak:StudyDesign
+  schema:rangeIncludes:
+  - '@id': schema:Number
+- '@id': outbreak:designAllocation
+  '@type': rdfs:Property
+  rdfs:comment: The method by which the study participants were allocated into groups
+  rdfs:label: designAllocation
+  schema:domainIncludes:
+    '@id': outbreak:StudyDesign
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:designModel
+  '@type': rdfs:Property
+  rdfs:comment: The general design of the strategy for assigning interventions to
+    participants in a clinical intervention study OR the general design of the strategy
+    for identifying and following up with participants during an observational study
+  rdfs:label: designModel
+  schema:domainIncludes:
+    '@id': outbreak:StudyDesign
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:designPrimaryPurpose
+  '@type': rdfs:Property
+  rdfs:comment: The primary purpose of the study
+  rdfs:label: designPrimaryPurpose
+  schema:domainIncludes:
+    '@id': outbreak:StudyDesign
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:designWhoMasked
+  '@type': rdfs:Property
+  rdfs:comment: The people who do not know which participants have been assigned to
+    which interventions
+  rdfs:label: designWhoMasked
+  schema:domainIncludes:
+    '@id': outbreak:StudyDesign
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:designStudyText
+  '@type': rdfs:Property
+  rdfs:comment: String description of the study design if structured information not
+    available
+  rdfs:label: designStudyText
+  schema:domainIncludes:
+    '@id': outbreak:StudyDesign
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:Intervention
+  '@type': rdfs:Class
+  rdfs:comment: a schema to describe Interventions discussed in Clinical Studies/Trials
+    for inclusion in outbreak.info Resources
+  rdfs:label: Intervention
+  rdfs:subClassOf:
+    '@id': schema:Thing
+- '@id': outbreak:category
+  '@type': rdfs:Property
+  rdfs:comment: The category of an intervention in the study
+  rdfs:label: category
+  schema:domainIncludes:
+    '@id': outbreak:Intervention
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:ArmGroup
+  '@type': rdfs:Class
+  rdfs:comment: This is the schema for describing arm groups in clinical studies/trials
+    for inclusion in outbreak.info Resources
+  rdfs:label: ArmGroup
+  rdfs:subClassOf:
+    '@id': schema:Thing
+- '@id': outbreak:intervention
+  '@type': rdfs:Property
+  rdfs:comment: The interventions (if any) in this ArmGroup
+  rdfs:label: intervention
+  schema:domainIncludes:
+    '@id': outbreak:ArmGroup
+  schema:rangeIncludes:
+  - '@id': outbreak:Intervention
+- '@id': outbreak:Outcome
+  '@type': rdfs:Class
+  rdfs:comment: This is the schema for describing a Clinical Trial/Study Outcome for
+    inclusion in  outbreak.info Resources
+  rdfs:label: Outcome
+  rdfs:subClassOf:
+    '@id': schema:Thing
+- '@id': outbreak:outcomeMeasure
+  '@type': rdfs:Property
+  rdfs:comment: The outcome measure for the study
+  rdfs:label: outcomeMeasure
+  schema:domainIncludes:
+    '@id': outbreak:Outcome
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:outcomeTimeFrame
+  '@type': rdfs:Property
+  rdfs:comment: The specific time point(s) and overall duration of evaluation must
+    be specified in this section
+  rdfs:label: outcomeTimeFrame
+  schema:domainIncludes:
+    '@id': outbreak:Outcome
+  schema:rangeIncludes:
+  - '@id': schema:Duration
+  - '@id': schema:Text
+- '@id': outbreak:outcomeType
+  '@type': rdfs:Property
+  rdfs:comment: The classification of the outcome measure as either primary, secondary,
+    or exploratory
+  rdfs:label: outcomeType
+  schema:domainIncludes:
+    '@id': outbreak:Outcome
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:Eligibility
+  '@type': rdfs:Class
+  rdfs:comment: This is the schema for describing information about Clinical Trials/Studies
+    eligibility criteria for inclusion in outbreak.info Resources
+  rdfs:label: Eligibility
+  rdfs:subClassOf:
+    '@id': schema:Thing
+- '@id': outbreak:inclusionCriteria
+  '@type': rdfs:Property
+  rdfs:comment: '"criteria for inclusion in the study'
+  rdfs:label: inclusionCriteria
+  schema:domainIncludes:
+    '@id': outbreak:Eligibility
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:minimumAge
+  '@type': rdfs:Property
+  rdfs:comment: the minimum age for a participant to be included in the study
+  rdfs:label: minimumAge
+  schema:domainIncludes:
+    '@id': outbreak:Eligibility
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:maximumAge
+  '@type': rdfs:Property
+  rdfs:comment: the maximum age for a participant to be included in the study
+  rdfs:label: maximumAge
+  schema:domainIncludes:
+    '@id': outbreak:Eligibility
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:gender
+  '@type': rdfs:Property
+  rdfs:comment: the sex requirement to be included in the study
+  rdfs:label: gender
+  schema:domainIncludes:
+    '@id': outbreak:Eligibility
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:genderBased
+  '@type': rdfs:Property
+  rdfs:comment: Boolean for whether or not participation is based on gender
+  rdfs:label: genderBased
+  schema:domainIncludes:
+    '@id': outbreak:Eligibility
+  schema:rangeIncludes:
+  - '@id': schema:Boolean
+- '@id': outbreak:healthyVolunteers
+  '@type': rdfs:Property
+  rdfs:comment: Boolean to indicate whether or not healthy volunteers may be included
+    in the study
+  rdfs:label: healthyVolunteers
+  schema:domainIncludes:
+    '@id': outbreak:Eligibility
+  schema:rangeIncludes:
+  - '@id': schema:Boolean
+- '@id': outbreak:stdAge
+  '@type': rdfs:Property
+  rdfs:comment: the age category of a participant to be included in the study if a
+    minimum and maximum age is not specified
+  rdfs:label: stdAge
+  schema:domainIncludes:
+    '@id': outbreak:Eligibility
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:exclusionCriteria
+  '@type': rdfs:Property
+  rdfs:comment: criteria for exclusion from the study
+  rdfs:label: exclusionCriteria
+  schema:domainIncludes:
+    '@id': outbreak:Eligibility
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:criteriaText
+  '@type': rdfs:Property
+  rdfs:comment: The descriptive criteria as published for the Clinical Trial
+  rdfs:label: criteriaText
+  schema:domainIncludes:
+    '@id': outbreak:Eligibility
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:StudyLocation
+  '@type': rdfs:Class
+  rdfs:comment: This is the schema for describing Clinical Trial/Study locations for
+    inclusion in outbreak.info Resources
+  rdfs:label: StudyLocation
+  rdfs:subClassOf:
+    '@id': schema:Place
+- '@id': outbreak:studyLocation
+  '@type': rdfs:Property
+  rdfs:comment: The location of the study
+  rdfs:label: studyLocation
+  schema:domainIncludes:
+    '@id': outbreak:StudyLocation
+  schema:rangeIncludes:
+  - '@id': schema:Place
+  - '@id': schema:Text
+- '@id': outbreak:studyLocationCity
+  '@type': rdfs:Property
+  rdfs:comment: The city in which the facility used for the study is located
+  rdfs:label: studyLocationCity
+  schema:domainIncludes:
+    '@id': outbreak:StudyLocation
+  schema:rangeIncludes:
+  - '@id': schema:City
+  - '@id': schema:Text
+- '@id': outbreak:studyLocationState
+  '@type': rdfs:Property
+  rdfs:comment: The state or province in which the facility used for the study is
+    located
+  rdfs:label: studyLocationState
+  schema:domainIncludes:
+    '@id': outbreak:StudyLocation
+  schema:rangeIncludes:
+  - '@id': schema:State
+  - '@id': schema:Text
+- '@id': outbreak:studyLocationCountry
+  '@type': rdfs:Property
+  rdfs:comment: The country in which the facility used for the study is located
+  rdfs:label: studyLocationCountry
+  schema:domainIncludes:
+    '@id': outbreak:StudyLocation
+  schema:rangeIncludes:
+  - '@id': schema:Country
+  - '@id': schema:Text
+- '@id': outbreak:studyLocationStatus
+  '@type': rdfs:Property
+  rdfs:comment: The recruitment status of the study at the specific study site
+  rdfs:label: studyLocationStatus
+  schema:domainIncludes:
+    '@id': outbreak:StudyLocation
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:ClinicalTrial
+  '@type': rdfs:Class
+  rdfs:comment: This is the schema for describing the Clinical Trials and other medical
+    studies used for outbreak.info Resources
+  rdfs:label: ClinicalTrial
+  rdfs:subClassOf:
+    '@id': schema:MedicalStudy
+- '@id': outbreak:identifierSource
+  '@type': rdfs:Property
+  rdfs:comment: Source of identifier assignment or type of identifier (NCTid, China
+    CTRid, EudraCT Number, etc.)
+  rdfs:label: identifierSource
+  schema:domainIncludes:
+    '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:dateModifiedType
+  '@type': rdfs:Property
+  rdfs:comment: The type of date. Equivalent to NCT's LastUpdatePostDateType
+  rdfs:label: dateModifiedType
+  schema:domainIncludes:
+    '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:healthConditionIdentifier
+  '@type': rdfs:Property
+  rdfs:comment: Ontological or controlled vocabulary identifier for the health condition
+    or disease
+  rdfs:label: healthConditionIdentifier
+  schema:domainIncludes:
+    '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': schema:Text
+  - '@id': schema:DefinedTerm
+- '@id': outbreak:hasResults
+  '@type': rdfs:Property
+  rdfs:comment: Boolean for if the clinical trial has published any results
+  rdfs:label: hasResults
+  schema:domainIncludes:
+    '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': schema:Boolean
+- '@id': outbreak:studyEvent
+  '@type': rdfs:Property
+  rdfs:comment: an event status such as StudyStart, PrimaryCompletion, Completion,
+    StudyFirstSubmit, StudyFirstSubmitQC, LastUpdateSubmit
+  rdfs:label: studyEvent
+  schema:domainIncludes:
+    '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': outbreak:StudyEvent
+- '@id': outbreak:studyStatus
+  '@type': rdfs:Property
+  rdfs:comment: The status of the study
+  rdfs:label: studyStatus
+  schema:domainIncludes:
+    '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': outbreak:StudyStatus
+- '@id': outbreak:studyDesign
+  '@type': rdfs:Property
+  rdfs:comment: The general design of the study
+  rdfs:label: studyDesign
+  schema:domainIncludes:
+    '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': outbreak:StudyDesign
+- '@id': outbreak:armGroup
+  '@type': rdfs:Property
+  rdfs:comment: The arm or factor of an interventional study
+  rdfs:label: armGroup
+  schema:domainIncludes:
+    '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': outbreak:ArmGroup
+- '@id': outbreak:outcome
+  '@type': rdfs:Property
+  rdfs:comment: The arm or factor of an interventional study
+  rdfs:label: outcome
+  schema:domainIncludes:
+    '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': outbreak:Outcome
+- '@id': outbreak:eligibilityCriteria
+  '@type': rdfs:Property
+  rdfs:comment: eligibility criteria
+  rdfs:label: eligibilityCriteria
+  schema:domainIncludes:
+    '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': outbreak:Eligibility
 - '@id': outbreak:author
-  '@type': rdf:Property
-  marginality: required
-  owl:cardinality: many
-  rdfs:comment: person, people, or organization that created the dataset
+  '@type': rdfs:Property
+  rdfs:comment: The author of this resource, content, or rating
   rdfs:label: author
   rdfs:sameAs:
     '@id': schema:author
   schema:domainIncludes:
-    '@id': outbreak:Dataset
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Protocol
+  - '@id': outbreak:Publication
+  - '@id': outbreak:ClinicalTrial
   schema:rangeIncludes:
   - '@id': outbreak:Person
   - '@id': outbreak:Organization
-- '@id': outbreak:name
-  '@type': rdf:Property
-  marginality: required
-  owl:cardinality: one
-  rdfs:comment: The name of the author as provided by the resource
-  rdfs:label: name
+- '@id': outbreak:dateCreated
+  '@type': rdfs:Property
+  rdfs:comment: Date the record was created
+  rdfs:label: dateCreated
   rdfs:sameAs:
-    '@id': schema:name
+    '@id': schema:dateCreated
   schema:domainIncludes:
-  - '@id': outbreak:Person
-  - '@id': outbreak:Organization
+  - '@id': outbreak:ClinicalTrial
   schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:affiliation
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: The author's affiliation(s)
-  rdfs:label: affiliation
+  - '@id': schema:Date
+- '@id': outbreak:datePublished
+  '@type': rdfs:Property
+  rdfs:comment: Date of first broadcast/publication
+  rdfs:label: datePublished
   rdfs:sameAs:
-    '@id': schema:affiliation
+    '@id': schema:datePublished
   schema:domainIncludes:
-  - '@id': outbreak:Person
-  - '@id': outbreak:Organization
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Protocol
+  - '@id': outbreak:Publication
+  - '@id': outbreak:ClinicalTrial
   schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:dataDownload
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: Available downloads of the dataset
-  rdfs:label: dataDownload
-  rdfs:sameAs:
-    '@id': schema:DataDownload
-  schema:domainIncludes:
-    '@id': outbreak:Dataset
-  schema:rangeIncludes:
-    '@id': outbreak:DataDownload
-- '@id': outbreak:contentUrl
-  '@type': rdf:Property
-  marginality: required
-  owl:cardinality: one
-  rdfs:comment: Link to the location where the dataset can be found, ideally a permanent
-    URL
-  rdfs:label: contentUrl
-  rdfs:sameAs:
-    '@id': schema:distribution
-  schema:domainIncludes:
-    '@id': outbreak:DataDownload
-  schema:rangeIncludes:
-    '@id': schema:URL
+  - '@id': schema:Date
 - '@id': outbreak:dateModified
-  '@type': rdf:Property
-  marginality: required
-  owl:cardinality: one
-  rdfs:comment: Date which the particular DataDownload (file) has been changed
+  '@type': rdfs:Property
+  rdfs:comment: The date on which the CreativeWork was most recently modified or when
+    the item's entry was modified within a DataFeed
   rdfs:label: dateModified
   rdfs:sameAs:
     '@id': schema:dateModified
   schema:domainIncludes:
-    '@id': outbreak:DataDownload
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Protocol
+  - '@id': outbreak:Publication
+  - '@id': outbreak:ClinicalTrial
   schema:rangeIncludes:
-    '@id': schema:Date
+  - '@id': schema:Date
+- '@id': outbreak:keywords
+  '@type': rdfs:Property
+  rdfs:comment: keywords for describing the record
+  rdfs:label: keywords
+  schema:domainIncludes:
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Protocol
+  - '@id': outbreak:Publication
+  - '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:abstract
+  '@type': rdfs:Property
+  rdfs:comment: A short descriptive summary of the publication or study
+  rdfs:label: abstract
+  rdfs:sameAs:
+    '@id': schema:abstract
+  schema:domainIncludes:
+  - '@id': outbreak:Publication
+  - '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:pmid
+  '@type': rdfs:Property
+  rdfs:comment: A pubmed identifier if available
+  rdfs:label: pmid
+  schema:domainIncludes:
+  - '@id': outbreak:CitationObject
+  - '@id': outbreak:Correction
+  - '@id': outbreak:Publication
+  schema:rangeIncludes:
+  - '@id': schema:Integer
+- '@id': outbreak:doi
+  '@type': rdfs:Property
+  rdfs:comment: A doi if available
+  rdfs:label: doi
+  schema:domainIncludes:
+  - '@id': outbreak:CitationObject
+  - '@id': outbreak:Correction
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Publication
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Protocol
+  schema:rangeIncludes:
+  - '@id': schema:Text
 - '@id': outbreak:funding
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: Funding for the generation of the dataset
+  '@type': rdfs:Property
+  rdfs:comment: Funding that supports (sponsors) the collection of this dataset through
+    some kind of financial contribution
   rdfs:label: funding
-  rdfs:sameAs:
-    '@id': outbreak:MonetaryGrant
   schema:domainIncludes:
-    '@id': outbreak:Dataset
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Publication
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Protocol
+  - '@id': outbreak:ClinicalTrial
   schema:rangeIncludes:
-    '@id': outbreak:MonetaryGrant
-- '@id': outbreak:funder
-  '@type': rdf:Property
-  marginality: required
-  owl:cardinality: many
-  rdfs:comment: 'Name of the funding organization ofr the dataset. Note: schema.org/funder
-    and schema.org/Grant have additional fields that can provide more information
-    about the funding organization, if desired'
-  rdfs:label: funder
+  - '@id': schema:MonetaryGrant
+- '@id': outbreak:measurementTechnique
+  '@type': rdfs:Property
+  rdfs:comment: A technique or technology used in this resource
+  rdfs:label: measurementTechnique
   rdfs:sameAs:
-    '@id': schema:funder
+    '@id': schema:measurementTechnique
   schema:domainIncludes:
-    '@id': outbreak:MonetaryGrant
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Protocol
   schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:identifier
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: The identifier of the grant (if available)
-  rdfs:label: identifier
-  rdfs:sameAs:
-    '@id': schema:identifier
-  schema:domainIncludes:
-    '@id': outbreak:MonetaryGrant
-  schema:rangeIncludes:
-    '@id': schema:Text
+  - '@id': schema:Text
+  - '@id': schema:DefinedTerm
 - '@id': outbreak:species
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
+  '@type': rdfs:Property
   rdfs:comment: Species(es) from which dataset has been collected
   rdfs:label: species
-  rdfs:sameAs:
-    '@id': schema:additionalType
   schema:domainIncludes:
-    '@id': outbreak:Dataset
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Analysis
   schema:rangeIncludes:
-    '@id': schema:Text
+  - '@id': schema:Text
+  - '@id': schema:DefinedTerm
 - '@id': outbreak:infectiousAgent
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: The actual infectious agent, such as a specific bacterium
+  '@type': rdfs:Property
+  rdfs:comment: infectious agents(s) which are the focus of the dataset
   rdfs:label: infectiousAgent
-  rdfs:sameAs:
-    '@id': schema:infectiousAgent
   schema:domainIncludes:
-    '@id': outbreak:Dataset
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:identifier
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: Unique identifier for the dataset
-  rdfs:label: identifier
-  rdfs:sameAs:
-    '@id': schema:identifier
-  schema:domainIncludes:
-    '@id': outbreak:Dataset
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:doi
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: DOI for the dataset if available
-  rdfs:label: doi
-  rdfs:sameAs:
-    '@id': schema:identifier
-  schema:domainIncludes:
-    '@id': outbreak:Dataset
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:license
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: License associated with re-use of the dataset
-  rdfs:label: license
-  rdfs:sameAs:
-    '@id': schema:license
-  schema:domainIncludes:
-    '@id': outbreak:Dataset
-  schema:rangeIncludes:
-    '@id': schema:URL
-- '@id': outbreak:citedBy
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: many
-  rdfs:comment: Associated resource (protocols, publications, etc.) that utilized
-    or was derived from this dataset.
-  rdfs:label: citedBy
-  rdfs:sameAs:
-    '@id': 'owl:inverseOf: schema:isBasedOn'
-  schema:domainIncludes:
-    '@id': outbreak:Dataset
-  schema:rangeIncludes:
-  - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
   - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-- '@id': outbreak:name
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: name of the resource (publication, protocol, etc.) utilize or was
-    derived from this dataset
-  rdfs:label: name
-  rdfs:sameAs:
-    '@id': schema:name
-  schema:domainIncludes:
-  - '@id': outbreak:ClinicalTrial
   - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
   schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:type
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: type of resource which utilized or was derived from this dataset
-  rdfs:label: type
-  rdfs:sameAs:
-    '@id': schema:additionalType
+  - '@id': schema:Text
+  - '@id': schema:DefinedTerm
+- '@id': outbreak:infectiousDisease
+  '@type': rdfs:Property
+  rdfs:comment: The disease or medical conditions caused by the infectious agent.
+    Important as some agents may cause multiple diseases
+  rdfs:label: infectiousDisease
   schema:domainIncludes:
-  - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
   - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:identifier
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: identifier for this resource which utilized or was derived from this
-    dataset
-  rdfs:label: identifier
-  rdfs:sameAs:
-    '@id': schema:identifier
-  schema:domainIncludes:
-  - '@id': outbreak:ClinicalTrial
   - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
   schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:isBasedOn
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: many
-  rdfs:comment: Associated resource (guidelines, protocols, publications, etc.) from
-    which this dataset was derived
-  rdfs:label: isBasedOn
-  rdfs:sameAs:
-    '@id': schema:isBasedOn
-  schema:domainIncludes:
-    '@id': outbreak:Dataset
-  schema:rangeIncludes:
-  - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-- '@id': outbreak:name
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: name of the associated resource from which this dataset was derived
-  rdfs:label: name
-  rdfs:sameAs:
-    '@id': schema:name
-  schema:domainIncludes:
-  - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:type
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: Type of resource (publication, analysis, ClinicalTrial, dataset, etc.)
-    from which this dataset was derived
-  rdfs:label: type
-  rdfs:sameAs:
-    '@id': schema:additionalType
-  schema:domainIncludes:
-  - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:identifier
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: Identifier for the resource
-  rdfs:label: identifier
-  rdfs:sameAs:
-    '@id': schema:identifier
-  schema:domainIncludes:
-  - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:versionDate
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: date of the version of the resource from which this dataset was derived.
-    Note this is NOT the same as dateModified, as the dataset may be based on an earlier
-    'dateModified' than is what is available from the resource
-  rdfs:label: versionDate
-  rdfs:sameAs:
-    '@id': schema:releaseDate
-  schema:domainIncludes:
-  - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-  schema:rangeIncludes:
-    '@id': schema:Date
-- '@id': outbreak:relatedTo
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: many
-  rdfs:comment: Other resources related to, but not a derivative of nor derived from
-    this dataset
-  rdfs:label: relatedTo
-  rdfs:sameAs:
-    '@id': schema:relatedTo
-  schema:domainIncludes:
-    '@id': outbreak:Dataset
-  schema:rangeIncludes:
-  - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-- '@id': outbreak:name
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: name of related resource
-  rdfs:label: name
-  rdfs:sameAs:
-    '@id': schema:name
-  schema:domainIncludes:
-  - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:type
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: type of related resource
-  rdfs:label: type
-  rdfs:sameAs:
-    '@id': schema:additionalType
-  schema:domainIncludes:
-  - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:identifier
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: identifier (if available) of related resource
-  rdfs:label: identifier
-  rdfs:sameAs:
-    '@id': schema:identifier
-  schema:domainIncludes:
-  - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-  schema:rangeIncludes:
-    '@id': schema:Text
+  - '@id': schema:Text
+  - '@id': schema:DefinedTerm
 - '@id': outbreak:topicCategory
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
+  '@type': rdfs:Property
   rdfs:comment: Applicable outbreak.info category
   rdfs:label: topicCategory
-  rdfs:sameAs:
-    '@id': schema:about
   schema:domainIncludes:
-    '@id': outbreak:Dataset
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Publication
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Protocol
+  - '@id': outbreak:ClinicalTrial
   schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:keywords
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: keywords
-  rdfs:label: keywords
-  rdfs:sameAs:
-    '@id': schema:keywords
+  - '@id': schema:Text
+- '@id': outbreak:isBasedOn
+  '@type': rdfs:Property
+  rdfs:comment: A citation to a resource (eg- publication, protocol, etc.) on which
+    this resource was derived (stored as an object, not a string)
+  rdfs:label: isBasedOn
   schema:domainIncludes:
-    '@id': outbreak:Dataset
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Publication
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Protocol
+  - '@id': outbreak:ClinicalTrial
   schema:rangeIncludes:
-    '@id': schema:Text
+  - '@id': outbreak:CitationObject
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Publication
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Protocol
+  - '@id': outbreak:ClinicalTrial
+  - '@id': schema:SoftwareApplication
+  - '@id': schema:CreativeWork
+- '@id': outbreak:isRelatedTo
+  '@type': rdfs:Property
+  rdfs:comment: A citation to a resource (eg- publication, protocol, etc.) which is
+    related to the resource but is not a derivative nor was derived from the resource
+    (stored as an object, not a string)
+  rdfs:label: isRelatedTo
+  schema:domainIncludes:
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Publication
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Protocol
+  - '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': outbreak:CitationObject
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Publication
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Protocol
+  - '@id': outbreak:ClinicalTrial
+  - '@id': schema:SoftwareApplication
+  - '@id': schema:CreativeWork
+- '@id': outbreak:citedBy
+  '@type': rdfs:Property
+  rdfs:comment: A citation to a resource (eg- publication, protocol, etc.) which is
+    derived from this resource (stored as an object, not a string)
+  rdfs:label: citedBy
+  rdfs:sameAs:
+    '@id': 'owl:inverseOf: outbreak:isBasedOn'
+  schema:domainIncludes:
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Publication
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Protocol
+  - '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': outbreak:CitationObject
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Publication
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Protocol
+  - '@id': outbreak:ClinicalTrial
+  - '@id': schema:SoftwareApplication
+  - '@id': schema:CreativeWork
 - '@id': outbreak:curatedBy
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The source from which this Analysis was identified for inclusion into
-    Outbreak.info. Provides provenance for a resource which was curated by another
+  '@type': rdfs:Property
+  rdfs:comment: The source from which this Dataset was identified for inclusion into
+    Outbreak.info. Provides provenance for a resource which was curated by another.
   rdfs:label: curatedBy
-  rdfs:sameAs:
-    '@id': schema:citation
   schema:domainIncludes:
-    '@id': outbreak:Dataset
-  schema:rangeIncludes:
-  - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
   - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-- '@id': outbreak:name
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: name of the source from which this Analysis was identified for inclusion
-  rdfs:label: name
-  rdfs:sameAs:
-    '@id': schema:name
-  schema:domainIncludes:
-  - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
   - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:url
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The corresponding url for the item in the source from which this Analysis
-    was identified (if available)
-  rdfs:label: url
-  rdfs:sameAs:
-    '@id': schema:url
-  schema:domainIncludes:
-  - '@id': outbreak:ClinicalTrial
   - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
   - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:versionDate
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: The last date when items were pulled from the source
-  rdfs:label: versionDate
-  rdfs:sameAs:
-    '@id': schema:releaseDate
-  schema:domainIncludes:
   - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
   schema:rangeIncludes:
-    '@id': schema:Date
+  - '@id': outbreak:Person
+  - '@id': outbreak:Organization
+  - '@id': outbreak:CitationObject
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Publication
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Protocol
+  - '@id': outbreak:ClinicalTrial
+  - '@id': schema:SoftwareApplication
+  - '@id': schema:CreativeWork
 - '@id': outbreak:curationDate
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The date this resource was added to outbreak.info, or the date when
-    this resource was updated in outbreak.info
+  '@type': rdfs:Property
+  rdfs:comment: The date this resource was added into outbreak.info, or was updated
+    in outbreak.info.
   rdfs:label: curationDate
-  rdfs:sameAs:
-    '@id': schema:releaseDate
   schema:domainIncludes:
-    '@id': outbreak:Dataset
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Publication
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Protocol
+  - '@id': outbreak:ClinicalTrial
   schema:rangeIncludes:
-    '@id': schema:Date
-- '@id': outbreak:Protocol
-  '@type': rdfs:Class
-  rdfs:comment: This is the schema for describing the Protocol schema used for outbreak.info.
-  rdfs:label: Protocol
-  rdfs:subClassOf:
-    '@id': schema:HowTo
-  schema:isPartOf:
-    '@id': https://discovery.biothings.io/view/outbreak/
-- '@id': outbreak:Publication
-  '@type': rdfs:Class
-  rdfs:comment: This is the schema for describing the Publication schema used for
-    outbreak.info.
-  rdfs:label: Publication
-  rdfs:subClassOf:
-    '@id': schema:ScholarlyArticle
-  schema:isPartOf:
-    '@id': https://discovery.biothings.io/view/outbreak/
-- '@id': outbreak:ClinicalTrial
-  '@type': rdfs:Class
-  rdfs:comment: This is the schema for describing the ClinicalTrial schema used for
-    outbreak.info.
-  rdfs:label: ClinicalTrial
-  rdfs:subClassOf:
-    '@id': schema:MedicalStudy
-  schema:isPartOf:
-    '@id': https://discovery.biothings.io/view/outbreak/
-'@id': https://discovery.biothings.io/view/outbreak/
+  - '@id': schema:Date
+- '@id': outbreak:evaluations
+  '@type': rdf:Property
+  rdfs:comment: One or more reviews, ratings, or other evaluations of this resource
+  rdfs:label: evaluations
+  schema:domainIncludes:
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Publication
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Protocol
+  - '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': schema:Review
+  - '@id': schema:Rating
+  - '@id': schema:AggregateRating

--- a/yaml/outbreak_Protocol.json
+++ b/yaml/outbreak_Protocol.json
@@ -1,173 +1,888 @@
 {
   "@context": {
-    "outbreak": "https://discovery.biothings.io/view/outbreak/",
-    "owl": "http://www.w3.org/2002/07/owl/",
-    "rdf": "http://www.w3.org/1999/02/22/-rdf-syntax-ns/",
-    "rdfs": "http://www.w3.org/2000/01/rdf/-schema/",
-    "schema": "http://schema.org/"
+    "schema": "http://schema.org/",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "outbreak": "http://discovery.biothings.io/view/"
   },
-  "@id": "https://discovery.biothings.io/view/outbreak/",
   "@graph": [
-    {
-      "@id": "outbreak:Product",
-      "@type": "rdfs:Class",
-      "rdfs:label": "Product",
-      "rdfs:comment": "This is the schema for describing the Product schema used for outbreak.info.",
-      "rdfs:subClassOf": {
-        "@id": "schema:Product"
-      },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
-      }
-    },
-    {"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"The name of the material or reagent","rdfs:label":"name","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":{"@id":"outbreak:Product"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:manufacturer","@type":"rdf:Property","rdfs:comment":"The name of the manufacturer of the material, biosample, or reagent","rdfs:label":"manufacturer","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:manufacturer"},"schema:domainIncludes":{"@id":"outbreak:Product"},"schema:rangeIncludes":{"@id":"outbreak:Organization"}},{"@id":"outbreak:brand","@type":"rdf:Property","rdfs:comment":"The name of the brand of the reagent, material, or biological sample (if different from the manufacturer)","rdfs:label":"brand","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:brand"},"schema:domainIncludes":{"@id":"outbreak:Product"},"schema:rangeIncludes":[{"@id":"schema:Text"},{"@id":"outbreak:Organization"}]},{"@id":"outbreak:identifier","@type":"rdf:Property","rdfs:comment":"The catalog number or identifier of the material or reagent","rdfs:label":"identifier","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":{"@id":"outbreak:Product"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:type","@type":"rdf:Property","rdfs:comment":"The type of material. Reagent, PPE, biological samples, etc.","rdfs:label":"type","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:addtionalType"},"schema:domainIncludes":{"@id":"outbreak:Product"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {
-      "@id": "outbreak:Instrument",
-      "@type": "rdfs:Class",
-      "rdfs:label": "Instrument",
-      "rdfs:comment": "This is the schema for describing the Instrument schema used for outbreak.info.",
-      "rdfs:subClassOf": {
-        "@id": "schema:Product"
-      },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
-      }
-    },  
-    {"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"The name of the instrument","rdfs:label":"name","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":{"@id":"outbreak:Instrument"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:manufacturer","@type":"rdf:Property","rdfs:comment":"The name of the manufacturer of the instrument","rdfs:label":"manufacturer","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:manufacturer"},"schema:domainIncludes":{"@id":"outbreak:Instrument"},"schema:rangeIncludes":{"@id":"outbreak:Organization"}},{"@id":"outbreak:brand","@type":"rdf:Property","rdfs:comment":"The brand of the instrument","rdfs:label":"brand","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:brand"},"schema:domainIncludes":{"@id":"outbreak:Instrument"},"schema:rangeIncludes":[{"@id":"schema:Text"},{"@id":"outbreak:Organization"}]},{"@id":"outbreak:model","@type":"rdf:Property","rdfs:comment":"The model number of the instrument","rdfs:label":"model","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:model"},"schema:domainIncludes":{"@id":"outbreak:Instrument"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {
-      "@id": "outbreak:Organization",
-      "@type": "rdfs:Class",
-      "rdfs:label": "Organization",
-      "rdfs:comment": "This is the schema for describing the Organization schema used for outbreak.info.",
-      "rdfs:subClassOf": {
-        "@id": "schema:Organization"
-      },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
-      }
-    },
-    {"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"The name of the organization, team or group","rdfs:label":"name","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":{"@id":"outbreak:Organization"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:alternateName","@type":"rdf:Property","rdfs:comment":"Alternative names or commonly used abbreviations for the organization, team or group","rdfs:label":"alternateName","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:alternateName"},"schema:domainIncludes":{"@id":"outbreak:Organization"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:affiliation","@type":"rdf:Property","rdfs:comment":"An overarching consortia, multi-institutional team or group in which the organization\/team\/group is a member or affiliate","rdfs:label":"affiliation","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:affiliation"},"schema:domainIncludes":{"@id":"outbreak:Organization"},"schema:rangeIncludes":{"@id":"outbreak:Organization"}},{"@id":"outbreak:affiliationStatus","@type":"rdf:Property","rdfs:comment":"The status of the organization's membership or affiliation in the overarching consortial, multi-institutional team or group (current, past)","rdfs:label":"affiliationStatus","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":{"@id":"outbreak:Organization"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:members","@type":"rdf:Property","rdfs:comment":"Members of this organization, team, or group","rdfs:label":"members","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:members"},"schema:domainIncludes":{"@id":"outbreak:Organization"},"schema:rangeIncludes":[{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"}]},{"@id":"outbreak:membershipStatus","@type":"rdf:Property","rdfs:comment":"Status of the members of this organization","rdfs:label":"membershipStatus","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":{"@id":"outbreak:Organization"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:isRelatedTo","@type":"rdf:Property","rdfs:comment":"A resource which a person played a role","rdfs:label":"isRelatedTo","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:isRelatedTo"},"schema:domainIncludes":{"@id":"outbreak:Organization"},"schema:rangeIncludes":[{"@id":"schema:CreativeWork"},{"@id":"schema:HowTo"}]},{"@id":"outbreak:class","@type":"rdf:Property","rdfs:comment":"A classification of the organization by a resource. Eg- for ClinicalTrials funders, it's [\"U.S. National Institutes of Health\", \"Other U.S. Federal agencies\", \"Industry\", \"All others\"]","rdfs:label":"class","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:addtionalType"},"schema:domainIncludes":[{"@id":"schema:CreativeWork"},{"@id":"schema:HowTo"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:role","@type":"rdf:Property","rdfs:comment":"The role of an organization in its involvement with a resource","rdfs:label":"role","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":[{"@id":"schema:CreativeWork"},{"@id":"schema:HowTo"}],"schema:rangeIncludes":{"@id":"schema:Text"}},
     {
       "@id": "outbreak:Person",
       "@type": "rdfs:Class",
+      "rdfs:comment": "This is the Person schema for describing authors and people for outbreak.info resources",
       "rdfs:label": "Person",
-      "rdfs:comment": "This is the schema for describing the Person schema used for outbreak.info.",
       "rdfs:subClassOf": {
         "@id": "schema:Person"
       },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
+      "$validation": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "The name of the person.",
+            "type": "string"
+          },
+          "alternateName": {
+            "description": "An alias for the person.",
+            "type": "string"
+          },
+          "familyName": {
+            "description": "Family name. In the U.S., the last name of an Person. This can be used along with givenName instead of the name property.",
+            "type": "string"
+          },
+          "givenName": {
+            "description": "Given name. In the U.S., the first name of a Person. This can be used along with familyName instead of the name property.",
+            "type": "string"
+          },
+          "affiliation": {
+            "description": "An organization that this person is affiliated with. For example, a school/university, a club, or a team.",
+            "oneOf": [
+              {
+                "$ref": "#/definitions/baseOrgObject"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/baseOrgObject"
+                }
+              }
+            ]
+          },
+          "orcid": {
+            "description": "the ORCID ID of the person",
+            "type": "string"
+          },
+          "role": {
+            "description": "authorship, sponsorship, or other contribution role played by the person or organization in the creation of this resource",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            ]
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "definitions":{
+            "baseOrgObject": {
+                "@type": "outbreak:Organization",
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "alternateName": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ]   
+            }
+        }
       }
     },
-    {"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"The name of the person","rdfs:label":"name","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":{"@id":"outbreak:Person"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:alternateName","@type":"rdf:Property","rdfs:comment":"Alternative ways in which the person's name is included in a record","rdfs:label":"alternateName","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:alternateName"},"schema:domainIncludes":{"@id":"outbreak:Person"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:givenName","@type":"rdf:Property","rdfs:comment":"The given name of the person","rdfs:label":"givenName","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:givenName"},"schema:domainIncludes":{"@id":"outbreak:Person"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:familyName","@type":"rdf:Property","rdfs:comment":"The family name of the person","rdfs:label":"familyName","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:familyName"},"schema:domainIncludes":{"@id":"outbreak:Person"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:affiliation","@type":"rdf:Property","rdfs:comment":"The organization with which the person is affiliated or has membership in","rdfs:label":"affiliation","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:affiliation"},"schema:domainIncludes":{"@id":"outbreak:Person"},"schema:rangeIncludes":{"@id":"outbreak:Organization"}},{"@id":"outbreak:affiliationStatus","@type":"rdf:Property","rdfs:comment":"The status of the person's membership or affiliation in an organization, team or group (current, past)","rdfs:label":"affiliationStatus","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:addtionalType"},"schema:domainIncludes":{"@id":"outbreak:Person"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:orcid","@type":"rdf:Property","rdfs:comment":"The ORCID ID of the person","rdfs:label":"orcid","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":{"@id":"outbreak:Person"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:isRelatedTo","@type":"rdf:Property","rdfs:comment":"A resource which a person played a role","rdfs:label":"isRelatedTo","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:isRelatedTo"},"schema:domainIncludes":{"@id":"outbreak:Person"},"schema:rangeIncludes":[{"@id":"schema:CreativeWork"},{"@id":"schema:HowTo"}]},{"@id":"outbreak:role","@type":"rdf:Property","rdfs:comment":"The role a person played in the creation of a resource","rdfs:label":"role","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:addtionalType"},"schema:domainIncludes":[{"@id":"schema:CreativeWork"},{"@id":"schema:HowTo"}],"schema:rangeIncludes":{"@id":"schema:Text"}},
+    {
+      "@id": "outbreak:orcid",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "the ORCID ID of the person",
+      "rdfs:label": "orcid",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Person"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:Organization",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the organization schema for describing authors, funders and other organizations referenced by outbreak.info resources",
+      "rdfs:label": "Organization",
+      "rdfs:subClassOf": {
+        "@id": "schema:Organization"
+      },
+      "$validation": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "The name of the organization.",
+            "type": "string"
+          },
+          "alternateName": {
+            "description": "An alias or acronym for the organization.",
+            "type": "string"
+          },
+          "affiliation": {
+            "description": "consortia or other organizations with which this organization is affiliated",
+            "oneOf": [
+              {
+                "$ref": "#/definitions/baseOrgObject"
+              },
+              {
+                "type": "array",
+                "items": {
+                    "$ref": "#/definitions/baseOrgObject"
+                }
+              }
+            ]
+          },
+          "class": {
+            "description": "A classification of the organization by a resource. Eg- for ClinicalTrials funders, it's [U.S. National Institutes of Health, Other U.S. Federal agencies, Industry, All others]",
+            "type": "string"
+          },
+          "role": {
+            "description": "The role of an organization in its involvement with a resource",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+              }
+            ]
+          },
+          "members": {
+            "description": "Members of this organization, team, or group",
+            "oneOf": [
+              {
+                "$ref": "#/definitions/basePersonObject"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/basePersonObject"
+                }
+              }
+            ]
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "definitions": {
+            "baseOrgObject":{
+                "description": "Affiliated Organization",
+                "@type": "outbreak:Organization",
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "description": "name of the organization",
+                    "type": "string"
+                  },
+                  "alternateName": {
+                    "description": "Alternate name or Acronym for the organization.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ]              
+            },
+            "basePersonObject":{
+                "@type": "outbreak:Person",
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "alternateName": {
+                        "type": "string"
+                    },
+                    "givenName": {
+                        "type": "string"
+                    },
+                    "familyName": {
+                        "type": "string"
+                    },
+                    "orcid": {
+                        "type": "string"
+                    },
+                    "affiliation": {
+                        "description": "consortia or other organizations with which this person is affiliated",
+                        "oneOf": [
+                          {
+                            "$ref": "#/definitions/baseOrgObject"
+                          },
+                          {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/baseOrgObject"
+                            }
+                          }
+                        ]
+                      }
+                },
+                "required": [
+                    "name"
+                ]                
+            }
+        }
+      }
+    },
+    {
+      "@id": "outbreak:affiliation",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "consortia or other organizations with which this organization is affiliated",
+      "rdfs:label": "affiliation",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Organization"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "outbreak:Organization"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:members",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Members of this organization, team, or group",
+      "rdfs:label": "members",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Organization"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "outbreak:Person"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:class",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "A classification of the organization by a resource. Eg- for ClinicalTrials funders, it's [U.S. National Institutes of Health, Other U.S. Federal agencies, Industry, All others]",
+      "rdfs:label": "class",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Organization"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:role",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "authorship, sponsorship, or other contribution role played by the person or organization in the creation of this resource. In a Clinical Study/Trial ArmGroup, it's equivalent to the ArmType in ClinicalTrials.gov",
+      "rdfs:label": "role",
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Person"},
+        {"@id": "outbreak:Organization"},
+        {"@id": "outbreak:ArmGroup"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
     {
       "@id": "outbreak:MonetaryGrant",
       "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing the MonetaryGrant schema used for outbreak.info",
       "rdfs:label": "MonetaryGrant",
-      "rdfs:comment": "This is the schema for describing the MonetaryGrant schema used for outbreak.info.",
       "rdfs:subClassOf": {
         "@id": "schema:MonetaryGrant"
       },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
+      "$validation": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "The name of the grant or funding.",
+            "type": "string"
+          },
+          "identifier": {
+            "description": "The funding or grant id",
+            "type": "string"
+          },
+          "url": {
+            "description": "URL of the grant or funding award.",
+            "type": "string",
+            "format": "uri"
+          },
+          "funder": {
+            "description": "The organization(s) that supported (sponsored) the grant through some kind of financial contribution.",
+            "oneOf": [
+              {
+                "$ref": "#/definitions/baseOrgObject"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/baseOrgObject"
+                }
+              }
+            ]
+          },
+          "recipient": {
+            "description": "The person or organization to whom or to which the grant was awarded",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/basePersonObject"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/basePersonObject"
+                }
+              },
+              {
+                "$ref": "#/definitions/baseOrgObject"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/baseOrgObject"
+                }
+              }
+            ]
+          }   
+        },
+        "required": [
+          "funder"
+        ],
+        "definitions": {
+            "baseOrgObject":{
+                "description": "Affiliated Organization",
+                "@type": "outbreak:Organization",
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "description": "name of the organization",
+                    "type": "string"
+                  },
+                  "alternateName": {
+                    "description": "Alternate name or Acronym for the organization.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ]              
+            },
+            "basePersonObject":{
+                "@type": "outbreak:Person",
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "alternateName": {
+                        "type": "string"
+                    },
+                    "givenName": {
+                        "type": "string"
+                    },
+                    "familyName": {
+                        "type": "string"
+                    },
+                    "orcid": {
+                        "type": "string"
+                    },
+                    "affiliation": {
+                        "description": "consortia or other organizations with which this person is affiliated",
+                        "oneOf": [
+                          {
+                            "$ref": "#/definitions/baseOrgObject"
+                          },
+                          {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/baseOrgObject"
+                            }
+                          }
+                        ]
+                      }
+                },
+                "required": [
+                    "name"
+                ]                
+            }
+        }
       }
     },
-    {"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"The name of the monetary grant","rdfs:label":"name","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":{"@id":"outbreak:MonetaryGrant"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:identifier","@type":"rdf:Property","rdfs:comment":"The grant ID or an identifier associated with the grant","rdfs:label":"identifier","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":{"@id":"outbreak:MonetaryGrant"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:url","@type":"rdf:Property","rdfs:comment":"The url for the grant (if available)","rdfs:label":"url","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:url"},"schema:domainIncludes":{"@id":"outbreak:MonetaryGrant"},"schema:rangeIncludes":{"@id":"schema:URL"}},{"@id":"outbreak:funder","@type":"rdf:Property","rdfs:comment":"The funding organization of the grant","rdfs:label":"funder","owl:cardinality":"many","marginality":"required","rdfs:sameAs":{"@id":"schema:funder"},"schema:domainIncludes":{"@id":"outbreak:MonetaryGrant"},"schema:rangeIncludes":{"@id":"outbreak:Organization"}},{"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"The name of the funding organization","rdfs:label":"name","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":{"@id":"outbreak:Organization"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:recipient","@type":"rdf:Property","rdfs:comment":"The person or organization to whom or to which the grant was awarded","rdfs:label":"recipient","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:recipient"},"schema:domainIncludes":{"@id":"outbreak:MonetaryGrant"},"schema:rangeIncludes":[{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"}]},{"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"The name of the recipient of the grant","rdfs:label":"name","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":[{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:affiliation","@type":"rdf:Property","rdfs:comment":"The affiliation of the recipient of the grant","rdfs:label":"affiliation","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:affiliation"},"schema:domainIncludes":[{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"}],"schema:rangeIncludes":{"@id":"schema:Text"}},
     {
-      "@id": "outbreak:Analysis",
+      "@id": "outbreak:recipient",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The person or organization to whom or to which the grant was awarded",
+      "rdfs:label": "recipient",
+      "schema:domainIncludes": {
+        "@id": "outbreak:MonetaryGrant"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Person"
+        },
+        {
+          "@id": "schema:Organization"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:DataDownload",
       "@type": "rdfs:Class",
-      "rdfs:label": "Analysis",
-      "rdfs:comment": "This is the schema for describing the Analysis schema used for outbreak.info.",
+      "rdfs:comment": "This is the schema for describing the DataDownload schema used for outbreak.info.",
+      "rdfs:label": "DataDownload",
+      "rdfs:subClassOf": {
+        "@id": "schema:DataDownload"
+      }
+    },
+    {
+      "@id": "outbreak:CitationObject",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "A citation object for a resource which is cited by the subject (ie- is a derivative of the subject), related to the subject, or from which the subject was based on (ie- is derived from).",
+      "rdfs:label": "CitationObject",
       "rdfs:subClassOf": {
         "@id": "schema:CreativeWork"
       },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
+      "$validation": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "The name or title of the cited resource.",
+            "type": "string"
+          },
+          "url": {
+            "description": "URL of the cited resource.",
+            "type": "string",
+            "format": "uri"
+          },
+          "identifier": {
+            "description": "An identifier associated with the citation",
+            "type": "string"
+          },
+          "citeText": {
+            "description": "The bibliographic citation for the referenced resource as is provided",
+            "type": "string"
+          },
+          "versionDate": {
+            "description": "The version date of the resource used at the time of the creation of the citation as certain resources (protocols, datasets) may change frequently over time.",
+            "format": "date",
+            "type": "string"
+          },
+          "pmid": {
+            "description": "A pubmed identifier if available",
+            "type": "string"
+          },
+          "doi": {
+            "description": "A doi if available",
+            "type": "string"
+          },
+          "sourceType": {
+            "description": "The @type of resource",
+            "enum": [
+              "Dataset",
+              "Publication",
+              "ClinicalTrial",
+              "Analysis",
+              "Protocol",
+              "SoftwareApplication",
+              "CreativeWork"
+            ]
+          }
+        },
+        "required": [
+          "name",
+          "sourceType"
+        ]
       }
+    },
+    {
+      "@id": "outbreak:citeText",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The bibliographic citation for the referenced resource as is provided",
+      "rdfs:label": "citeText",
+      "schema:domainIncludes": {
+        "@id": "outbreak:CitationObject"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:versionDate",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The version date of the resource used at the time of the creation of the citation as certain resources (protocols, datasets) may change frequently over time.",
+      "rdfs:label": "versionDate",
+      "schema:domainIncludes": {
+        "@id": "outbreak:CitationObject"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Date"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:sourceType",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The type of resource",
+      "rdfs:label": "sourceType",
+      "schema:domainIncludes": {
+        "@id": "outbreak:CitationObject"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
     },
     {
       "@id": "outbreak:Dataset",
       "@type": "rdfs:Class",
-      "rdfs:label": "Dataset",
       "rdfs:comment": "This is the schema for describing the Dataset schema used for outbreak.info.",
+      "rdfs:label": "Dataset",
       "rdfs:subClassOf": {
         "@id": "schema:Dataset"
+      }
+    },
+    {
+      "@id": "outbreak:Correction",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing a Correction used for outbreak.info. A Correction is a specialized subclass of the CitationObject",
+      "rdfs:label": "Correction",
+      "rdfs:subClassOf": {
+        "@id": "schema:CreativeWork"
+      }
+    },
+    {
+      "@id": "outbreak:correctionType",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Type of notice or correction: (correction, retraction, expression of convern, withdrawal, erratum, update, correction/republication, preprint, peer reviewed version)",
+      "rdfs:label": "correctionType",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Correction"
       },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:Publication",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing the Publication used for outbreak.info",
+      "rdfs:label": "Publication",
+      "rdfs:subClassOf": {
+        "@id": "schema:MedicalScholarlyArticle"
+      }
+    },
+    {
+      "@id": "outbreak:journalName",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The name of the journal (or publisher if journal name not available)",
+      "rdfs:label": "journalName",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Publication"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:journalNameAbbrevation",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "abbreviated Journal Title (note, this should be autopopulated)",
+      "rdfs:label": "journalNameAbbrevation",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Publication"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:volumeNumber",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Volume number of journal in which the article was published",
+      "rdfs:label": "volumeNumber",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Publication"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:issueNumber",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Issue of journal in which the article was published",
+      "rdfs:label": "issueNumber",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Publication"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:Analysis",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing an Analysis for inclusion in outbreak.info resources",
+      "rdfs:label": "Analysis",
+      "rdfs:subClassOf": {
+        "@id": "schema:CreativeWork"
+      }
+    },
+    {
+      "@id": "outbreak:domainUrl",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The domain name or main site on which webpage or specific url can be found",
+      "rdfs:label": "domainUrl",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Analysis"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:URL"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:assumption",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Statement of assumptions / limitations of the model",
+      "rdfs:label": "assumption",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Analysis"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:analysisTechnique",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "A technique or technology used in a analysis",
+      "rdfs:label": "analysisTechnique",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Analysis"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:analysisTopic",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The underlying question, goal, or aim of the analysis",
+      "rdfs:label": "analysisTopic",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Analysis"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:Product",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing a reagent, material, sample, or some other product used in a protocol resource in outbreak.info",
+      "rdfs:label": "Product",
+      "rdfs:subClassOf": {
+        "@id": "schema:Product"
+      },
+      "$validation": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "manufacturer": {
+            "description": "The manufacturer of the reagent, material, sample or product.",
+            "@type": "outbreak:Organization",
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "alternatename": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ]
+          },
+          "category": {
+            "description": "The type of product (chemical/reagent, biological sample, PPE, or other.",
+            "oneOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "chemical or reagent",
+                  "biological sample",
+                  "PPE",
+                  "other"
+                ]
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "chemical or reagent",
+                    "biological sample",
+                    "PPE",
+                    "other"
+                  ]
+                }
+              }
+            ]
+          },
+          "brand": {
+            "description": "The brand(s) associated with the product",
+            "type": "string"
+          },
+          "identifier": {
+            "description": "An identifier for the product (preferably the manufacturer's identifier for the product)",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the reagent/sample/material/product",
+            "type": "string"
+          },
+          "url": {
+            "description": "URL of the product",
+            "type": "string",
+            "format": "uri"
+          }
+        },
+        "required": [
+          "name"
+        ]
+      }
+    },
+    {
+      "@id": "outbreak:Instrument",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing an instrument used in a protocol resource listed in outbreak.info",
+      "rdfs:label": "Instrument",
+      "rdfs:subClassOf": {
+        "@id": "schema:Product"
+      },
+      "$validation": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "manufacturer": {
+            "description": "The manufacturer of the instrument",
+            "@type": "outbreak:Organization",
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "alternateName": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ]
+          },
+          "model": {
+            "description": "The model of the instrument",
+            "type": "string"
+          },
+          "brand": {
+            "description": "The brand(s) associated with the instrument",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the instrument",
+            "type": "string"
+          },
+          "url": {
+            "description": "URL of the product page for the instrument",
+            "type": "string",
+            "format": "uri"
+          }
+        },
+        "required": [
+          "name"
+        ]
       }
     },
     {
       "@id": "outbreak:Protocol",
       "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing the Protocols for outbreak.info Resources.",
       "rdfs:label": "Protocol",
-      "rdfs:comment": "This is the schema for describing the Protocol schema used for outbreak.info.",
       "rdfs:subClassOf": {
         "@id": "schema:HowTo"
       },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
-      },
       "$validation": {
-          "$schema": "http://json-schema.org/draft-07/schema#",
-          "type": "object",
-          "properties": {
-            "name": {
-              "description": "name of the protocol",
-              "type": "string"
-            },
-            "description": {
-              "description": "description of the protocol",
-              "type": "string"
-            },
-            "datePublished": {
-              "description": "PublicationDate of the protocol online if available",
-              "format": "date",
-              "type": "string"
-            },
-            "url": {
-              "description": "url where the protocol can be found",
-              "oneOf": [
-                {
-                  "type": "string",
-                  "format": "uri"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "type": "string",
-                    "format": "uri"
-                  }
-                }
-              ]
-            },
-            "identifier": {
-              "description": "An identifier associated with the protocol (if available)",
-              "type": "string"
-            },
-            "doi": {
-              "description": "A DOI associated with the protocol if available",
-              "type": "string"
-            },
-            "license": {
-              "description": "License",
-              "type": "string"
-            },
-            "warning": {
-              "description": "Precautions, warnings, and/or safety warnings associated with the protocol",
-              "oneOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                }
-              ]
-            },
-            "dateModified": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "The name of the protocol",
+            "type": "string"
+          },
+          "description": {
+            "description": "A description of the protocol",
+            "type": "string"
+          },
+          "datePublished": {
+            "description": "Publication Date of the protocol online if available",
+            "format": "date",
+            "type": "string"
+          },
+          "url": {
+            "description": "url where the protocol can be found",
+            "type": "string",
+            "format": "uri"
+          },
+          "identifier": {
+            "description": "An identifier associated with the protocol",
+            "type": "string"
+          },
+          "doi": {
+            "description": "the DOI of the protocol",
+            "type": "string"
+          },
+          "license": {
+            "description": "A license document that applies to this content, typically indicated by URL.",
+            "type": "string"
+          },
+          "warning": {
+            "description": "Precautions, warnings, and/or safety warnings associated with or highlighted by the protocol",
+            "type": "string"
+          },
+          "dateModified": {
               "description": "Date of protocol update",
               "oneOf": [
                 {
@@ -182,24 +897,14 @@
                   }
                 }
               ]
-            },
-            "correctionNote": {
-              "description": "statement of what was updated/changed since prior version",
-              "oneOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                }
-              ]
-            },
-            "status": {
-              "description": "The status of the protocol",
-              "enum": [
+          },
+          "correctionNote": {
+            "description": "statement of what was updated/changed since prior version",
+            "type": "string"
+          },
+          "protocolStatus": {
+            "description": "The status of the protocol",
+            "enum": [
                 "Working--In use by author",
                 "Working--not in use by author",
                 "Working--in use by others",
@@ -207,8 +912,8 @@
                 "In Development",
                 "Deprecated"
               ]
-            },
-            "material": {
+          },
+          "material": {
               "description": "the reagent, biological sample, or material such as PPE source materials) used or tested in this protocol",
               "oneOf": [
                 {
@@ -222,7 +927,7 @@
                 }
               ]
             },
-            "instrument": {
+          "instrument": {
               "description": "For LabProtocols it would be a laboratory equipment use by a person to follow one or more steps described in this LabProtocol.",
               "oneOf": [
                 {
@@ -235,8 +940,8 @@
                   }
                 }
               ]
-            },
-            "measurementTechnique": {
+          },
+          "measurementTechnique": {
                 "description": "A technique or technology used in this protocol.",
                 "oneOf": [{
                     "$ref": "#/definitions/controlledVocabulary"
@@ -248,8 +953,8 @@
                     }
                   }
                 ]
-            },
-            "protocolSetting": {
+          },
+          "protocolSetting": {
               "description": "The type of 'protocol' based on setting in which it would apply",
               "enum": [
                     "clinical",
@@ -258,8 +963,8 @@
                     "computational",
                     "public"
               ]
-            },
-            "protocolCategory": {
+          },
+          "protocolCategory": {
               "description": "The type of 'protocol' based on degree of specificity and purpose",
               "enum": [
                     "protocol",
@@ -267,8 +972,8 @@
                     "policy",
                     "guideline"
               ]
-            },
-            "usedToGenerate": {
+          },
+          "usedToGenerate": {
               "description": "Type of evidence/data generated by the protocol",
               "oneOf": [
                 {
@@ -281,8 +986,8 @@
                   }
                 }
               ]
-            },
-            "inComplianceWith": {
+          },
+          "inComplianceWith": {
               "description": "Guidelines or Standards to which these protocols adhere. ie- GMP, GCP, other EQUATOR guidelines. Useful for selecting protocols where certain standards/guidelines must be met",
               "oneOf": [
                 {
@@ -295,8 +1000,8 @@
                   }
                 }
               ]
-            },
-            "keywords": {
+          },
+          "keywords": {
               "description": "keywords",
               "oneOf": [
                 {
@@ -309,8 +1014,8 @@
                   }
                 }
               ]
-            },
-            "topicCategory": {
+          },
+          "topicCategory": {
               "description": "Applicable outbreak.info category",
               "oneOf": [
                 {
@@ -347,7 +1052,8 @@
                     "Behavioral Research",
                     "Epidemiology",
                     "Classical Epidemiology",
-                    "Molecular Epidemiology"
+                    "Molecular Epidemiology",
+                    "Information Sciences"
                   ]
                 },
                 {
@@ -386,14 +1092,15 @@
                         "Behavioral Research",
                         "Epidemiology",
                         "Classical Epidemiology",
-                        "Molecular Epidemiology"
+                        "Molecular Epidemiology",
+                        "Information Sciences"
                       ]
                   }
                 }
               ]
 
-            },
-            "author": {
+          },
+          "author": {
               "description": "person, people, or organization that created the protocol",
               "anyOf": [
                 {
@@ -415,8 +1122,8 @@
                   }
                 }
               ]
-            },
-            "funding": {
+          },
+          "funding": {
               "description": "The funder of the Protocol",
               "oneOf": [
                 {
@@ -429,8 +1136,8 @@
                   }
                 }
               ]
-            },
-            "citedBy": {
+          },
+          "citedBy": {
               "description": "Associated guidelines, protocols, publications, etc. that include, adapt, modify, expand, etc. this protocol.",
               "oneOf": [
                 {
@@ -443,8 +1150,8 @@
                   }
                 }
               ]
-            },
-            "isBasedOn": {
+          },
+          "isBasedOn": {
               "description": "Associated resource (guidelines, protocols, publications, etc.) from which this protocol was derived",
               "oneOf": [
                 {
@@ -457,8 +1164,8 @@
                   }
                 }
               ]
-            },
-            "isRelatedTo": {
+          },
+          "isRelatedTo": {
               "description": "Other resources related to, but not a derivative of nor derived from this protocol",
               "oneOf": [
                 {
@@ -471,8 +1178,8 @@
                   }
                 }
               ]
-            },
-            "curatedBy": {
+          },
+          "curatedBy": {
             "description": "The source from which this Protocol was identified for inclusion into Outbreak.info. Provides provenance for a resource which was curated by another.",
             "anyOf": [{
                 "$ref": "#/definitions/citation"
@@ -503,24 +1210,46 @@
               }
             ]
           },
-            "curationDate":{
+          "curationDate":{
             "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
             "type": "string",
             "format": "date"
-          }
           },
-          "required": [
-            "name",
-            "description",
-            "datePublished",
-            "url",
-            "identifier",
-            "author"
-          ],
-          "definitions": {
-            "controlledVocabulary": {
+          "evaluations":{
+              "description": "Reviews, Ratings, or other types of evaluations on this resource",
+              "anyOf":[
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/reviewObject"
+                }
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/ratingObject"
+                }
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/aggregateRatingObject"
+                }
+              }
+            ]
+            }  
+        },
+        "required": [
+          "description",
+          "identifier",
+          "name",
+          "url",
+          "author"
+        ],
+        "definitions": {
+          "controlledVocabulary": {
               "definition": "collection of vocabulary terms defined in ontologies",
-              "@type": "CreativeWork",
+              "@type": "DefinedTerm",
               "type": "string",
               "strict": false,
               "vocabulary": {
@@ -535,10 +1264,10 @@
                   "http://purl.obolibrary.org/obo/OBI_0000011"
                 ]
               }
-            },
-            "miscControlledVocabulary": {
+          },
+          "miscControlledVocabulary": {
               "definition": "collection of vocabulary terms defined in ontologies",
-              "@type": "CreativeWork",
+              "@type": "DefinedTerm",
               "type": "string",
               "strict": false,
               "vocabulary": {
@@ -549,165 +1278,8 @@
                   "http://purl.obolibrary.org/obo/ECO_0000000"
                 ]
               }
-            },
-            "baseOrgObject":{
-            "description": "A barebones Organization object to work around recursion issues in DDE",
-            "@type": "Organization",
-            "type": "object",
-            "properties": {
-              "name": {
-                "description": "name of the organization",
-                "type": "string"
-              },
-              "alternateName": {
-                "description": "Alternate name or Acronym for the organization.",
-                "type": "string"
-              }
-            },
-            "required": [
-              "name"
-            ]              
-          }, 
-            "person": {
-              "description": "Reusable person definition",
-              "@type": "Person",
-              "type": "object",
-              "properties": {
-                "name": {
-                  "type": "string"
-                },
-                "givenName": {
-                  "type": "string"
-                },
-                "familyName": {
-                  "type": "string"
-                },
-                "orcid": {
-                  "type": "string"
-                },
-                "affiliation": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/definitions/baseOrgObject"
-                    },
-                    {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/definitions/baseOrgObject"
-                      }
-                    }
-                  ]
-                }
-              },
-              "required": [
-                "name"
-              ]
-            },
-            "memberObject": {
-              "description": "Reusable person definition accounting for recursion issues in DDE",
-              "@type": "Person",
-              "type": "object",
-              "properties": {
-                "name": {
-                  "type": "string"
-                },
-                "givenName": {
-                  "type": "string"
-                },
-                "familyName": {
-                  "type": "string"
-                },
-                "orcid": {
-                  "type": "string"
-                },
-                "affiliation": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/definitions/baseOrgObject"
-                    },
-                    {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/definitions/baseOrgObject"
-                      }
-                    }
-                  ]
-                }
-              },
-              "required": [
-                "name"
-              ]
-            },
-            "organization": {
-            "description": "Reusable organization definition",
-            "@type": "Organization",
-            "type": "object",
-            "properties": {
-              "name": {
-                "type": "string"
-              },
-              "alternateName": {
-                "type": "string"
-              },
-              "affiliation": {
-                "$ref": "#/definitions/baseOrgObject"
-              },
-              "members": {
-                 "oneOf": [
-                    {
-                      "$ref": "#/definitions/memberObject"
-                    },
-                    {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/definitions/memberObject"
-                      }
-                    }
-                  ]
-              }
-            },
-            "required": [
-              "name"
-            ]
           },
-            "funding": {
-                "type": "object",
-                "@type": "MonetaryGrant",
-                "description": "Information about funding support",
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "description": "The name of the monetary grant that funded/funds the protocol"
-                  },
-                  "identifier": {
-                    "type": "string",
-                    "description": "Unique identifier(s) for the grant(s) used to fund the protocol"
-                  },
-                  "funder": {
-                    "description": "name of the funding organization",
-                    "oneOf": [
-                  {
-                    "$ref": "#/definitions/baseOrgObject"
-                  },
-                  {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/definitions/baseOrgObject"
-                    }
-                  }
-                ]
-                  },
-                  "url": {
-                    "type": "string",
-                    "format": "uri",
-                    "description": "award URL"
-                  }
-                },
-                "required": [
-                  "funder"
-                ]
-          },
-            "product": {
+          "product": {
               "type": "object",
               "@type": "Product",
               "description": "the reagent, biological sample, or material such as PPE source materials) used or tested in this protocol",
@@ -738,7 +1310,7 @@
                     }
                   ]
                 },
-                "type": {
+                "category": {
                   "description": "The type of material. Reagent, PPE, biological samples, etc.",
                   "enum": [
                     "chemical or reagent",
@@ -752,7 +1324,7 @@
                 "name"
               ]
             },
-            "instrument": {
+          "instrument": {
               "type": "object",
               "@type": "Product",
               "description": "A laboratory equipment use by a person to follow one or more steps described in this protocol.",
@@ -778,95 +1350,1628 @@
                 "name"
               ]
             },
-            "citation": {
-                "description": "A citation object for a resource which is cited by the protocol (ie- is a derivative of the protocol) , related to the protocol, or from which the protocol was based on (ie- is derived from).",
-                "@type": "Thing",
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "description": "Name of or title of the citation",
-                    "type": "string"
-                  },
-                  "identifier": {
-                    "description": "An identifier associated with the citation",
-                    "type": "string"
-                  },
-                  "pmid": {
-                    "description": "A pubmed identifier if available",
-                    "type": "string"
-                  },
-                  "doi": {
-                    "description": "A doi if available",
-                    "type": "string"
-                  },
-                  "type": {
-                    "description": "The type of resource",
-                    "enum": [
-                      "Dataset",
-                      "Publication",
-                      "ClinicalTrial", 
-                      "Analysis",
-                      "Protocol", 
-                      "SoftwareApplication",
-                      "Other"
-                      ]
-                  },
-                  "url": {
-                    "description": "The url of the resource cited.",
+          "baseOrgObject":{
+            "description": "A barebones Organization object to work around recursion issues in DDE",
+            "@type": "outbreak:Organization",
+            "type": "object",
+            "properties": {
+              "name": {
+                "description": "name of the organization",
+                "type": "string"
+              },
+              "alternateName": {
+                "description": "Alternate name or Acronym for the organization.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ]              
+          }, 
+          "person": {
+              "description": "Reusable person definition",
+              "@type": "outbreak:Person",
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "givenName": {
+                  "type": "string"
+                },
+                "familyName": {
+                  "type": "string"
+                },
+                "orcid": {
+                  "type": "string"
+                },
+                "affiliation": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/definitions/baseOrgObject"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/baseOrgObject"
+                      }
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "name"
+              ]
+            },
+          "memberObject": {
+              "description": "Reusable person definition accounting for recursion issues in DDE",
+              "@type": "outbreak:Person",
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "givenName": {
+                  "type": "string"
+                },
+                "familyName": {
+                  "type": "string"
+                },
+                "orcid": {
+                  "type": "string"
+                },
+                "affiliation": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/definitions/baseOrgObject"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/baseOrgObject"
+                      }
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "name"
+              ]
+            },
+          "organization": {
+            "description": "Reusable organization definition",
+            "@type": "outbreak:Organization",
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "alternateName": {
+                "type": "string"
+              },
+              "affiliation": {
+                "$ref": "#/definitions/baseOrgObject"
+              },
+              "members": {
+                 "oneOf": [
+                    {
+                      "$ref": "#/definitions/memberObject"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/memberObject"
+                      }
+                    }
+                  ]
+              }
+            },
+            "required": [
+              "name"
+            ]
+          },
+          "funding": {
+            "type": "object",
+            "@type": "outbreak:MonetaryGrant",
+            "description": "Information about funding support",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "The name of the monetary grant that funded/funds the Dataset"
+              },
+              "identifier": {
+                "type": "string",
+                "description": "Unique identifier(s) for the grant(s) used to fund the Dataset"
+              },
+              "funder": {
+                "description": "name of the funding organization",
+                "oneOf": [
+              {
+                "$ref": "#/definitions/baseOrgObject"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/baseOrgObject"
+                }
+              }
+            ]
+              },
+              "url": {
+                "type": "string",
+                "format": "uri",
+                "description": "award URL"
+              }
+            },
+            "required": [
+              "funder"
+            ]
+          },
+          "citation": {
+            "description": "A citation object for a resource which is cited by the protocol (ie- is a derivative of the protocol), related to the protocol, or from which the protocol was based on (ie- is derived from).",
+            "@type": "outbreak:CitationObject",
+            "type": "object",
+            "properties": {
+              "name": {
+                "description": "Name of or title of the citation",
+                "type": "string"
+              },
+              "identifier": {
+                "description": "An identifier associated with the citation",
+                "type": "string"
+              },
+              "pmid": {
+                "description": "A pubmed identifier if available",
+                "type": "string"
+              },
+              "doi": {
+                "description": "A doi if available",
+                "type": "string"
+              },
+              "sourceType": {
+                "description": "The type of resource",
+                "enum": [
+                  "Dataset",
+                  "Publication",
+                  "ClinicalTrial", 
+                  "Analysis",
+                  "Protocol", 
+                  "SoftwareApplication",
+                  "CreativeWork"
+                  ]
+              },
+              "url": {
+                "description": "The url of the resource cited.",
+                "type": "string",
+                "format": "uri"
+              },
+              "versionDate": {
+                "description": "The version date of the resource used at the time of the creation of the citation as certain resources (protocols, datasets) may change frequently over time.",
+                "type": "string",
+                "format": "date"
+              },
+              "citeText": {
+                "description": "The bibliographic citation for the referenced resource as is provided",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "sourceType"
+            ]
+          },
+          "reviewObject": {
+            "description": "A review or descriptive evaluation of the resource",
+            "@type": "Review",
+            "type": "object",
+            "properties": {
+              "name": {
                     "type": "string",
-                    "format": "uri"
+                    "description": "The name of the review"
                   },
-                  "versionDate": {
-                    "description": "The version date of the resource used at the time of the creation of the citation as certain resources (protocols, datasets) may change frequently over time.",
+              "reviewAspect":{
+                    "description": "This Review or Rating is relevant to this part or facet of the itemReviewed",
+                    "type": "string"
+                  },
+              "reviewBody": {
+                      "description": "The actual body of the review.",
+                      "type": "string"
+                  },
+              "reviewRating": {
+                "description": "The rating given in this review",
+                    "$ref": "#/definitions/ratingObject"      
+                },
+              "author": {
+                    "description": "The author of this content or rating.",
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/person"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/person"
+                      }
+                      },
+                      {
+                        "$ref": "#/definitions/organization"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/organization"
+                      }
+                }
+              ]
+            },
+              "curationDate":{
+                    "description": "The date this evaluation was added into outbreak.info, or was updated in outbreak.info.",
+                    "type": "string",
+                    "format": "date"
+                  }
+                },
+              "required": [
+              ]
+            },
+          "ratingObject": {
+            "description": "A rating or categorical evaluation of the resource",
+            "@type": "Rating",
+            "type": "object",
+            "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "The name of the rating"
+                  },
+                  "ratingExplanation": {
+                    "type": "string",
+                    "description": "An explanation of the rating"    
+                  },
+                  "ratingValue": {
+                    "type": "string",
+                    "description": "The rating for the content."
+                  },
+                  "reviewAspect": {
+                    "type": "string",
+                    "description": "This Review or Rating is relevant to this part or facet of the itemReviewed"
+                  },
+                  "author": {
+                    "description": "The author of this content or rating.",
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/person"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/person"
+                      }
+                      },
+                      {
+                        "$ref": "#/definitions/organization"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/organization"
+                      }
+                }
+              ]
+            },
+                  "curationDate":{
+                    "description": "The date this evaluation was added into outbreak.info, or was updated in outbreak.info.",
+                    "type": "string",
+                    "format": "date"
+                  }
+                },
+            "required": [
+            ]
+          },
+          "aggregateRatingObject": {
+            "description": "A cumulative evaluation of the resource",
+            "@type": "AggregateRating",
+            "type": "object",
+            "properties": {
+                "name": {
+                "type": "string",
+                "description": "The name of the aggregate rating"
+                },
+                "ratingValue": {
+                    "type": "string",
+                    "description": "The rating for the content."
+                },
+                "reviewAspect":{
+                  "description": "This Review or Rating is relevant to this part or facet of the itemReviewed",
+                  "type": "string"
+                },
+                "author": {
+                    "description": "The author of this content or rating.",
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/person"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/person"
+                      }
+                      },
+                      {
+                        "$ref": "#/definitions/organization"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/organization"
+                      }
+                }
+              ]
+            },
+                "curationDate": {
+                    "description": "The date this evaluation was added into outbreak.info, or was updated in outbreak.info.",
                     "type": "string",
                     "format": "date"
                   },
-                  "citeText": {
-                      "description": "The bibliographic citation for the referenced resource as is provided",
-                      "type": "string"
-                    }
-                },
-                "required": [
-                  "name",
-                  "type"
-                ]
-              }
+                "reviews": {
+                  "anyOf": [
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/reviewObject"
+                        }
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/ratingObject"
+                        }
+                      }
+                      
+                  ]
+                }
+            }
           }
+        }
       }
     },
-    {"@id":"outbreak:url","@type":"rdf:Property","rdfs:comment":"url where the protocol can be found","rdfs:label":"url","owl:cardinality":"many","marginality":"required","rdfs:sameAs":{"@id":"schema:url"},"schema:domainIncludes":{"@id":"outbreak:Protocol"},"schema:rangeIncludes":{"@id":"schema:URL"}},{"@id":"outbreak:identifier","@type":"rdf:Property","rdfs:comment":"An identifier associated with the protocol","rdfs:label":"identifier","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":{"@id":"outbreak:Protocol"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:doi","@type":"rdf:Property","rdfs:comment":"A DOI associated with the protocol if available","rdfs:label":"doi","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":{"@id":"outbreak:Protocol"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"name of the protocol","rdfs:label":"name","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":{"@id":"outbreak:Protocol"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:description","@type":"rdf:Property","rdfs:comment":"description of the protocol","rdfs:label":"description","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:description"},"schema:domainIncludes":{"@id":"outbreak:Protocol"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:status","@type":"rdf:Property","rdfs:comment":"The status of the protocol","rdfs:label":"status","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:creativeWorkStatus"},"schema:domainIncludes":{"@id":"outbreak:Protocol"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:measurementTechnique","@type":"rdf:Property","rdfs:comment":"This is the measurement technique or assay type covered described by the protocol","rdfs:label":"measurementTechnique","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"outbreak:measurementTechnique"},"schema:domainIncludes":{"@id":"outbreak:Protocol"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:protocolSetting","@type":"rdf:Property","rdfs:comment":"The type of research setting in which a \"protocol\" is appropriate, such as 'clinical', 'experimental', 'field', 'computational'","rdfs:label":"protocolSetting","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":{"@id":"outbreak:Protocol"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:protocolCategory","@type":"rdf:Property","rdfs:comment":"The type of \"protocol\" such as guideline, procedure, policy, etc.","rdfs:label":"protocolCategory","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":{"@id":"outbreak:Protocol"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:author","@type":"rdf:Property","rdfs:comment":"person, people, or organization that created the protocol","rdfs:label":"author","owl:cardinality":"many","marginality":"required","rdfs:sameAs":{"@id":"schema:author"},"schema:domainIncludes":{"@id":"outbreak:Protocol"},"schema:rangeIncludes":[{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"}]},{"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"The name of the author as provided by the resource","rdfs:label":"name","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":[{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:affiliation","@type":"rdf:Property","rdfs:comment":"The author's affiliation(s)","rdfs:label":"affiliation","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:affiliation"},"schema:domainIncludes":[{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:material","@type":"rdf:Property","rdfs:comment":"the reagent, biological sample, or material such as PPE source materials) used or tested in this protocol","rdfs:label":"material","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:Product"},"schema:domainIncludes":{"@id":"outbreak:Protocol"},"schema:rangeIncludes":{"@id":"outbreak:Product"}},{"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"The name of the material or reagent","rdfs:label":"name","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":{"@id":"outbreak:Product"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:manufacturer","@type":"rdf:Property","rdfs:comment":"The manufacturer, brand, or vendor of the material or reagent","rdfs:label":"manufacturer","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:manufacturer"},"schema:domainIncludes":{"@id":"outbreak:Product"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:identifier","@type":"rdf:Property","rdfs:comment":"The catalog number or identifier of the material or reagent","rdfs:label":"identifier","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":{"@id":"outbreak:Product"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:type","@type":"rdf:Property","rdfs:comment":"Type of material","rdfs:label":"type","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":{"@id":"outbreak:Product"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:instrument","@type":"rdf:Property","rdfs:comment":"For LabProtocols it would be a laboratory equipment use by a person to follow one or more steps described in this LabProtocol.","rdfs:label":"instrument","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:Product"},"schema:domainIncludes":{"@id":"outbreak:Protocol"},"schema:rangeIncludes":{"@id":"outbreak:Instrument"}},{"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"The name\/model number of the instrument","rdfs:label":"name","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":{"@id":"outbreak:Instrument"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:manufacturer","@type":"rdf:Property","rdfs:comment":"The manufacturer, brand, or vendor of the instrument","rdfs:label":"manufacturer","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:manufacturer"},"schema:domainIncludes":{"@id":"outbreak:Instrument"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:warning","@type":"rdf:Property","rdfs:comment":"Precautions, warnings, and\/or safety warnings associated with the protocol","rdfs:label":"warning","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:warning"},"schema:domainIncludes":{"@id":"outbreak:Protocol"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:license","@type":"rdf:Property","rdfs:comment":"License","rdfs:label":"license","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:license"},"schema:domainIncludes":{"@id":"outbreak:Protocol"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:funding","@type":"rdf:Property","rdfs:comment":"Funding for the generation of the protocol","rdfs:label":"funding","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"outbreak:MonetaryGrant"},"schema:domainIncludes":{"@id":"outbreak:Protocol"},"schema:rangeIncludes":{"@id":"outbreak:MonetaryGrant"}},{"@id":"outbreak:funder","@type":"rdf:Property","rdfs:comment":"The funder of the study","rdfs:label":"funder","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:funder"},"schema:domainIncludes":{"@id":"outbreak:MonetaryGrant"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:identifier","@type":"rdf:Property","rdfs:comment":"The identifier of the grant (if available)","rdfs:label":"identifier","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":{"@id":"outbreak:MonetaryGrant"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:datePublished","@type":"rdf:Property","rdfs:comment":"PublicationDate of the protocol online if available","rdfs:label":"datePublished","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:datePublished"},"schema:domainIncludes":{"@id":"outbreak:Protocol"},"schema:rangeIncludes":{"@id":"schema:Date"}},{"@id":"outbreak:dateModified","@type":"rdf:Property","rdfs:comment":"Date of protocol update","rdfs:label":"dateModified","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:dateModified"},"schema:domainIncludes":{"@id":"outbreak:Protocol"},"schema:rangeIncludes":{"@id":"schema:Date"}},
-    {"@id":"outbreak:correctionNote","@type":"rdf:Property","rdfs:comment":"statement of what was updated\/changed since prior version","rdfs:label":"correctionNote","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:correction"},"schema:domainIncludes":{"@id":"outbreak:Protocol"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:citedBy","@type":"rdf:Property","rdfs:comment":"Associated guidelines, protocols, publications, etc. that include, adapt, modify, expand, etc. this protocol.","rdfs:label":"citedBy","owl:cardinality":"many","marginality":"optional","owl:inverseOf":{"@id":"schema:isBasedOn"},"schema:domainIncludes":{"@id":"outbreak:Protocol"},"schema:rangeIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}]},{"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"name of the resource (publication, protocol, etc.) which was derived from this protocol","rdfs:label":"name","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:type","@type":"rdf:Property","rdfs:comment":"type of resource which was derived from this protocol","rdfs:label":"type","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:additionalType"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:identifier","@type":"rdf:Property","rdfs:comment":"identifier for this resource which was derived from this protocol","rdfs:label":"identifier","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:isBasedOn","@type":"rdf:Property","rdfs:comment":"Associated resource (guidelines, protocols, publications, etc.) from which this protocol was derived","rdfs:label":"isBasedOn","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:isBasedOn"},"schema:domainIncludes":{"@id":"outbreak:Protocol"},"schema:rangeIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}]},{"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"name of the associated resource from which this protocol was derived","rdfs:label":"name","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:type","@type":"rdf:Property","rdfs:comment":"Type of resource (publication, analysis, ClinicalTrial, dataset, etc.) from which this protocol was derived","rdfs:label":"type","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:additionalType"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:identifier","@type":"rdf:Property","rdfs:comment":"Identifier for the resource","rdfs:label":"identifier","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:versionDate","@type":"rdf:Property","rdfs:comment":"date of the version of the resource from which this protocol was derived. Note this is NOT the same as dateModified, as the protocol may be based on an earlier 'dateModified' than is what is available from the resource","rdfs:label":"versionDate","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:releaseDate"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Date"}},{"@id":"outbreak:isRelatedTo","@type":"rdf:Property","rdfs:comment":"Other resources related to, but not a derivative of nor derived from this protocol","rdfs:label":"isRelatedTo","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:isRelatedTo"},"schema:domainIncludes":{"@id":"outbreak:Protocol"},"schema:rangeIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}]},{"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"name of related resource","rdfs:label":"name","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:type","@type":"rdf:Property","rdfs:comment":"type of related resource","rdfs:label":"type","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:additionalType"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:identifier","@type":"rdf:Property","rdfs:comment":"identifier (if available_ of related resource","rdfs:label":"identifier","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:topicCategory","@type":"rdf:Property","rdfs:comment":"Applicable outbreak.info category","rdfs:label":"topicCategory","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:about"},"schema:domainIncludes":{"@id":"outbreak:Protocol"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:keywords","@type":"rdf:Property","rdfs:comment":"keywords","rdfs:label":"keywords","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:keywords"},"schema:domainIncludes":{"@id":"outbreak:Protocol"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:usedToGenerate","@type":"rdf:Property","rdfs:comment":"Type of evidence\/data generated by the protocol","rdfs:label":"usedToGenerate","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":{"@id":"outbreak:Protocol"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:inComplianceWith","@type":"rdf:Property","rdfs:comment":"Guidelines or Standards to which these protocols adhere. ie- GMP, GCP, other EQUATOR guidelines. Useful for selecting protocols where certain standards\/guidelines must be met","rdfs:label":"inComplianceWith","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":{"@id":"outbreak:Protocol"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:duration","@type":"rdf:Property","rdfs:comment":"The time it takes to actually carry out the protocol, in ISO 8601 date format.","rdfs:label":"duration","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:performTime"},"schema:domainIncludes":{"@id":"outbreak:Protocol"},"schema:rangeIncludes":[{"@id":"schema:Duration"},{"@id":"schema:Text"}]},
-    {"@id":"outbreak:curatedBy","@type":"rdf:Property","rdfs:comment":"The source from which this protocol was identified for inclusion into Outbreak.info. Provides provenance for a resource which was curated by another","rdfs:label":"curatedBy","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:citation"},"schema:domainIncludes":{"@id":"outbreak:Protocol"},"schema:rangeIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"},{"@id":"schema:Thing"}]},
-    {"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"name of the source from which this protocol was identified for inclusion","rdfs:label":"name","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:curationDate","@type":"rdf:Property","rdfs:comment":"The date this resource was added to outbreak.info, or the date when this resource was updated in outbreak.info","rdfs:label":"curationDate","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:releaseDate"},"schema:domainIncludes":{"@id":"outbreak:Protocol"},"schema:rangeIncludes":{"@id":"schema:Date"}},
     {
-      "@id": "outbreak:Publication",
-      "@type": "rdfs:Class",
-      "rdfs:label": "Publication",
-      "rdfs:comment": "This is the schema for describing the Publication schema used for outbreak.info.",
-      "rdfs:subClassOf": {
-        "@id": "schema:ScholarlyArticle"
+      "@id": "outbreak:warning",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Precautions, warnings, and/or safety warnings associated with or highlighted by the protocol",
+      "rdfs:label": "warning",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Protocol"
       },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:correctionNote",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "statement of what was updated/changed since prior version",
+      "rdfs:label": "correctionNote",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Protocol"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:protocolStatus",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The status of the protocol",
+      "rdfs:label": "protocolStatus",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Protocol"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:instrument",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "A laboratory equipment use by a person to follow one or more steps described in this Protocol",
+      "rdfs:label": "instrument",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Protocol"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "outbreak:Instrument"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:protocolSetting",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The type of 'protocol' based on setting in which it would apply",
+      "rdfs:label": "protocolSetting",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Protocol"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:protocolCategory",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The type of 'protocol' based on degree of specificity and purpose",
+      "rdfs:label": "protocolCategory",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Protocol"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:usedToGenerate",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Type of evidence/data generated by the protocol",
+      "rdfs:label": "usedToGenerate",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Protocol"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:inComplianceWith",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Guidelines or Standards to which these protocols adhere. ie- GMP, GCP, other EQUATOR guidelines. Useful for selecting protocols where certain standards/guidelines must be met",
+      "rdfs:label": "inComplianceWith",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Protocol"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    }, 
+    {
+      "@id": "outbreak:StudyEvent",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing StudyEvents, a class that describes categorical events in Clinical Trials added to outbreak.info",
+      "rdfs:label": "StudyEvent",
+      "rdfs:subClassOf": {
+        "@id": "schema:Thing"
       }
     },
     {
+      "@id": "outbreak:studyEventType",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Type of the event status such as StudyStart, PrimaryCompletion, Completion, StudyFirstSubmit, StudyFirstSubmitQC, LastUpdateSubmit",
+      "rdfs:label": "studyEventType",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyEvent"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:studyEventDate",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The corresponding/actual date of the study event (ie- the StartDate, Primary CompletionDate, CompletionDate, StudyFirstSubmitDate, StudyFirstSubmitQCDate, LastUpdateSubmitDate)",
+      "rdfs:label": "studyEventDate",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyEvent"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Date"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:studyEventDateType",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "the type of date provided (actual, anticipated, or estimated)",
+      "rdfs:label": "studyEventDateType",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyEvent"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },  
+    {
+      "@id": "outbreak:StudyStatus",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing the status of a ClinicalTrial resource in outbreak.info",
+      "rdfs:label": "StudyStatus",
+      "rdfs:subClassOf": {
+        "@id": "schema:Thing"
+      }
+    },
+    {
+      "@id": "outbreak:status",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The recruitment status of the study",
+      "rdfs:label": "status",
+      "rdfs:sameAs":{"@id":"schema:status"},
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyStatus"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:statusExpandedAccess",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Flag for whether or not the study has expanded Access status",
+      "rdfs:label": "statusExpandedAccess",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyStatus"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Boolean"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:statusDate",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The date that the status was verified. Equivalent to NCT's StatusVerifiedDate",
+      "rdfs:label": "statusDate",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyStatus"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Date"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:enrollmentCount",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The number of participants enrolled in the study",
+      "rdfs:label": "enrollmentCount",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyStatus"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Number"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:enrollmentType",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The type of estimation used to determine the enrollmentCount (actual counts, target size, etc.)",
+      "rdfs:label": "enrollmentType",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyStatus"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:whyStopped",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "A brief explanation of the reason(s) why such clinical study was stopped (for a clinical study that is Suspended, Terminated, or Withdrawn prior to its planned completion as anticipated by the protocol)",
+      "rdfs:label": "whyStopped",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyStatus"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:StudyDesign",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing the study design of a clinical trial/study for inclusion into outbreak.info resources",
+      "rdfs:label": "StudyDesign",
+      "rdfs:subClassOf": {
+        "@id": "schema:Thing"
+      }
+    },
+    {
+      "@id": "outbreak:studyType",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Type of human study, can be subtypes of observational study or interventional studies and may include the temporal relationship of observation period to time of participant enrollment.",
+      "rdfs:label": "studyType",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyDesign"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:phase",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Stage or phase of the study in the U.S. if applicable",
+      "rdfs:label": "phase",
+      "rdfs:sameAs":{"@id":"schema:phase"},
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyDesign"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:phaseNumber",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The number of the phase or stage of the study",
+      "rdfs:label": "phaseNumber",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyDesign"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Number"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:designAllocation",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The method by which the study participants were allocated into groups",
+      "rdfs:label": "designAllocation",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyDesign"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:designModel",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The general design of the strategy for assigning interventions to participants in a clinical intervention study OR the general design of the strategy for identifying and following up with participants during an observational study",
+      "rdfs:label": "designModel",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyDesign"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:designPrimaryPurpose",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The primary purpose of the study",
+      "rdfs:label": "designPrimaryPurpose",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyDesign"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:designWhoMasked",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The people who do not know which participants have been assigned to which interventions",
+      "rdfs:label": "designWhoMasked",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyDesign"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:designStudyText",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "String description of the study design if structured information not available",
+      "rdfs:label": "designStudyText",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyDesign"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:Intervention",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "a schema to describe Interventions discussed in Clinical Studies/Trials for inclusion in outbreak.info Resources",
+      "rdfs:label": "Intervention",
+      "rdfs:subClassOf": {
+        "@id": "schema:Thing"
+      }
+    },
+    {
+      "@id": "outbreak:category",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The category of an intervention in the study",
+      "rdfs:label": "category",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Intervention"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:ArmGroup",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing arm groups in clinical studies/trials for inclusion in outbreak.info Resources",
+      "rdfs:label": "ArmGroup",
+      "rdfs:subClassOf": {
+        "@id": "schema:Thing"
+      }
+    },
+    {
+      "@id": "outbreak:intervention",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The interventions (if any) in this ArmGroup",
+      "rdfs:label": "intervention",
+      "schema:domainIncludes": {
+        "@id": "outbreak:ArmGroup"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "outbreak:Intervention"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:Outcome",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing a Clinical Trial/Study Outcome for inclusion in  outbreak.info Resources",
+      "rdfs:label": "Outcome",
+      "rdfs:subClassOf": {
+        "@id": "schema:Thing"
+      }
+    },
+    {
+      "@id": "outbreak:outcomeMeasure",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The outcome measure for the study",
+      "rdfs:label": "outcomeMeasure",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Outcome"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:outcomeTimeFrame",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The specific time point(s) and overall duration of evaluation must be specified in this section",
+      "rdfs:label": "outcomeTimeFrame",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Outcome"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Duration"
+        },
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:outcomeType",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The classification of the outcome measure as either primary, secondary, or exploratory",
+      "rdfs:label": "outcomeType",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Outcome"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:Eligibility",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing information about Clinical Trials/Studies eligibility criteria for inclusion in outbreak.info Resources",
+      "rdfs:label": "Eligibility",
+      "rdfs:subClassOf": {
+        "@id": "schema:Thing"
+      }
+    },
+    {
+      "@id": "outbreak:inclusionCriteria",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "\"criteria for inclusion in the study",
+      "rdfs:label": "inclusionCriteria",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Eligibility"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:minimumAge",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "the minimum age for a participant to be included in the study",
+      "rdfs:label": "minimumAge",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Eligibility"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:maximumAge",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "the maximum age for a participant to be included in the study",
+      "rdfs:label": "maximumAge",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Eligibility"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:gender",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "the sex requirement to be included in the study",
+      "rdfs:label": "gender",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Eligibility"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:genderBased",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Boolean for whether or not participation is based on gender",
+      "rdfs:label": "genderBased",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Eligibility"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Boolean"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:healthyVolunteers",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Boolean to indicate whether or not healthy volunteers may be included in the study",
+      "rdfs:label": "healthyVolunteers",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Eligibility"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Boolean"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:stdAge",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "the age category of a participant to be included in the study if a minimum and maximum age is not specified",
+      "rdfs:label": "stdAge",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Eligibility"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:exclusionCriteria",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "criteria for exclusion from the study",
+      "rdfs:label": "exclusionCriteria",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Eligibility"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:criteriaText",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The descriptive criteria as published for the Clinical Trial",
+      "rdfs:label": "criteriaText",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Eligibility"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:StudyLocation",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing Clinical Trial/Study locations for inclusion in outbreak.info Resources",
+      "rdfs:label": "StudyLocation",
+      "rdfs:subClassOf": {
+        "@id": "schema:Place"
+      }
+    },
+    {
+      "@id": "outbreak:studyLocation",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The location of the study",
+      "rdfs:label": "studyLocation",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyLocation"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Place"
+        },
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:studyLocationCity",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The city in which the facility used for the study is located",
+      "rdfs:label": "studyLocationCity",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyLocation"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:City"
+        },
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:studyLocationState",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The state or province in which the facility used for the study is located",
+      "rdfs:label": "studyLocationState",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyLocation"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:State"
+        },
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:studyLocationCountry",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The country in which the facility used for the study is located",
+      "rdfs:label": "studyLocationCountry",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyLocation"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Country"
+        },
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:studyLocationStatus",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The recruitment status of the study at the specific study site",
+      "rdfs:label": "studyLocationStatus",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyLocation"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+{
       "@id": "outbreak:ClinicalTrial",
       "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing the Clinical Trials and other medical studies used for outbreak.info Resources",
       "rdfs:label": "ClinicalTrial",
-      "rdfs:comment": "This is the schema for describing the ClinicalTrial schema used for outbreak.info.",
       "rdfs:subClassOf": {
         "@id": "schema:MedicalStudy"
-      },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
       }
+    },
+    {
+      "@id": "outbreak:identifierSource",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Source of identifier assignment or type of identifier (NCTid, China CTRid, EudraCT Number, etc.)",
+      "rdfs:label": "identifierSource",
+      "schema:domainIncludes": {
+        "@id": "outbreak:ClinicalTrial"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:dateModifiedType",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The type of date. Equivalent to NCT's LastUpdatePostDateType",
+      "rdfs:label": "dateModifiedType",
+      "schema:domainIncludes": {
+        "@id": "outbreak:ClinicalTrial"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:healthConditionIdentifier",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Ontological or controlled vocabulary identifier for the health condition or disease",
+      "rdfs:label": "healthConditionIdentifier",
+      "schema:domainIncludes": {
+        "@id": "outbreak:ClinicalTrial"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        },
+        {
+          "@id": "schema:DefinedTerm"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:hasResults",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Boolean for if the clinical trial has published any results",
+      "rdfs:label": "hasResults",
+      "schema:domainIncludes": {
+        "@id": "outbreak:ClinicalTrial"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Boolean"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:studyEvent",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "an event status such as StudyStart, PrimaryCompletion, Completion, StudyFirstSubmit, StudyFirstSubmitQC, LastUpdateSubmit",
+      "rdfs:label": "studyEvent",
+      "schema:domainIncludes": {
+        "@id": "outbreak:ClinicalTrial"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "outbreak:StudyEvent"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:studyStatus",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The status of the study",
+      "rdfs:label": "studyStatus",
+      "schema:domainIncludes": {
+        "@id": "outbreak:ClinicalTrial"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "outbreak:StudyStatus"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:studyDesign",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The general design of the study",
+      "rdfs:label": "studyDesign",
+      "schema:domainIncludes": {
+        "@id": "outbreak:ClinicalTrial"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "outbreak:StudyDesign"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:armGroup",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The arm or factor of an interventional study",
+      "rdfs:label": "armGroup",
+      "schema:domainIncludes": {
+        "@id": "outbreak:ClinicalTrial"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "outbreak:ArmGroup"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:outcome",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The arm or factor of an interventional study",
+      "rdfs:label": "outcome",
+      "schema:domainIncludes": {
+        "@id": "outbreak:ClinicalTrial"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "outbreak:Outcome"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:eligibilityCriteria",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "eligibility criteria",
+      "rdfs:label": "eligibilityCriteria",
+      "schema:domainIncludes": {
+        "@id": "outbreak:ClinicalTrial"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "outbreak:Eligibility"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:author",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The author of this resource, content, or rating",
+      "rdfs:label": "author",
+      "rdfs:sameAs": {"@id":"schema:author"},
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "outbreak:Person"
+        },
+        {
+          "@id": "outbreak:Organization"
+        }  
+      ]
+    },
+    {
+      "@id": "outbreak:dateCreated",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Date the record was created",
+      "rdfs:label": "dateCreated",
+      "rdfs:sameAs": {"@id":"schema:dateCreated"},
+      "schema:domainIncludes": [
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Date"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:datePublished",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Date of first broadcast/publication",
+      "rdfs:label": "datePublished",
+      "rdfs:sameAs": {"@id":"schema:datePublished"},
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Date"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:dateModified",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The date on which the CreativeWork was most recently modified or when the item's entry was modified within a DataFeed",
+      "rdfs:label": "dateModified",
+      "rdfs:sameAs": {"@id":"schema:dateModified"},
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Date"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:keywords",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "keywords for describing the record",
+      "rdfs:label": "keywords",
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:abstract",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "A short descriptive summary of the publication or study",
+      "rdfs:label": "abstract",
+      "rdfs:sameAs": {"@id":"schema:abstract"},
+      "schema:domainIncludes": [
+          {"@id": "outbreak:Publication"},
+          {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:pmid",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "A pubmed identifier if available",
+      "rdfs:label": "pmid",
+      "schema:domainIncludes": [
+          {"@id": "outbreak:CitationObject"},
+          {"@id": "outbreak:Correction"},
+          {"@id": "outbreak:Publication"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Integer"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:doi",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "A doi if available",
+      "rdfs:label": "doi",
+      "schema:domainIncludes": [
+          {"@id": "outbreak:CitationObject"},
+          {"@id": "outbreak:Correction"},
+          {"@id": "outbreak:Dataset"},
+          {"@id": "outbreak:Publication"},
+          {"@id": "outbreak:Analysis"},
+          {"@id": "outbreak:Protocol"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:funding",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Funding that supports (sponsors) the collection of this dataset through some kind of financial contribution",
+      "rdfs:label": "funding",
+      "schema:domainIncludes": [
+          {"@id": "outbreak:Dataset"},
+          {"@id": "outbreak:Publication"},
+          {"@id": "outbreak:Analysis"},
+          {"@id": "outbreak:Protocol"},
+          {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:MonetaryGrant"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:measurementTechnique",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "A technique or technology used in this resource",
+      "rdfs:label": "measurementTechnique",
+      "rdfs:sameAs": {"@id":"schema:measurementTechnique"},
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Protocol"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        },
+        {
+          "@id": "schema:DefinedTerm"
+        }  
+      ]
+    },
+    {
+      "@id": "outbreak:species",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Species(es) from which dataset has been collected",
+      "rdfs:label": "species",
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Analysis"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        },
+        {
+          "@id": "schema:DefinedTerm"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:infectiousAgent",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "infectious agents(s) which are the focus of the dataset",
+      "rdfs:label": "infectiousAgent",
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Analysis"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        },
+        {
+          "@id": "schema:DefinedTerm"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:infectiousDisease",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The disease or medical conditions caused by the infectious agent. Important as some agents may cause multiple diseases",
+      "rdfs:label": "infectiousDisease",
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Analysis"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        },
+        {
+          "@id": "schema:DefinedTerm"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:topicCategory",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Applicable outbreak.info category",
+      "rdfs:label": "topicCategory",
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+
+    {
+      "@id": "outbreak:isBasedOn",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "A citation to a resource (eg- publication, protocol, etc.) on which this resource was derived (stored as an object, not a string)",
+      "rdfs:label": "isBasedOn",
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {"@id": "outbreak:CitationObject"},
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:ClinicalTrial"},
+        {"@id": "schema:SoftwareApplication"},
+        {"@id": "schema:CreativeWork"}
+      ]
+    },
+    {
+      "@id": "outbreak:isRelatedTo",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "A citation to a resource (eg- publication, protocol, etc.) which is related to the resource but is not a derivative nor was derived from the resource (stored as an object, not a string)",
+      "rdfs:label": "isRelatedTo",
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {"@id": "outbreak:CitationObject"},
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:ClinicalTrial"},
+        {"@id": "schema:SoftwareApplication"},
+        {"@id": "schema:CreativeWork"}
+      ]
+    },
+    {
+      "@id": "outbreak:citedBy",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "A citation to a resource (eg- publication, protocol, etc.) which is derived from this resource (stored as an object, not a string)",
+      "rdfs:label": "citedBy",
+      "rdfs:sameAs":{"@id":"owl:inverseOf: outbreak:isBasedOn"},
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {"@id": "outbreak:CitationObject"},
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:ClinicalTrial"},
+        {"@id": "schema:SoftwareApplication"},
+        {"@id": "schema:CreativeWork"}
+      ]
+    },
+    {
+      "@id": "outbreak:curatedBy",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The source from which this Dataset was identified for inclusion into Outbreak.info. Provides provenance for a resource which was curated by another.",
+      "rdfs:label": "curatedBy",
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {"@id": "outbreak:Person"},
+        {"@id": "outbreak:Organization"},
+        {"@id": "outbreak:CitationObject"},
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:ClinicalTrial"},
+        {"@id": "schema:SoftwareApplication"},
+        {"@id": "schema:CreativeWork"}
+      ]
+    },
+    {
+      "@id": "outbreak:curationDate",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
+      "rdfs:label": "curationDate",
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {"@id": "schema:Date"}
+      ]
+    },
+    {
+      "@id": "outbreak:evaluations",
+      "@type": "rdf:Property",
+      "rdfs:comment":"One or more reviews, ratings, or other evaluations of this resource",
+      "rdfs:label": "evaluations",
+      "schema:domainIncludes":[
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes":[
+        {"@id": "schema:Review"},
+        {"@id": "schema:Rating"},
+        {"@id": "schema:AggregateRating"}
+      ]
     }
   ]
 }

--- a/yaml/outbreak_Protocol.yml
+++ b/yaml/outbreak_Protocol.yml
@@ -1,551 +1,668 @@
 '@context':
-  outbreak: https://discovery.biothings.io/view/outbreak/
-  owl: http://www.w3.org/2002/07/owl/
-  rdf: http://www.w3.org/1999/02/22/-rdf-syntax-ns/
-  rdfs: http://www.w3.org/2000/01/rdf/-schema/
+  outbreak: http://discovery.biothings.io/view/
+  rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
+  rdfs: http://www.w3.org/2000/01/rdf-schema#
   schema: http://schema.org/
 '@graph':
-- '@id': outbreak:Product
+- $validation:
+    $schema: http://json-schema.org/draft-07/schema#
+    definitions:
+      baseOrgObject:
+        '@type': outbreak:Organization
+        properties:
+          alternateName:
+            type: string
+          name:
+            type: string
+        required:
+        - name
+        type: object
+    properties:
+      affiliation:
+        description: An organization that this person is affiliated with. For example,
+          a school/university, a club, or a team.
+        oneOf:
+        - $ref: '#/definitions/baseOrgObject'
+        - items:
+            $ref: '#/definitions/baseOrgObject'
+          type: array
+      alternateName:
+        description: An alias for the person.
+        type: string
+      familyName:
+        description: Family name. In the U.S., the last name of an Person. This can
+          be used along with givenName instead of the name property.
+        type: string
+      givenName:
+        description: Given name. In the U.S., the first name of a Person. This can
+          be used along with familyName instead of the name property.
+        type: string
+      name:
+        description: The name of the person.
+        type: string
+      orcid:
+        description: the ORCID ID of the person
+        type: string
+      role:
+        description: authorship, sponsorship, or other contribution role played by
+          the person or organization in the creation of this resource
+        oneOf:
+        - type: string
+        - items:
+            type: string
+          type: array
+    required:
+    - name
+    type: object
+  '@id': outbreak:Person
   '@type': rdfs:Class
-  rdfs:comment: This is the schema for describing the Product schema used for outbreak.info.
-  rdfs:label: Product
-  rdfs:subClassOf:
-    '@id': schema:Product
-  schema:isPartOf:
-    '@id': https://discovery.biothings.io/view/outbreak/
-- '@id': outbreak:name
-  '@type': rdf:Property
-  marginality: required
-  owl:cardinality: one
-  rdfs:comment: The name of the material or reagent
-  rdfs:label: name
-  rdfs:sameAs:
-    '@id': schema:name
-  schema:domainIncludes:
-    '@id': outbreak:Product
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:manufacturer
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The name of the manufacturer of the material, biosample, or reagent
-  rdfs:label: manufacturer
-  rdfs:sameAs:
-    '@id': schema:manufacturer
-  schema:domainIncludes:
-    '@id': outbreak:Product
-  schema:rangeIncludes:
-    '@id': outbreak:Organization
-- '@id': outbreak:brand
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: The name of the brand of the reagent, material, or biological sample
-    (if different from the manufacturer)
-  rdfs:label: brand
-  rdfs:sameAs:
-    '@id': schema:brand
-  schema:domainIncludes:
-    '@id': outbreak:Product
-  schema:rangeIncludes:
-  - '@id': schema:Text
-  - '@id': outbreak:Organization
-- '@id': outbreak:identifier
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: The catalog number or identifier of the material or reagent
-  rdfs:label: identifier
-  rdfs:sameAs:
-    '@id': schema:identifier
-  schema:domainIncludes:
-    '@id': outbreak:Product
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:type
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The type of material. Reagent, PPE, biological samples, etc.
-  rdfs:label: type
-  rdfs:sameAs:
-    '@id': schema:addtionalType
-  schema:domainIncludes:
-    '@id': outbreak:Product
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:Instrument
-  '@type': rdfs:Class
-  rdfs:comment: This is the schema for describing the Instrument schema used for outbreak.info.
-  rdfs:label: Instrument
-  rdfs:subClassOf:
-    '@id': schema:Product
-  schema:isPartOf:
-    '@id': https://discovery.biothings.io/view/outbreak/
-- '@id': outbreak:name
-  '@type': rdf:Property
-  marginality: required
-  owl:cardinality: one
-  rdfs:comment: The name of the instrument
-  rdfs:label: name
-  rdfs:sameAs:
-    '@id': schema:name
-  schema:domainIncludes:
-    '@id': outbreak:Instrument
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:manufacturer
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The name of the manufacturer of the instrument
-  rdfs:label: manufacturer
-  rdfs:sameAs:
-    '@id': schema:manufacturer
-  schema:domainIncludes:
-    '@id': outbreak:Instrument
-  schema:rangeIncludes:
-    '@id': outbreak:Organization
-- '@id': outbreak:brand
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: The brand of the instrument
-  rdfs:label: brand
-  rdfs:sameAs:
-    '@id': schema:brand
-  schema:domainIncludes:
-    '@id': outbreak:Instrument
-  schema:rangeIncludes:
-  - '@id': schema:Text
-  - '@id': outbreak:Organization
-- '@id': outbreak:model
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The model number of the instrument
-  rdfs:label: model
-  rdfs:sameAs:
-    '@id': schema:model
-  schema:domainIncludes:
-    '@id': outbreak:Instrument
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:Organization
-  '@type': rdfs:Class
-  rdfs:comment: This is the schema for describing the Organization schema used for
-    outbreak.info.
-  rdfs:label: Organization
-  rdfs:subClassOf:
-    '@id': schema:Organization
-  schema:isPartOf:
-    '@id': https://discovery.biothings.io/view/outbreak/
-- '@id': outbreak:name
-  '@type': rdf:Property
-  marginality: required
-  owl:cardinality: one
-  rdfs:comment: The name of the organization, team or group
-  rdfs:label: name
-  rdfs:sameAs:
-    '@id': schema:name
-  schema:domainIncludes:
-    '@id': outbreak:Organization
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:alternateName
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: Alternative names or commonly used abbreviations for the organization,
-    team or group
-  rdfs:label: alternateName
-  rdfs:sameAs:
-    '@id': schema:alternateName
-  schema:domainIncludes:
-    '@id': outbreak:Organization
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:affiliation
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: An overarching consortia, multi-institutional team or group in which
-    the organization/team/group is a member or affiliate
-  rdfs:label: affiliation
-  rdfs:sameAs:
-    '@id': schema:affiliation
-  schema:domainIncludes:
-    '@id': outbreak:Organization
-  schema:rangeIncludes:
-    '@id': outbreak:Organization
-- '@id': outbreak:affiliationStatus
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The status of the organization's membership or affiliation in the
-    overarching consortial, multi-institutional team or group (current, past)
-  rdfs:label: affiliationStatus
-  rdfs:sameAs:
-    '@id': schema:additionalType
-  schema:domainIncludes:
-    '@id': outbreak:Organization
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:members
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: Members of this organization, team, or group
-  rdfs:label: members
-  rdfs:sameAs:
-    '@id': schema:members
-  schema:domainIncludes:
-    '@id': outbreak:Organization
-  schema:rangeIncludes:
-  - '@id': outbreak:Person
-  - '@id': outbreak:Organization
-- '@id': outbreak:membershipStatus
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: Status of the members of this organization
-  rdfs:label: membershipStatus
-  rdfs:sameAs:
-    '@id': schema:additionalType
-  schema:domainIncludes:
-    '@id': outbreak:Organization
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:relatedTo
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: many
-  rdfs:comment: A resource which a person played a role
-  rdfs:label: relatedTo
-  rdfs:sameAs:
-    '@id': schema:relatedTo
-  schema:domainIncludes:
-    '@id': outbreak:Organization
-  schema:rangeIncludes:
-  - '@id': schema:CreativeWork
-  - '@id': schema:HowTo
-- '@id': outbreak:class
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: many
-  rdfs:comment: A classification of the organization by a resource. Eg- for ClinicalTrials
-    funders, it's ["U.S. National Institutes of Health", "Other U.S. Federal agencies",
-    "Industry", "All others"]
-  rdfs:label: class
-  rdfs:sameAs:
-    '@id': schema:addtionalType
-  schema:domainIncludes:
-  - '@id': schema:CreativeWork
-  - '@id': schema:HowTo
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:role
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: many
-  rdfs:comment: The role of an organization in its involvement with a resource
-  rdfs:label: role
-  rdfs:sameAs:
-    '@id': schema:additionalType
-  schema:domainIncludes:
-  - '@id': schema:CreativeWork
-  - '@id': schema:HowTo
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:Person
-  '@type': rdfs:Class
-  rdfs:comment: This is the schema for describing the Person schema used for outbreak.info.
+  rdfs:comment: This is the Person schema for describing authors and people for outbreak.info
+    resources
   rdfs:label: Person
   rdfs:subClassOf:
     '@id': schema:Person
-  schema:isPartOf:
-    '@id': https://discovery.biothings.io/view/outbreak/
-- '@id': outbreak:name
-  '@type': rdf:Property
-  marginality: required
-  owl:cardinality: one
-  rdfs:comment: The name of the person
-  rdfs:label: name
-  rdfs:sameAs:
-    '@id': schema:name
-  schema:domainIncludes:
-    '@id': outbreak:Person
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:alternateName
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: Alternative ways in which the person's name is included in a record
-  rdfs:label: alternateName
-  rdfs:sameAs:
-    '@id': schema:alternateName
-  schema:domainIncludes:
-    '@id': outbreak:Person
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:givenName
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The given name of the person
-  rdfs:label: givenName
-  rdfs:sameAs:
-    '@id': schema:givenName
-  schema:domainIncludes:
-    '@id': outbreak:Person
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:familyName
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The family name of the person
-  rdfs:label: familyName
-  rdfs:sameAs:
-    '@id': schema:familyName
-  schema:domainIncludes:
-    '@id': outbreak:Person
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:affiliation
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: The organization with which the person is affiliated or has membership
-    in
-  rdfs:label: affiliation
-  rdfs:sameAs:
-    '@id': schema:affiliation
-  schema:domainIncludes:
-    '@id': outbreak:Person
-  schema:rangeIncludes:
-    '@id': outbreak:Organization
-- '@id': outbreak:affiliationStatus
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The status of the person's membership or affiliation in an organization,
-    team or group (current, past)
-  rdfs:label: affiliationStatus
-  rdfs:sameAs:
-    '@id': schema:addtionalType
-  schema:domainIncludes:
-    '@id': outbreak:Person
-  schema:rangeIncludes:
-    '@id': schema:Text
 - '@id': outbreak:orcid
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The ORCID ID of the person
+  '@type': rdfs:Property
+  rdfs:comment: the ORCID ID of the person
   rdfs:label: orcid
-  rdfs:sameAs:
-    '@id': schema:identifier
   schema:domainIncludes:
     '@id': outbreak:Person
   schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:relatedTo
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: many
-  rdfs:comment: A resource which a person played a role
-  rdfs:label: relatedTo
-  rdfs:sameAs:
-    '@id': schema:relatedTo
+  - '@id': schema:Text
+- $validation:
+    $schema: http://json-schema.org/draft-07/schema#
+    definitions:
+      baseOrgObject:
+        '@type': outbreak:Organization
+        description: Affiliated Organization
+        properties:
+          alternateName:
+            description: Alternate name or Acronym for the organization.
+            type: string
+          name:
+            description: name of the organization
+            type: string
+        required:
+        - name
+        type: object
+      basePersonObject:
+        '@type': outbreak:Person
+        properties:
+          affiliation:
+            description: consortia or other organizations with which this person is
+              affiliated
+            oneOf:
+            - $ref: '#/definitions/baseOrgObject'
+            - items:
+                $ref: '#/definitions/baseOrgObject'
+              type: array
+          alternateName:
+            type: string
+          familyName:
+            type: string
+          givenName:
+            type: string
+          name:
+            type: string
+          orcid:
+            type: string
+        required:
+        - name
+        type: object
+    properties:
+      affiliation:
+        description: consortia or other organizations with which this organization
+          is affiliated
+        oneOf:
+        - $ref: '#/definitions/baseOrgObject'
+        - items:
+            $ref: '#/definitions/baseOrgObject'
+          type: array
+      alternateName:
+        description: An alias or acronym for the organization.
+        type: string
+      class:
+        description: A classification of the organization by a resource. Eg- for ClinicalTrials
+          funders, it's [U.S. National Institutes of Health, Other U.S. Federal agencies,
+          Industry, All others]
+        type: string
+      members:
+        description: Members of this organization, team, or group
+        oneOf:
+        - $ref: '#/definitions/basePersonObject'
+        - items:
+            $ref: '#/definitions/basePersonObject'
+          type: array
+      name:
+        description: The name of the organization.
+        type: string
+      role:
+        description: The role of an organization in its involvement with a resource
+        oneOf:
+        - type: string
+        - items:
+            type: string
+          type: array
+    required:
+    - name
+    type: object
+  '@id': outbreak:Organization
+  '@type': rdfs:Class
+  rdfs:comment: This is the organization schema for describing authors, funders and
+    other organizations referenced by outbreak.info resources
+  rdfs:label: Organization
+  rdfs:subClassOf:
+    '@id': schema:Organization
+- '@id': outbreak:affiliation
+  '@type': rdfs:Property
+  rdfs:comment: consortia or other organizations with which this organization is affiliated
+  rdfs:label: affiliation
   schema:domainIncludes:
-    '@id': outbreak:Person
+    '@id': outbreak:Organization
   schema:rangeIncludes:
-  - '@id': schema:CreativeWork
-  - '@id': schema:HowTo
+  - '@id': outbreak:Organization
+- '@id': outbreak:members
+  '@type': rdfs:Property
+  rdfs:comment: Members of this organization, team, or group
+  rdfs:label: members
+  schema:domainIncludes:
+    '@id': outbreak:Organization
+  schema:rangeIncludes:
+  - '@id': outbreak:Person
+- '@id': outbreak:class
+  '@type': rdfs:Property
+  rdfs:comment: A classification of the organization by a resource. Eg- for ClinicalTrials
+    funders, it's [U.S. National Institutes of Health, Other U.S. Federal agencies,
+    Industry, All others]
+  rdfs:label: class
+  schema:domainIncludes:
+    '@id': outbreak:Organization
+  schema:rangeIncludes:
+  - '@id': schema:Text
 - '@id': outbreak:role
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: The role a person played in the creation of a resource
+  '@type': rdfs:Property
+  rdfs:comment: authorship, sponsorship, or other contribution role played by the
+    person or organization in the creation of this resource. In a Clinical Study/Trial
+    ArmGroup, it's equivalent to the ArmType in ClinicalTrials.gov
   rdfs:label: role
-  rdfs:sameAs:
-    '@id': schema:addtionalType
   schema:domainIncludes:
-  - '@id': schema:CreativeWork
-  - '@id': schema:HowTo
+  - '@id': outbreak:Person
+  - '@id': outbreak:Organization
+  - '@id': outbreak:ArmGroup
   schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:MonetaryGrant
+  - '@id': schema:Text
+- $validation:
+    $schema: http://json-schema.org/draft-07/schema#
+    definitions:
+      baseOrgObject:
+        '@type': outbreak:Organization
+        description: Affiliated Organization
+        properties:
+          alternateName:
+            description: Alternate name or Acronym for the organization.
+            type: string
+          name:
+            description: name of the organization
+            type: string
+        required:
+        - name
+        type: object
+      basePersonObject:
+        '@type': outbreak:Person
+        properties:
+          affiliation:
+            description: consortia or other organizations with which this person is
+              affiliated
+            oneOf:
+            - $ref: '#/definitions/baseOrgObject'
+            - items:
+                $ref: '#/definitions/baseOrgObject'
+              type: array
+          alternateName:
+            type: string
+          familyName:
+            type: string
+          givenName:
+            type: string
+          name:
+            type: string
+          orcid:
+            type: string
+        required:
+        - name
+        type: object
+    properties:
+      funder:
+        description: The organization(s) that supported (sponsored) the grant through
+          some kind of financial contribution.
+        oneOf:
+        - $ref: '#/definitions/baseOrgObject'
+        - items:
+            $ref: '#/definitions/baseOrgObject'
+          type: array
+      identifier:
+        description: The funding or grant id
+        type: string
+      name:
+        description: The name of the grant or funding.
+        type: string
+      recipient:
+        anyOf:
+        - $ref: '#/definitions/basePersonObject'
+        - items:
+            $ref: '#/definitions/basePersonObject'
+          type: array
+        - $ref: '#/definitions/baseOrgObject'
+        - items:
+            $ref: '#/definitions/baseOrgObject'
+          type: array
+        description: The person or organization to whom or to which the grant was
+          awarded
+      url:
+        description: URL of the grant or funding award.
+        format: uri
+        type: string
+    required:
+    - funder
+    type: object
+  '@id': outbreak:MonetaryGrant
   '@type': rdfs:Class
   rdfs:comment: This is the schema for describing the MonetaryGrant schema used for
-    outbreak.info.
+    outbreak.info
   rdfs:label: MonetaryGrant
   rdfs:subClassOf:
     '@id': schema:MonetaryGrant
-  schema:isPartOf:
-    '@id': https://discovery.biothings.io/view/outbreak/
-- '@id': outbreak:name
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The name of the monetary grant
-  rdfs:label: name
-  rdfs:sameAs:
-    '@id': schema:name
-  schema:domainIncludes:
-    '@id': outbreak:MonetaryGrant
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:identifier
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The grant ID or an identifier associated with the grant
-  rdfs:label: identifier
-  rdfs:sameAs:
-    '@id': schema:identifier
-  schema:domainIncludes:
-    '@id': outbreak:MonetaryGrant
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:url
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The url for the grant (if available)
-  rdfs:label: url
-  rdfs:sameAs:
-    '@id': schema:url
-  schema:domainIncludes:
-    '@id': outbreak:MonetaryGrant
-  schema:rangeIncludes:
-    '@id': schema:URL
-- '@id': outbreak:funder
-  '@type': rdf:Property
-  marginality: required
-  owl:cardinality: many
-  rdfs:comment: The funding organization of the grant
-  rdfs:label: funder
-  rdfs:sameAs:
-    '@id': schema:funder
-  schema:domainIncludes:
-    '@id': outbreak:MonetaryGrant
-  schema:rangeIncludes:
-    '@id': outbreak:Organization
-- '@id': outbreak:name
-  '@type': rdf:Property
-  marginality: required
-  owl:cardinality: one
-  rdfs:comment: The name of the funding organization
-  rdfs:label: name
-  rdfs:sameAs:
-    '@id': schema:name
-  schema:domainIncludes:
-    '@id': outbreak:Organization
-  schema:rangeIncludes:
-    '@id': schema:Text
 - '@id': outbreak:recipient
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
+  '@type': rdfs:Property
   rdfs:comment: The person or organization to whom or to which the grant was awarded
   rdfs:label: recipient
-  rdfs:sameAs:
-    '@id': schema:recipient
   schema:domainIncludes:
     '@id': outbreak:MonetaryGrant
   schema:rangeIncludes:
-  - '@id': outbreak:Person
-  - '@id': outbreak:Organization
-- '@id': outbreak:name
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The name of the recipient of the grant
-  rdfs:label: name
-  rdfs:sameAs:
-    '@id': schema:name
-  schema:domainIncludes:
-  - '@id': outbreak:Person
-  - '@id': outbreak:Organization
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:affiliation
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: The affiliation of the recipient of the grant
-  rdfs:label: affiliation
-  rdfs:sameAs:
-    '@id': schema:affiliation
-  schema:domainIncludes:
-  - '@id': outbreak:Person
-  - '@id': outbreak:Organization
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:Analysis
+  - '@id': schema:Person
+  - '@id': schema:Organization
+- '@id': outbreak:DataDownload
   '@type': rdfs:Class
-  rdfs:comment: This is the schema for describing the Analysis schema used for outbreak.info.
-  rdfs:label: Analysis
+  rdfs:comment: This is the schema for describing the DataDownload schema used for
+    outbreak.info.
+  rdfs:label: DataDownload
+  rdfs:subClassOf:
+    '@id': schema:DataDownload
+- $validation:
+    $schema: http://json-schema.org/draft-07/schema#
+    properties:
+      citeText:
+        description: The bibliographic citation for the referenced resource as is
+          provided
+        type: string
+      doi:
+        description: A doi if available
+        type: string
+      identifier:
+        description: An identifier associated with the citation
+        type: string
+      name:
+        description: The name or title of the cited resource.
+        type: string
+      pmid:
+        description: A pubmed identifier if available
+        type: string
+      sourceType:
+        description: The @type of resource
+        enum:
+        - Dataset
+        - Publication
+        - ClinicalTrial
+        - Analysis
+        - Protocol
+        - SoftwareApplication
+        - CreativeWork
+      url:
+        description: URL of the cited resource.
+        format: uri
+        type: string
+      versionDate:
+        description: The version date of the resource used at the time of the creation
+          of the citation as certain resources (protocols, datasets) may change frequently
+          over time.
+        format: date
+        type: string
+    required:
+    - name
+    - sourceType
+    type: object
+  '@id': outbreak:CitationObject
+  '@type': rdfs:Class
+  rdfs:comment: A citation object for a resource which is cited by the subject (ie-
+    is a derivative of the subject), related to the subject, or from which the subject
+    was based on (ie- is derived from).
+  rdfs:label: CitationObject
   rdfs:subClassOf:
     '@id': schema:CreativeWork
-  schema:isPartOf:
-    '@id': https://discovery.biothings.io/view/outbreak/
+- '@id': outbreak:citeText
+  '@type': rdfs:Property
+  rdfs:comment: The bibliographic citation for the referenced resource as is provided
+  rdfs:label: citeText
+  schema:domainIncludes:
+    '@id': outbreak:CitationObject
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:versionDate
+  '@type': rdfs:Property
+  rdfs:comment: The version date of the resource used at the time of the creation
+    of the citation as certain resources (protocols, datasets) may change frequently
+    over time.
+  rdfs:label: versionDate
+  schema:domainIncludes:
+    '@id': outbreak:CitationObject
+  schema:rangeIncludes:
+  - '@id': schema:Date
+- '@id': outbreak:sourceType
+  '@type': rdfs:Property
+  rdfs:comment: The type of resource
+  rdfs:label: sourceType
+  schema:domainIncludes:
+    '@id': outbreak:CitationObject
+  schema:rangeIncludes:
+  - '@id': schema:Text
 - '@id': outbreak:Dataset
   '@type': rdfs:Class
   rdfs:comment: This is the schema for describing the Dataset schema used for outbreak.info.
   rdfs:label: Dataset
   rdfs:subClassOf:
     '@id': schema:Dataset
-  schema:isPartOf:
-    '@id': https://discovery.biothings.io/view/outbreak/
+- '@id': outbreak:Correction
+  '@type': rdfs:Class
+  rdfs:comment: This is the schema for describing a Correction used for outbreak.info.
+    A Correction is a specialized subclass of the CitationObject
+  rdfs:label: Correction
+  rdfs:subClassOf:
+    '@id': schema:CreativeWork
+- '@id': outbreak:correctionType
+  '@type': rdfs:Property
+  rdfs:comment: 'Type of notice or correction: (correction, retraction, expression
+    of convern, withdrawal, erratum, update, correction/republication, preprint, peer
+    reviewed version)'
+  rdfs:label: correctionType
+  schema:domainIncludes:
+    '@id': outbreak:Correction
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:Publication
+  '@type': rdfs:Class
+  rdfs:comment: This is the schema for describing the Publication used for outbreak.info
+  rdfs:label: Publication
+  rdfs:subClassOf:
+    '@id': schema:MedicalScholarlyArticle
+- '@id': outbreak:journalName
+  '@type': rdfs:Property
+  rdfs:comment: The name of the journal (or publisher if journal name not available)
+  rdfs:label: journalName
+  schema:domainIncludes:
+    '@id': outbreak:Publication
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:journalNameAbbrevation
+  '@type': rdfs:Property
+  rdfs:comment: abbreviated Journal Title (note, this should be autopopulated)
+  rdfs:label: journalNameAbbrevation
+  schema:domainIncludes:
+    '@id': outbreak:Publication
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:volumeNumber
+  '@type': rdfs:Property
+  rdfs:comment: Volume number of journal in which the article was published
+  rdfs:label: volumeNumber
+  schema:domainIncludes:
+    '@id': outbreak:Publication
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:issueNumber
+  '@type': rdfs:Property
+  rdfs:comment: Issue of journal in which the article was published
+  rdfs:label: issueNumber
+  schema:domainIncludes:
+    '@id': outbreak:Publication
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:Analysis
+  '@type': rdfs:Class
+  rdfs:comment: This is the schema for describing an Analysis for inclusion in outbreak.info
+    resources
+  rdfs:label: Analysis
+  rdfs:subClassOf:
+    '@id': schema:CreativeWork
+- '@id': outbreak:domainUrl
+  '@type': rdfs:Property
+  rdfs:comment: The domain name or main site on which webpage or specific url can
+    be found
+  rdfs:label: domainUrl
+  schema:domainIncludes:
+    '@id': outbreak:Analysis
+  schema:rangeIncludes:
+  - '@id': schema:URL
+- '@id': outbreak:assumption
+  '@type': rdfs:Property
+  rdfs:comment: Statement of assumptions / limitations of the model
+  rdfs:label: assumption
+  schema:domainIncludes:
+    '@id': outbreak:Analysis
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:analysisTechnique
+  '@type': rdfs:Property
+  rdfs:comment: A technique or technology used in a analysis
+  rdfs:label: analysisTechnique
+  schema:domainIncludes:
+    '@id': outbreak:Analysis
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:analysisTopic
+  '@type': rdfs:Property
+  rdfs:comment: The underlying question, goal, or aim of the analysis
+  rdfs:label: analysisTopic
+  schema:domainIncludes:
+    '@id': outbreak:Analysis
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- $validation:
+    $schema: http://json-schema.org/draft-07/schema#
+    properties:
+      brand:
+        description: The brand(s) associated with the product
+        type: string
+      category:
+        description: The type of product (chemical/reagent, biological sample, PPE,
+          or other.
+        oneOf:
+        - enum:
+          - chemical or reagent
+          - biological sample
+          - PPE
+          - other
+          type: string
+        - items:
+            enum:
+            - chemical or reagent
+            - biological sample
+            - PPE
+            - other
+            type: string
+          type: array
+      identifier:
+        description: An identifier for the product (preferably the manufacturer's
+          identifier for the product)
+        type: string
+      manufacturer:
+        '@type': outbreak:Organization
+        description: The manufacturer of the reagent, material, sample or product.
+        properties:
+          alternatename:
+            type: string
+          name:
+            type: string
+        required:
+        - name
+        type: object
+      name:
+        description: The name of the reagent/sample/material/product
+        type: string
+      url:
+        description: URL of the product
+        format: uri
+        type: string
+    required:
+    - name
+    type: object
+  '@id': outbreak:Product
+  '@type': rdfs:Class
+  rdfs:comment: This is the schema for describing a reagent, material, sample, or
+    some other product used in a protocol resource in outbreak.info
+  rdfs:label: Product
+  rdfs:subClassOf:
+    '@id': schema:Product
+- $validation:
+    $schema: http://json-schema.org/draft-07/schema#
+    properties:
+      brand:
+        description: The brand(s) associated with the instrument
+        type: string
+      manufacturer:
+        '@type': outbreak:Organization
+        description: The manufacturer of the instrument
+        properties:
+          alternateName:
+            type: string
+          name:
+            type: string
+        required:
+        - name
+        type: object
+      model:
+        description: The model of the instrument
+        type: string
+      name:
+        description: The name of the instrument
+        type: string
+      url:
+        description: URL of the product page for the instrument
+        format: uri
+        type: string
+    required:
+    - name
+    type: object
+  '@id': outbreak:Instrument
+  '@type': rdfs:Class
+  rdfs:comment: This is the schema for describing an instrument used in a protocol
+    resource listed in outbreak.info
+  rdfs:label: Instrument
+  rdfs:subClassOf:
+    '@id': schema:Product
 - $validation:
     $schema: http://json-schema.org/draft-07/schema#
     definitions:
+      aggregateRatingObject:
+        '@type': AggregateRating
+        description: A cumulative evaluation of the resource
+        properties:
+          author:
+            anyOf:
+            - $ref: '#/definitions/person'
+            - items:
+                $ref: '#/definitions/person'
+              type: array
+            - $ref: '#/definitions/organization'
+            - items:
+                $ref: '#/definitions/organization'
+              type: array
+            description: The author of this content or rating.
+          curationDate:
+            description: The date this evaluation was added into outbreak.info, or
+              was updated in outbreak.info.
+            format: date
+            type: string
+          name:
+            description: The name of the aggregate rating
+            type: string
+          ratingValue:
+            description: The rating for the content.
+            type: string
+          reviewAspect:
+            description: This Review or Rating is relevant to this part or facet of
+              the itemReviewed
+            type: string
+          reviews:
+            anyOf:
+            - items:
+                $ref: '#/definitions/reviewObject'
+              type: array
+            - items:
+                $ref: '#/definitions/ratingObject'
+              type: array
+        type: object
+      baseOrgObject:
+        '@type': outbreak:Organization
+        description: A barebones Organization object to work around recursion issues
+          in DDE
+        properties:
+          alternateName:
+            description: Alternate name or Acronym for the organization.
+            type: string
+          name:
+            description: name of the organization
+            type: string
+        required:
+        - name
+        type: object
       citation:
-        '@type': CreativeWork
-        description: A citation object for a resource which is cited by the dataset
-          (ie- is a derivative of the dataset) , related to the dataset, or from which
-          the dataset was based on (ie- is derived from).
+        '@type': outbreak:CitationObject
+        description: A citation object for a resource which is cited by the protocol
+          (ie- is a derivative of the protocol), related to the protocol, or from
+          which the protocol was based on (ie- is derived from).
         properties:
           citeText:
             description: The bibliographic citation for the referenced resource as
               is provided
             type: string
           doi:
+            description: A doi if available
             type: string
           identifier:
+            description: An identifier associated with the citation
             type: string
           name:
-            description: name of the referenced resource
+            description: Name of or title of the citation
             type: string
           pmid:
-            type: integer
-          type:
+            description: A pubmed identifier if available
+            type: string
+          sourceType:
+            description: The type of resource
             enum:
-            - ClinicalStudy
-            - Analysis
-            - Publication
             - Dataset
+            - Publication
+            - ClinicalTrial
+            - Analysis
             - Protocol
             - SoftwareApplication
-            - Other
+            - CreativeWork
           url:
+            description: The url of the resource cited.
             format: uri
             type: string
           versionDate:
-            description: Date of the version of the resource that is referenced
+            description: The version date of the resource used at the time of the
+              creation of the citation as certain resources (protocols, datasets)
+              may change frequently over time.
             format: date
             type: string
         required:
         - name
-        - type
+        - sourceType
         type: object
       controlledVocabulary:
-        '@type': CreativeWork
+        '@type': DefinedTerm
         definition: collection of vocabulary terms defined in ontologies
         strict: false
         type: string
@@ -559,25 +676,25 @@
           - eco
           - obi
       funding:
-        '@type': MonetaryGrant
+        '@type': outbreak:MonetaryGrant
         description: Information about funding support
         properties:
           funder:
             description: name of the funding organization
             oneOf:
-            - $ref: '#/definitions/organization'
+            - $ref: '#/definitions/baseOrgObject'
             - items:
-                $ref: '#/definitions/organization'
+                $ref: '#/definitions/baseOrgObject'
               type: array
-            type: array
           identifier:
-            description: Unique identifier(s) for the grant(s) used to fund the Protocol
+            description: Unique identifier(s) for the grant(s) used to fund the Dataset
             type: string
           name:
-            description: The name of the monetary grant that funded/funds the Protocol
+            description: The name of the monetary grant that funded/funds the Dataset
             type: string
           url:
             description: award URL
+            format: uri
             type: string
         required:
         - funder
@@ -585,13 +702,13 @@
       instrument:
         '@type': Product
         description: A laboratory equipment use by a person to follow one or more
-          steps described in this Protocol.
+          steps described in this protocol.
         properties:
           brand:
             description: The brand of the instrument
             type: string
           manufacturer:
-            $ref: '#/definitions/organization'
+            $ref: '#/definitions/baseOrgObject'
             description: The name of the manufacturer of the material, biosample,
               or reagent
           model:
@@ -603,8 +720,30 @@
         required:
         - name
         type: object
+      memberObject:
+        '@type': outbreak:Person
+        description: Reusable person definition accounting for recursion issues in
+          DDE
+        properties:
+          affiliation:
+            oneOf:
+            - $ref: '#/definitions/baseOrgObject'
+            - items:
+                $ref: '#/definitions/baseOrgObject'
+              type: array
+          familyName:
+            type: string
+          givenName:
+            type: string
+          name:
+            type: string
+          orcid:
+            type: string
+        required:
+        - name
+        type: object
       miscControlledVocabulary:
-        '@type': CreativeWork
+        '@type': DefinedTerm
         definition: collection of vocabulary terms defined in ontologies
         strict: false
         type: string
@@ -614,27 +753,34 @@
           ontology:
           - eco
       organization:
-        '@type': Organization
+        '@type': outbreak:Organization
         description: Reusable organization definition
         properties:
           affiliation:
+            $ref: '#/definitions/baseOrgObject'
+          alternateName:
             type: string
+          members:
+            oneOf:
+            - $ref: '#/definitions/memberObject'
+            - items:
+                $ref: '#/definitions/memberObject'
+              type: array
           name:
             type: string
         required:
         - name
         type: object
       person:
-        '@type': Person
+        '@type': outbreak:Person
         description: Reusable person definition
         properties:
           affiliation:
             oneOf:
-            - $ref: '#/definitions/organization'
+            - $ref: '#/definitions/baseOrgObject'
             - items:
-                $ref: '#/definitions/organization'
+                $ref: '#/definitions/baseOrgObject'
               type: array
-            type: array
           familyName:
             type: string
           givenName:
@@ -652,9 +798,16 @@
           materials) used or tested in this protocol
         properties:
           brand:
-            description: The name of the brand of the reagent, material, or biological
-              sample (if different from the manufacturer)
+            description: The brand of the reagent, material, or biological sample
+              (if different from the manufacturer)
             type: string
+          category:
+            description: The type of material. Reagent, PPE, biological samples, etc.
+            enum:
+            - chemical or reagent
+            - biological sample
+            - PPE
+            - other
           identifier:
             description: The catalog number or identifier of the material or reagent
             oneOf:
@@ -663,26 +816,87 @@
                 type: string
               type: array
           manufacturer:
-            $ref: '#/definitions/organization'
-            description: The name of the manufacturer of the material, biosample,
-              or reagent
+            $ref: '#/definitions/baseOrgObject'
+            description: The manufacturer of the material, biosample, or reagent
           name:
             description: The name of the material or reagent
             type: string
-          type:
-            description: The type of material. Reagent, PPE, biological samples, etc.
-            enum:
-            - chemical or reagent
-            - ' biological sample'
-            - ' PPE'
-            - ' other'
         required:
         - name
         type: object
+      ratingObject:
+        '@type': Rating
+        description: A rating or categorical evaluation of the resource
+        properties:
+          author:
+            anyOf:
+            - $ref: '#/definitions/person'
+            - items:
+                $ref: '#/definitions/person'
+              type: array
+            - $ref: '#/definitions/organization'
+            - items:
+                $ref: '#/definitions/organization'
+              type: array
+            description: The author of this content or rating.
+          curationDate:
+            description: The date this evaluation was added into outbreak.info, or
+              was updated in outbreak.info.
+            format: date
+            type: string
+          name:
+            description: The name of the rating
+            type: string
+          ratingExplanation:
+            description: An explanation of the rating
+            type: string
+          ratingValue:
+            description: The rating for the content.
+            type: string
+          reviewAspect:
+            description: This Review or Rating is relevant to this part or facet of
+              the itemReviewed
+            type: string
+        required: []
+        type: object
+      reviewObject:
+        '@type': Review
+        description: A review or descriptive evaluation of the resource
+        properties:
+          author:
+            anyOf:
+            - $ref: '#/definitions/person'
+            - items:
+                $ref: '#/definitions/person'
+              type: array
+            - $ref: '#/definitions/organization'
+            - items:
+                $ref: '#/definitions/organization'
+              type: array
+            description: The author of this content or rating.
+          curationDate:
+            description: The date this evaluation was added into outbreak.info, or
+              was updated in outbreak.info.
+            format: date
+            type: string
+          name:
+            description: The name of the review
+            type: string
+          reviewAspect:
+            description: This Review or Rating is relevant to this part or facet of
+              the itemReviewed
+            type: string
+          reviewBody:
+            description: The actual body of the review.
+            type: string
+          reviewRating:
+            $ref: '#/definitions/ratingObject'
+            description: The rating given in this review
+        required: []
+        type: object
     properties:
       author:
-        description: person, people, or organization that created the protocol
-        oneOf:
+        anyOf:
         - $ref: '#/definitions/person'
         - items:
             $ref: '#/definitions/person'
@@ -691,6 +905,7 @@
         - items:
             $ref: '#/definitions/organization'
           type: array
+        description: person, people, or organization that created the protocol
       citedBy:
         description: Associated guidelines, protocols, publications, etc. that include,
           adapt, modify, expand, etc. this protocol.
@@ -699,18 +914,11 @@
         - items:
             $ref: '#/definitions/citation'
           type: array
-      correction:
+      correctionNote:
         description: statement of what was updated/changed since prior version
-        oneOf:
-        - type: string
-        - items:
-            type: string
-          type: array
+        type: string
       curatedBy:
-        description: The source from which this Protocol was identified for inclusion
-          into Outbreak.info. Provides provenance for a resource which was curated
-          by another.
-        oneOf:
+        anyOf:
         - $ref: '#/definitions/citation'
         - $ref: '#/definitions/person'
         - $ref: '#/definitions/organization'
@@ -723,6 +931,9 @@
         - items:
             $ref: '#/definitions/citation'
           type: array
+        description: The source from which this Protocol was identified for inclusion
+          into Outbreak.info. Provides provenance for a resource which was curated
+          by another.
       curationDate:
         description: The date this resource was added into outbreak.info, or was updated
           in outbreak.info.
@@ -738,15 +949,27 @@
             type: string
           type: array
       datePublished:
-        description: PublicationDate of the protocol online if available
+        description: Publication Date of the protocol online if available
         format: date
         type: string
       description:
-        description: description of the protocol
+        description: A description of the protocol
         type: string
       doi:
-        description: A DOI associated with the protocol if available
+        description: the DOI of the protocol
         type: string
+      evaluations:
+        anyOf:
+        - items:
+            $ref: '#/definitions/reviewObject'
+          type: array
+        - items:
+            $ref: '#/definitions/ratingObject'
+          type: array
+        - items:
+            $ref: '#/definitions/aggregateRatingObject'
+          type: array
+        description: Reviews, Ratings, or other types of evaluations on this resource
       funding:
         description: The funder of the Protocol
         oneOf:
@@ -755,7 +978,7 @@
             $ref: '#/definitions/funding'
           type: array
       identifier:
-        description: An identifier associated with the protocol (if available)
+        description: An identifier associated with the protocol
         type: string
       inComplianceWith:
         description: Guidelines or Standards to which these protocols adhere. ie-
@@ -782,6 +1005,14 @@
         - items:
             $ref: '#/definitions/citation'
           type: array
+      isRelatedTo:
+        description: Other resources related to, but not a derivative of nor derived
+          from this protocol
+        oneOf:
+        - $ref: '#/definitions/citation'
+        - items:
+            $ref: '#/definitions/citation'
+          type: array
       keywords:
         description: keywords
         oneOf:
@@ -790,7 +1021,8 @@
             type: string
           type: array
       license:
-        description: License
+        description: A license document that applies to this content, typically indicated
+          by URL.
         type: string
       material:
         description: the reagent, biological sample, or material such as PPE source
@@ -808,7 +1040,7 @@
             $ref: '#/definitions/controlledVocabulary'
           type: array
       name:
-        description: name of the protocol
+        description: The name of the protocol
         type: string
       protocolCategory:
         description: The type of 'protocol' based on degree of specificity and purpose
@@ -825,15 +1057,7 @@
         - field
         - computational
         - public
-      relatedTo:
-        description: Other resources related to, but not a derivative of nor derived
-          from this protocol
-        oneOf:
-        - $ref: '#/definitions/citation'
-        - items:
-            $ref: '#/definitions/citation'
-          type: array
-      status:
+      protocolStatus:
         description: The status of the protocol
         enum:
         - Working--In use by author
@@ -879,6 +1103,7 @@
           - Epidemiology
           - Classical Epidemiology
           - Molecular Epidemiology
+          - Information Sciences
         - items:
             enum:
             - Clinical
@@ -914,16 +1139,12 @@
             - Epidemiology
             - Classical Epidemiology
             - Molecular Epidemiology
+            - Information Sciences
           type: array
       url:
         description: url where the protocol can be found
-        oneOf:
-        - format: uri
-          type: string
-        - items:
-            format: uri
-            type: string
-          type: array
+        format: uri
+        type: string
       usedToGenerate:
         description: Type of evidence/data generated by the protocol
         oneOf:
@@ -933,779 +1154,828 @@
           type: array
       warning:
         description: Precautions, warnings, and/or safety warnings associated with
-          the protocol
-        oneOf:
-        - type: string
-        - items:
-            type: string
-          type: array
+          or highlighted by the protocol
+        type: string
     required:
-    - name
     - description
-    - datePublished
+    - identifier
+    - name
     - url
     - author
     type: object
   '@id': outbreak:Protocol
   '@type': rdfs:Class
-  rdfs:comment: This is the schema for describing the Protocol schema used for outbreak.info.
+  rdfs:comment: This is the schema for describing the Protocols for outbreak.info
+    Resources.
   rdfs:label: Protocol
   rdfs:subClassOf:
     '@id': schema:HowTo
-  schema:isPartOf:
-    '@id': https://discovery.biothings.io/view/outbreak/
-- '@id': outbreak:url
-  '@type': rdf:Property
-  marginality: required
-  owl:cardinality: many
-  rdfs:comment: url where the protocol can be found
-  rdfs:label: url
-  rdfs:sameAs:
-    '@id': schema:url
-  schema:domainIncludes:
-    '@id': outbreak:Protocol
-  schema:rangeIncludes:
-    '@id': schema:URL
-- '@id': outbreak:identifier
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: An identifier associated with the protocol (if available)
-  rdfs:label: identifier
-  rdfs:sameAs:
-    '@id': schema:identifier
-  schema:domainIncludes:
-    '@id': outbreak:Protocol
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:doi
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: A DOI associated with the protocol if available
-  rdfs:label: doi
-  rdfs:sameAs:
-    '@id': schema:identifier
-  schema:domainIncludes:
-    '@id': outbreak:Protocol
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:name
-  '@type': rdf:Property
-  marginality: required
-  owl:cardinality: one
-  rdfs:comment: name of the protocol
-  rdfs:label: name
-  rdfs:sameAs:
-    '@id': schema:name
-  schema:domainIncludes:
-    '@id': outbreak:Protocol
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:description
-  '@type': rdf:Property
-  marginality: required
-  owl:cardinality: one
-  rdfs:comment: description of the protocol
-  rdfs:label: description
-  rdfs:sameAs:
-    '@id': schema:description
-  schema:domainIncludes:
-    '@id': outbreak:Protocol
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:status
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The status of the protocol
-  rdfs:label: status
-  rdfs:sameAs:
-    '@id': schema:creativeWorkStatus
-  schema:domainIncludes:
-    '@id': outbreak:Protocol
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:measurementTechnique
-  '@type': rdf:Property
-  marginality: required
-  owl:cardinality: one
-  rdfs:comment: This is the measurement technique or assay type covered described
-    by the protocol
-  rdfs:label: measurementTechnique
-  rdfs:sameAs:
-    '@id': outbreak:measurementTechnique
-  schema:domainIncludes:
-    '@id': outbreak:Protocol
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:protocolSetting
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: The type of research setting in which a "protocol" is appropriate,
-    such as 'clinical', 'experimental', 'field', 'computational'
-  rdfs:label: protocolSetting
-  rdfs:sameAs:
-    '@id': schema:additionalType
-  schema:domainIncludes:
-    '@id': outbreak:Protocol
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:protocolCategory
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: The type of "protocol" such as guideline, procedure, policy, etc.
-  rdfs:label: protocolCategory
-  rdfs:sameAs:
-    '@id': schema:additionalType
-  schema:domainIncludes:
-    '@id': outbreak:Protocol
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:author
-  '@type': rdf:Property
-  marginality: required
-  owl:cardinality: many
-  rdfs:comment: person, people, or organization that created the protocol
-  rdfs:label: author
-  rdfs:sameAs:
-    '@id': schema:author
-  schema:domainIncludes:
-    '@id': outbreak:Protocol
-  schema:rangeIncludes:
-  - '@id': outbreak:Person
-  - '@id': outbreak:Organization
-- '@id': outbreak:name
-  '@type': rdf:Property
-  marginality: required
-  owl:cardinality: one
-  rdfs:comment: The name of the author as provided by the resource
-  rdfs:label: name
-  rdfs:sameAs:
-    '@id': schema:name
-  schema:domainIncludes:
-  - '@id': outbreak:Person
-  - '@id': outbreak:Organization
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:affiliation
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: The author's affiliation(s)
-  rdfs:label: affiliation
-  rdfs:sameAs:
-    '@id': schema:affiliation
-  schema:domainIncludes:
-  - '@id': outbreak:Person
-  - '@id': outbreak:Organization
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:material
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: the reagent, biological sample, or material such as PPE source materials)
-    used or tested in this protocol
-  rdfs:label: material
-  rdfs:sameAs:
-    '@id': schema:Product
-  schema:domainIncludes:
-    '@id': outbreak:Protocol
-  schema:rangeIncludes:
-    '@id': outbreak:Product
-- '@id': outbreak:name
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: The name of the material or reagent
-  rdfs:label: name
-  rdfs:sameAs:
-    '@id': schema:name
-  schema:domainIncludes:
-    '@id': outbreak:Product
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:manufacturer
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: The manufacturer, brand, or vendor of the material or reagent
-  rdfs:label: manufacturer
-  rdfs:sameAs:
-    '@id': schema:manufacturer
-  schema:domainIncludes:
-    '@id': outbreak:Product
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:identifier
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: The catalog number or identifier of the material or reagent
-  rdfs:label: identifier
-  rdfs:sameAs:
-    '@id': schema:identifier
-  schema:domainIncludes:
-    '@id': outbreak:Product
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:type
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: Type of material
-  rdfs:label: type
-  rdfs:sameAs:
-    '@id': schema:additionalType
-  schema:domainIncludes:
-    '@id': outbreak:Product
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:instrument
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: many
-  rdfs:comment: For LabProtocols it would be a laboratory equipment use by a person
-    to follow one or more steps described in this LabProtocol.
-  rdfs:label: instrument
-  rdfs:sameAs:
-    '@id': schema:Product
-  schema:domainIncludes:
-    '@id': outbreak:Protocol
-  schema:rangeIncludes:
-    '@id': outbreak:Instrument
-- '@id': outbreak:name
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The name/model number of the instrument
-  rdfs:label: name
-  rdfs:sameAs:
-    '@id': schema:name
-  schema:domainIncludes:
-    '@id': outbreak:Instrument
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:manufacturer
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The manufacturer, brand, or vendor of the instrument
-  rdfs:label: manufacturer
-  rdfs:sameAs:
-    '@id': schema:manufacturer
-  schema:domainIncludes:
-    '@id': outbreak:Instrument
-  schema:rangeIncludes:
-    '@id': schema:Text
 - '@id': outbreak:warning
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: many
-  rdfs:comment: Precautions, warnings, and/or safety warnings associated with the
-    protocol
+  '@type': rdfs:Property
+  rdfs:comment: Precautions, warnings, and/or safety warnings associated with or highlighted
+    by the protocol
   rdfs:label: warning
-  rdfs:sameAs:
-    '@id': schema:warning
   schema:domainIncludes:
     '@id': outbreak:Protocol
   schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:license
-  '@type': rdf:Property
-  marginality: required
-  owl:cardinality: one
-  rdfs:comment: License
-  rdfs:label: license
-  rdfs:sameAs:
-    '@id': schema:license
-  schema:domainIncludes:
-    '@id': outbreak:Protocol
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:funding
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: Funding for the generation of the protocol
-  rdfs:label: funding
-  rdfs:sameAs:
-    '@id': outbreak:MonetaryGrant
-  schema:domainIncludes:
-    '@id': outbreak:Protocol
-  schema:rangeIncludes:
-    '@id': outbreak:MonetaryGrant
-- '@id': outbreak:funder
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: The funder of the study
-  rdfs:label: funder
-  rdfs:sameAs:
-    '@id': schema:funder
-  schema:domainIncludes:
-    '@id': outbreak:MonetaryGrant
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:identifier
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: The identifier of the grant (if available)
-  rdfs:label: identifier
-  rdfs:sameAs:
-    '@id': schema:identifier
-  schema:domainIncludes:
-    '@id': outbreak:MonetaryGrant
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:datePublished
-  '@type': rdf:Property
-  marginality: required
-  owl:cardinality: one
-  rdfs:comment: PublicationDate of the protocol online if available
-  rdfs:label: datePublished
-  rdfs:sameAs:
-    '@id': schema:datePublished
-  schema:domainIncludes:
-    '@id': outbreak:Protocol
-  schema:rangeIncludes:
-    '@id': schema:Date
-- '@id': outbreak:dateModified
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: many
-  rdfs:comment: Date of protocol update
-  rdfs:label: dateModified
-  rdfs:sameAs:
-    '@id': schema:dateModified
-  schema:domainIncludes:
-    '@id': outbreak:Protocol
-  schema:rangeIncludes:
-    '@id': schema:Date
-- '@id': outbreak:correction
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: many
+  - '@id': schema:Text
+- '@id': outbreak:correctionNote
+  '@type': rdfs:Property
   rdfs:comment: statement of what was updated/changed since prior version
-  rdfs:label: correction
-  rdfs:sameAs:
-    '@id': schema:correction
+  rdfs:label: correctionNote
   schema:domainIncludes:
     '@id': outbreak:Protocol
   schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:citedBy
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: many
-  owl:inverseOf:
-    '@id': schema:isBasedOn
-  rdfs:comment: Associated guidelines, protocols, publications, etc. that include,
-    adapt, modify, expand, etc. this protocol.
-  rdfs:label: citedBy
+  - '@id': schema:Text
+- '@id': outbreak:protocolStatus
+  '@type': rdfs:Property
+  rdfs:comment: The status of the protocol
+  rdfs:label: protocolStatus
   schema:domainIncludes:
     '@id': outbreak:Protocol
   schema:rangeIncludes:
-  - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-- '@id': outbreak:name
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: name of the resource (publication, protocol, etc.) which was derived
-    from this protocol
-  rdfs:label: name
-  rdfs:sameAs:
-    '@id': schema:name
-  schema:domainIncludes:
-  - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:type
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: type of resource which was derived from this protocol
-  rdfs:label: type
-  rdfs:sameAs:
-    '@id': schema:additionalType
-  schema:domainIncludes:
-  - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:identifier
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: identifier for this resource which was derived from this protocol
-  rdfs:label: identifier
-  rdfs:sameAs:
-    '@id': schema:identifier
-  schema:domainIncludes:
-  - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:isBasedOn
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: many
-  rdfs:comment: Associated resource (guidelines, protocols, publications, etc.) from
-    which this protocol was derived
-  rdfs:label: isBasedOn
-  rdfs:sameAs:
-    '@id': schema:isBasedOn
+  - '@id': schema:Text
+- '@id': outbreak:instrument
+  '@type': rdfs:Property
+  rdfs:comment: A laboratory equipment use by a person to follow one or more steps
+    described in this Protocol
+  rdfs:label: instrument
   schema:domainIncludes:
     '@id': outbreak:Protocol
   schema:rangeIncludes:
-  - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-- '@id': outbreak:name
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: name of the associated resource from which this protocol was derived
-  rdfs:label: name
-  rdfs:sameAs:
-    '@id': schema:name
-  schema:domainIncludes:
-  - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:type
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: Type of resource (publication, analysis, ClinicalTrial, dataset, etc.)
-    from which this protocol was derived
-  rdfs:label: type
-  rdfs:sameAs:
-    '@id': schema:additionalType
-  schema:domainIncludes:
-  - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:identifier
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: Identifier for the resource
-  rdfs:label: identifier
-  rdfs:sameAs:
-    '@id': schema:identifier
-  schema:domainIncludes:
-  - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:versionDate
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: date of the version of the resource from which this protocol was derived.
-    Note this is NOT the same as dateModified, as the protocol may be based on an
-    earlier 'dateModified' than is what is available from the resource
-  rdfs:label: versionDate
-  rdfs:sameAs:
-    '@id': schema:releaseDate
-  schema:domainIncludes:
-  - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-  schema:rangeIncludes:
-    '@id': schema:Date
-- '@id': outbreak:relatedTo
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: many
-  rdfs:comment: Other resources related to, but not a derivative of nor derived from
-    this protocol
-  rdfs:label: relatedTo
-  rdfs:sameAs:
-    '@id': schema:relatedTo
+  - '@id': outbreak:Instrument
+- '@id': outbreak:protocolSetting
+  '@type': rdfs:Property
+  rdfs:comment: The type of 'protocol' based on setting in which it would apply
+  rdfs:label: protocolSetting
   schema:domainIncludes:
     '@id': outbreak:Protocol
   schema:rangeIncludes:
-  - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-- '@id': outbreak:name
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: name of related resource
-  rdfs:label: name
-  rdfs:sameAs:
-    '@id': schema:name
-  schema:domainIncludes:
-  - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:type
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: type of related resource
-  rdfs:label: type
-  rdfs:sameAs:
-    '@id': schema:additionalType
-  schema:domainIncludes:
-  - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:identifier
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: identifier (if available_ of related resource
-  rdfs:label: identifier
-  rdfs:sameAs:
-    '@id': schema:identifier
-  schema:domainIncludes:
-  - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:topicCategory
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: Applicable outbreak.info category
-  rdfs:label: topicCategory
-  rdfs:sameAs:
-    '@id': schema:about
+  - '@id': schema:Text
+- '@id': outbreak:protocolCategory
+  '@type': rdfs:Property
+  rdfs:comment: The type of 'protocol' based on degree of specificity and purpose
+  rdfs:label: protocolCategory
   schema:domainIncludes:
     '@id': outbreak:Protocol
   schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:keywords
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: keywords
-  rdfs:label: keywords
-  rdfs:sameAs:
-    '@id': schema:keywords
-  schema:domainIncludes:
-    '@id': outbreak:Protocol
-  schema:rangeIncludes:
-    '@id': schema:Text
+  - '@id': schema:Text
 - '@id': outbreak:usedToGenerate
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: many
+  '@type': rdfs:Property
   rdfs:comment: Type of evidence/data generated by the protocol
   rdfs:label: usedToGenerate
-  rdfs:sameAs:
-    '@id': schema:additionalType
   schema:domainIncludes:
     '@id': outbreak:Protocol
   schema:rangeIncludes:
-    '@id': schema:Text
+  - '@id': schema:Text
 - '@id': outbreak:inComplianceWith
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: many
+  '@type': rdfs:Property
   rdfs:comment: Guidelines or Standards to which these protocols adhere. ie- GMP,
     GCP, other EQUATOR guidelines. Useful for selecting protocols where certain standards/guidelines
     must be met
   rdfs:label: inComplianceWith
-  rdfs:sameAs:
-    '@id': schema:additionalType
   schema:domainIncludes:
     '@id': outbreak:Protocol
   schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:duration
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: The time it takes to actually carry out the protocol, in ISO 8601
-    date format.
-  rdfs:label: duration
-  rdfs:sameAs:
-    '@id': schema:performTime
+  - '@id': schema:Text
+- '@id': outbreak:StudyEvent
+  '@type': rdfs:Class
+  rdfs:comment: This is the schema for describing StudyEvents, a class that describes
+    categorical events in Clinical Trials added to outbreak.info
+  rdfs:label: StudyEvent
+  rdfs:subClassOf:
+    '@id': schema:Thing
+- '@id': outbreak:studyEventType
+  '@type': rdfs:Property
+  rdfs:comment: Type of the event status such as StudyStart, PrimaryCompletion, Completion,
+    StudyFirstSubmit, StudyFirstSubmitQC, LastUpdateSubmit
+  rdfs:label: studyEventType
   schema:domainIncludes:
-    '@id': outbreak:Protocol
+    '@id': outbreak:StudyEvent
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:studyEventDate
+  '@type': rdfs:Property
+  rdfs:comment: The corresponding/actual date of the study event (ie- the StartDate,
+    Primary CompletionDate, CompletionDate, StudyFirstSubmitDate, StudyFirstSubmitQCDate,
+    LastUpdateSubmitDate)
+  rdfs:label: studyEventDate
+  schema:domainIncludes:
+    '@id': outbreak:StudyEvent
+  schema:rangeIncludes:
+  - '@id': schema:Date
+- '@id': outbreak:studyEventDateType
+  '@type': rdfs:Property
+  rdfs:comment: the type of date provided (actual, anticipated, or estimated)
+  rdfs:label: studyEventDateType
+  schema:domainIncludes:
+    '@id': outbreak:StudyEvent
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:StudyStatus
+  '@type': rdfs:Class
+  rdfs:comment: This is the schema for describing the status of a ClinicalTrial resource
+    in outbreak.info
+  rdfs:label: StudyStatus
+  rdfs:subClassOf:
+    '@id': schema:Thing
+- '@id': outbreak:status
+  '@type': rdfs:Property
+  rdfs:comment: The recruitment status of the study
+  rdfs:label: status
+  rdfs:sameAs:
+    '@id': schema:status
+  schema:domainIncludes:
+    '@id': outbreak:StudyStatus
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:statusExpandedAccess
+  '@type': rdfs:Property
+  rdfs:comment: Flag for whether or not the study has expanded Access status
+  rdfs:label: statusExpandedAccess
+  schema:domainIncludes:
+    '@id': outbreak:StudyStatus
+  schema:rangeIncludes:
+  - '@id': schema:Boolean
+- '@id': outbreak:statusDate
+  '@type': rdfs:Property
+  rdfs:comment: The date that the status was verified. Equivalent to NCT's StatusVerifiedDate
+  rdfs:label: statusDate
+  schema:domainIncludes:
+    '@id': outbreak:StudyStatus
+  schema:rangeIncludes:
+  - '@id': schema:Date
+- '@id': outbreak:enrollmentCount
+  '@type': rdfs:Property
+  rdfs:comment: The number of participants enrolled in the study
+  rdfs:label: enrollmentCount
+  schema:domainIncludes:
+    '@id': outbreak:StudyStatus
+  schema:rangeIncludes:
+  - '@id': schema:Number
+- '@id': outbreak:enrollmentType
+  '@type': rdfs:Property
+  rdfs:comment: The type of estimation used to determine the enrollmentCount (actual
+    counts, target size, etc.)
+  rdfs:label: enrollmentType
+  schema:domainIncludes:
+    '@id': outbreak:StudyStatus
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:whyStopped
+  '@type': rdfs:Property
+  rdfs:comment: A brief explanation of the reason(s) why such clinical study was stopped
+    (for a clinical study that is Suspended, Terminated, or Withdrawn prior to its
+    planned completion as anticipated by the protocol)
+  rdfs:label: whyStopped
+  schema:domainIncludes:
+    '@id': outbreak:StudyStatus
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:StudyDesign
+  '@type': rdfs:Class
+  rdfs:comment: This is the schema for describing the study design of a clinical trial/study
+    for inclusion into outbreak.info resources
+  rdfs:label: StudyDesign
+  rdfs:subClassOf:
+    '@id': schema:Thing
+- '@id': outbreak:studyType
+  '@type': rdfs:Property
+  rdfs:comment: Type of human study, can be subtypes of observational study or interventional
+    studies and may include the temporal relationship of observation period to time
+    of participant enrollment.
+  rdfs:label: studyType
+  schema:domainIncludes:
+    '@id': outbreak:StudyDesign
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:phase
+  '@type': rdfs:Property
+  rdfs:comment: Stage or phase of the study in the U.S. if applicable
+  rdfs:label: phase
+  rdfs:sameAs:
+    '@id': schema:phase
+  schema:domainIncludes:
+    '@id': outbreak:StudyDesign
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:phaseNumber
+  '@type': rdfs:Property
+  rdfs:comment: The number of the phase or stage of the study
+  rdfs:label: phaseNumber
+  schema:domainIncludes:
+    '@id': outbreak:StudyDesign
+  schema:rangeIncludes:
+  - '@id': schema:Number
+- '@id': outbreak:designAllocation
+  '@type': rdfs:Property
+  rdfs:comment: The method by which the study participants were allocated into groups
+  rdfs:label: designAllocation
+  schema:domainIncludes:
+    '@id': outbreak:StudyDesign
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:designModel
+  '@type': rdfs:Property
+  rdfs:comment: The general design of the strategy for assigning interventions to
+    participants in a clinical intervention study OR the general design of the strategy
+    for identifying and following up with participants during an observational study
+  rdfs:label: designModel
+  schema:domainIncludes:
+    '@id': outbreak:StudyDesign
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:designPrimaryPurpose
+  '@type': rdfs:Property
+  rdfs:comment: The primary purpose of the study
+  rdfs:label: designPrimaryPurpose
+  schema:domainIncludes:
+    '@id': outbreak:StudyDesign
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:designWhoMasked
+  '@type': rdfs:Property
+  rdfs:comment: The people who do not know which participants have been assigned to
+    which interventions
+  rdfs:label: designWhoMasked
+  schema:domainIncludes:
+    '@id': outbreak:StudyDesign
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:designStudyText
+  '@type': rdfs:Property
+  rdfs:comment: String description of the study design if structured information not
+    available
+  rdfs:label: designStudyText
+  schema:domainIncludes:
+    '@id': outbreak:StudyDesign
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:Intervention
+  '@type': rdfs:Class
+  rdfs:comment: a schema to describe Interventions discussed in Clinical Studies/Trials
+    for inclusion in outbreak.info Resources
+  rdfs:label: Intervention
+  rdfs:subClassOf:
+    '@id': schema:Thing
+- '@id': outbreak:category
+  '@type': rdfs:Property
+  rdfs:comment: The category of an intervention in the study
+  rdfs:label: category
+  schema:domainIncludes:
+    '@id': outbreak:Intervention
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:ArmGroup
+  '@type': rdfs:Class
+  rdfs:comment: This is the schema for describing arm groups in clinical studies/trials
+    for inclusion in outbreak.info Resources
+  rdfs:label: ArmGroup
+  rdfs:subClassOf:
+    '@id': schema:Thing
+- '@id': outbreak:intervention
+  '@type': rdfs:Property
+  rdfs:comment: The interventions (if any) in this ArmGroup
+  rdfs:label: intervention
+  schema:domainIncludes:
+    '@id': outbreak:ArmGroup
+  schema:rangeIncludes:
+  - '@id': outbreak:Intervention
+- '@id': outbreak:Outcome
+  '@type': rdfs:Class
+  rdfs:comment: This is the schema for describing a Clinical Trial/Study Outcome for
+    inclusion in  outbreak.info Resources
+  rdfs:label: Outcome
+  rdfs:subClassOf:
+    '@id': schema:Thing
+- '@id': outbreak:outcomeMeasure
+  '@type': rdfs:Property
+  rdfs:comment: The outcome measure for the study
+  rdfs:label: outcomeMeasure
+  schema:domainIncludes:
+    '@id': outbreak:Outcome
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:outcomeTimeFrame
+  '@type': rdfs:Property
+  rdfs:comment: The specific time point(s) and overall duration of evaluation must
+    be specified in this section
+  rdfs:label: outcomeTimeFrame
+  schema:domainIncludes:
+    '@id': outbreak:Outcome
   schema:rangeIncludes:
   - '@id': schema:Duration
   - '@id': schema:Text
-- '@id': outbreak:curatedBy
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  owl:inverseOf:
-    '@id': schema:isBasedOn
-  rdfs:comment: The source from which this Analysis was identified for inclusion into
-    Outbreak.info. Provides provenance for a resource which was curated by another
-  rdfs:label: curatedBy
+- '@id': outbreak:outcomeType
+  '@type': rdfs:Property
+  rdfs:comment: The classification of the outcome measure as either primary, secondary,
+    or exploratory
+  rdfs:label: outcomeType
   schema:domainIncludes:
-    '@id': outbreak:Protocol
+    '@id': outbreak:Outcome
   schema:rangeIncludes:
-  - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-- '@id': outbreak:name
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: name of the source from which this Analysis was identified for inclusion
-  rdfs:label: name
-  rdfs:sameAs:
-    '@id': schema:name
-  schema:domainIncludes:
-  - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:url
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The corresponding url for the item in the source from which this Analysis
-    was identified (if available)
-  rdfs:label: url
-  rdfs:sameAs:
-    '@id': schema:url
-  schema:domainIncludes:
-  - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:versionDate
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: The last date when items were pulled from the source
-  rdfs:label: versionDate
-  rdfs:sameAs:
-    '@id': schema:releaseDate
-  schema:domainIncludes:
-  - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-  schema:rangeIncludes:
-    '@id': schema:Date
-- '@id': outbreak:curationDate
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The date this resource was added to outbreak.info, or the date when
-    this resource was updated in outbreak.info
-  rdfs:label: curationDate
-  rdfs:sameAs:
-    '@id': schema:releaseDate
-  schema:domainIncludes:
-    '@id': outbreak:Protocol
-  schema:rangeIncludes:
-    '@id': schema:Date
-- '@id': outbreak:Publication
+  - '@id': schema:Text
+- '@id': outbreak:Eligibility
   '@type': rdfs:Class
-  rdfs:comment: This is the schema for describing the Publication schema used for
-    outbreak.info.
-  rdfs:label: Publication
+  rdfs:comment: This is the schema for describing information about Clinical Trials/Studies
+    eligibility criteria for inclusion in outbreak.info Resources
+  rdfs:label: Eligibility
   rdfs:subClassOf:
-    '@id': schema:ScholarlyArticle
-  schema:isPartOf:
-    '@id': https://discovery.biothings.io/view/outbreak/
+    '@id': schema:Thing
+- '@id': outbreak:inclusionCriteria
+  '@type': rdfs:Property
+  rdfs:comment: '"criteria for inclusion in the study'
+  rdfs:label: inclusionCriteria
+  schema:domainIncludes:
+    '@id': outbreak:Eligibility
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:minimumAge
+  '@type': rdfs:Property
+  rdfs:comment: the minimum age for a participant to be included in the study
+  rdfs:label: minimumAge
+  schema:domainIncludes:
+    '@id': outbreak:Eligibility
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:maximumAge
+  '@type': rdfs:Property
+  rdfs:comment: the maximum age for a participant to be included in the study
+  rdfs:label: maximumAge
+  schema:domainIncludes:
+    '@id': outbreak:Eligibility
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:gender
+  '@type': rdfs:Property
+  rdfs:comment: the sex requirement to be included in the study
+  rdfs:label: gender
+  schema:domainIncludes:
+    '@id': outbreak:Eligibility
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:genderBased
+  '@type': rdfs:Property
+  rdfs:comment: Boolean for whether or not participation is based on gender
+  rdfs:label: genderBased
+  schema:domainIncludes:
+    '@id': outbreak:Eligibility
+  schema:rangeIncludes:
+  - '@id': schema:Boolean
+- '@id': outbreak:healthyVolunteers
+  '@type': rdfs:Property
+  rdfs:comment: Boolean to indicate whether or not healthy volunteers may be included
+    in the study
+  rdfs:label: healthyVolunteers
+  schema:domainIncludes:
+    '@id': outbreak:Eligibility
+  schema:rangeIncludes:
+  - '@id': schema:Boolean
+- '@id': outbreak:stdAge
+  '@type': rdfs:Property
+  rdfs:comment: the age category of a participant to be included in the study if a
+    minimum and maximum age is not specified
+  rdfs:label: stdAge
+  schema:domainIncludes:
+    '@id': outbreak:Eligibility
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:exclusionCriteria
+  '@type': rdfs:Property
+  rdfs:comment: criteria for exclusion from the study
+  rdfs:label: exclusionCriteria
+  schema:domainIncludes:
+    '@id': outbreak:Eligibility
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:criteriaText
+  '@type': rdfs:Property
+  rdfs:comment: The descriptive criteria as published for the Clinical Trial
+  rdfs:label: criteriaText
+  schema:domainIncludes:
+    '@id': outbreak:Eligibility
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:StudyLocation
+  '@type': rdfs:Class
+  rdfs:comment: This is the schema for describing Clinical Trial/Study locations for
+    inclusion in outbreak.info Resources
+  rdfs:label: StudyLocation
+  rdfs:subClassOf:
+    '@id': schema:Place
+- '@id': outbreak:studyLocation
+  '@type': rdfs:Property
+  rdfs:comment: The location of the study
+  rdfs:label: studyLocation
+  schema:domainIncludes:
+    '@id': outbreak:StudyLocation
+  schema:rangeIncludes:
+  - '@id': schema:Place
+  - '@id': schema:Text
+- '@id': outbreak:studyLocationCity
+  '@type': rdfs:Property
+  rdfs:comment: The city in which the facility used for the study is located
+  rdfs:label: studyLocationCity
+  schema:domainIncludes:
+    '@id': outbreak:StudyLocation
+  schema:rangeIncludes:
+  - '@id': schema:City
+  - '@id': schema:Text
+- '@id': outbreak:studyLocationState
+  '@type': rdfs:Property
+  rdfs:comment: The state or province in which the facility used for the study is
+    located
+  rdfs:label: studyLocationState
+  schema:domainIncludes:
+    '@id': outbreak:StudyLocation
+  schema:rangeIncludes:
+  - '@id': schema:State
+  - '@id': schema:Text
+- '@id': outbreak:studyLocationCountry
+  '@type': rdfs:Property
+  rdfs:comment: The country in which the facility used for the study is located
+  rdfs:label: studyLocationCountry
+  schema:domainIncludes:
+    '@id': outbreak:StudyLocation
+  schema:rangeIncludes:
+  - '@id': schema:Country
+  - '@id': schema:Text
+- '@id': outbreak:studyLocationStatus
+  '@type': rdfs:Property
+  rdfs:comment: The recruitment status of the study at the specific study site
+  rdfs:label: studyLocationStatus
+  schema:domainIncludes:
+    '@id': outbreak:StudyLocation
+  schema:rangeIncludes:
+  - '@id': schema:Text
 - '@id': outbreak:ClinicalTrial
   '@type': rdfs:Class
-  rdfs:comment: This is the schema for describing the ClinicalTrial schema used for
-    outbreak.info.
+  rdfs:comment: This is the schema for describing the Clinical Trials and other medical
+    studies used for outbreak.info Resources
   rdfs:label: ClinicalTrial
   rdfs:subClassOf:
     '@id': schema:MedicalStudy
-  schema:isPartOf:
-    '@id': https://discovery.biothings.io/view/outbreak/
-'@id': https://discovery.biothings.io/view/outbreak/
+- '@id': outbreak:identifierSource
+  '@type': rdfs:Property
+  rdfs:comment: Source of identifier assignment or type of identifier (NCTid, China
+    CTRid, EudraCT Number, etc.)
+  rdfs:label: identifierSource
+  schema:domainIncludes:
+    '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:dateModifiedType
+  '@type': rdfs:Property
+  rdfs:comment: The type of date. Equivalent to NCT's LastUpdatePostDateType
+  rdfs:label: dateModifiedType
+  schema:domainIncludes:
+    '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:healthConditionIdentifier
+  '@type': rdfs:Property
+  rdfs:comment: Ontological or controlled vocabulary identifier for the health condition
+    or disease
+  rdfs:label: healthConditionIdentifier
+  schema:domainIncludes:
+    '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': schema:Text
+  - '@id': schema:DefinedTerm
+- '@id': outbreak:hasResults
+  '@type': rdfs:Property
+  rdfs:comment: Boolean for if the clinical trial has published any results
+  rdfs:label: hasResults
+  schema:domainIncludes:
+    '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': schema:Boolean
+- '@id': outbreak:studyEvent
+  '@type': rdfs:Property
+  rdfs:comment: an event status such as StudyStart, PrimaryCompletion, Completion,
+    StudyFirstSubmit, StudyFirstSubmitQC, LastUpdateSubmit
+  rdfs:label: studyEvent
+  schema:domainIncludes:
+    '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': outbreak:StudyEvent
+- '@id': outbreak:studyStatus
+  '@type': rdfs:Property
+  rdfs:comment: The status of the study
+  rdfs:label: studyStatus
+  schema:domainIncludes:
+    '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': outbreak:StudyStatus
+- '@id': outbreak:studyDesign
+  '@type': rdfs:Property
+  rdfs:comment: The general design of the study
+  rdfs:label: studyDesign
+  schema:domainIncludes:
+    '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': outbreak:StudyDesign
+- '@id': outbreak:armGroup
+  '@type': rdfs:Property
+  rdfs:comment: The arm or factor of an interventional study
+  rdfs:label: armGroup
+  schema:domainIncludes:
+    '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': outbreak:ArmGroup
+- '@id': outbreak:outcome
+  '@type': rdfs:Property
+  rdfs:comment: The arm or factor of an interventional study
+  rdfs:label: outcome
+  schema:domainIncludes:
+    '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': outbreak:Outcome
+- '@id': outbreak:eligibilityCriteria
+  '@type': rdfs:Property
+  rdfs:comment: eligibility criteria
+  rdfs:label: eligibilityCriteria
+  schema:domainIncludes:
+    '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': outbreak:Eligibility
+- '@id': outbreak:author
+  '@type': rdfs:Property
+  rdfs:comment: The author of this resource, content, or rating
+  rdfs:label: author
+  rdfs:sameAs:
+    '@id': schema:author
+  schema:domainIncludes:
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Protocol
+  - '@id': outbreak:Publication
+  - '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': outbreak:Person
+  - '@id': outbreak:Organization
+- '@id': outbreak:dateCreated
+  '@type': rdfs:Property
+  rdfs:comment: Date the record was created
+  rdfs:label: dateCreated
+  rdfs:sameAs:
+    '@id': schema:dateCreated
+  schema:domainIncludes:
+  - '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': schema:Date
+- '@id': outbreak:datePublished
+  '@type': rdfs:Property
+  rdfs:comment: Date of first broadcast/publication
+  rdfs:label: datePublished
+  rdfs:sameAs:
+    '@id': schema:datePublished
+  schema:domainIncludes:
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Protocol
+  - '@id': outbreak:Publication
+  - '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': schema:Date
+- '@id': outbreak:dateModified
+  '@type': rdfs:Property
+  rdfs:comment: The date on which the CreativeWork was most recently modified or when
+    the item's entry was modified within a DataFeed
+  rdfs:label: dateModified
+  rdfs:sameAs:
+    '@id': schema:dateModified
+  schema:domainIncludes:
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Protocol
+  - '@id': outbreak:Publication
+  - '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': schema:Date
+- '@id': outbreak:keywords
+  '@type': rdfs:Property
+  rdfs:comment: keywords for describing the record
+  rdfs:label: keywords
+  schema:domainIncludes:
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Protocol
+  - '@id': outbreak:Publication
+  - '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:abstract
+  '@type': rdfs:Property
+  rdfs:comment: A short descriptive summary of the publication or study
+  rdfs:label: abstract
+  rdfs:sameAs:
+    '@id': schema:abstract
+  schema:domainIncludes:
+  - '@id': outbreak:Publication
+  - '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:pmid
+  '@type': rdfs:Property
+  rdfs:comment: A pubmed identifier if available
+  rdfs:label: pmid
+  schema:domainIncludes:
+  - '@id': outbreak:CitationObject
+  - '@id': outbreak:Correction
+  - '@id': outbreak:Publication
+  schema:rangeIncludes:
+  - '@id': schema:Integer
+- '@id': outbreak:doi
+  '@type': rdfs:Property
+  rdfs:comment: A doi if available
+  rdfs:label: doi
+  schema:domainIncludes:
+  - '@id': outbreak:CitationObject
+  - '@id': outbreak:Correction
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Publication
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Protocol
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:funding
+  '@type': rdfs:Property
+  rdfs:comment: Funding that supports (sponsors) the collection of this dataset through
+    some kind of financial contribution
+  rdfs:label: funding
+  schema:domainIncludes:
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Publication
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Protocol
+  - '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': schema:MonetaryGrant
+- '@id': outbreak:measurementTechnique
+  '@type': rdfs:Property
+  rdfs:comment: A technique or technology used in this resource
+  rdfs:label: measurementTechnique
+  rdfs:sameAs:
+    '@id': schema:measurementTechnique
+  schema:domainIncludes:
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Protocol
+  schema:rangeIncludes:
+  - '@id': schema:Text
+  - '@id': schema:DefinedTerm
+- '@id': outbreak:species
+  '@type': rdfs:Property
+  rdfs:comment: Species(es) from which dataset has been collected
+  rdfs:label: species
+  schema:domainIncludes:
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Analysis
+  schema:rangeIncludes:
+  - '@id': schema:Text
+  - '@id': schema:DefinedTerm
+- '@id': outbreak:infectiousAgent
+  '@type': rdfs:Property
+  rdfs:comment: infectious agents(s) which are the focus of the dataset
+  rdfs:label: infectiousAgent
+  schema:domainIncludes:
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Analysis
+  schema:rangeIncludes:
+  - '@id': schema:Text
+  - '@id': schema:DefinedTerm
+- '@id': outbreak:infectiousDisease
+  '@type': rdfs:Property
+  rdfs:comment: The disease or medical conditions caused by the infectious agent.
+    Important as some agents may cause multiple diseases
+  rdfs:label: infectiousDisease
+  schema:domainIncludes:
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Analysis
+  schema:rangeIncludes:
+  - '@id': schema:Text
+  - '@id': schema:DefinedTerm
+- '@id': outbreak:topicCategory
+  '@type': rdfs:Property
+  rdfs:comment: Applicable outbreak.info category
+  rdfs:label: topicCategory
+  schema:domainIncludes:
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Publication
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Protocol
+  - '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:isBasedOn
+  '@type': rdfs:Property
+  rdfs:comment: A citation to a resource (eg- publication, protocol, etc.) on which
+    this resource was derived (stored as an object, not a string)
+  rdfs:label: isBasedOn
+  schema:domainIncludes:
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Publication
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Protocol
+  - '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': outbreak:CitationObject
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Publication
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Protocol
+  - '@id': outbreak:ClinicalTrial
+  - '@id': schema:SoftwareApplication
+  - '@id': schema:CreativeWork
+- '@id': outbreak:isRelatedTo
+  '@type': rdfs:Property
+  rdfs:comment: A citation to a resource (eg- publication, protocol, etc.) which is
+    related to the resource but is not a derivative nor was derived from the resource
+    (stored as an object, not a string)
+  rdfs:label: isRelatedTo
+  schema:domainIncludes:
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Publication
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Protocol
+  - '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': outbreak:CitationObject
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Publication
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Protocol
+  - '@id': outbreak:ClinicalTrial
+  - '@id': schema:SoftwareApplication
+  - '@id': schema:CreativeWork
+- '@id': outbreak:citedBy
+  '@type': rdfs:Property
+  rdfs:comment: A citation to a resource (eg- publication, protocol, etc.) which is
+    derived from this resource (stored as an object, not a string)
+  rdfs:label: citedBy
+  rdfs:sameAs:
+    '@id': 'owl:inverseOf: outbreak:isBasedOn'
+  schema:domainIncludes:
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Publication
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Protocol
+  - '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': outbreak:CitationObject
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Publication
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Protocol
+  - '@id': outbreak:ClinicalTrial
+  - '@id': schema:SoftwareApplication
+  - '@id': schema:CreativeWork
+- '@id': outbreak:curatedBy
+  '@type': rdfs:Property
+  rdfs:comment: The source from which this Dataset was identified for inclusion into
+    Outbreak.info. Provides provenance for a resource which was curated by another.
+  rdfs:label: curatedBy
+  schema:domainIncludes:
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Publication
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Protocol
+  - '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': outbreak:Person
+  - '@id': outbreak:Organization
+  - '@id': outbreak:CitationObject
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Publication
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Protocol
+  - '@id': outbreak:ClinicalTrial
+  - '@id': schema:SoftwareApplication
+  - '@id': schema:CreativeWork
+- '@id': outbreak:curationDate
+  '@type': rdfs:Property
+  rdfs:comment: The date this resource was added into outbreak.info, or was updated
+    in outbreak.info.
+  rdfs:label: curationDate
+  schema:domainIncludes:
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Publication
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Protocol
+  - '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': schema:Date
+- '@id': outbreak:evaluations
+  '@type': rdf:Property
+  rdfs:comment: One or more reviews, ratings, or other evaluations of this resource
+  rdfs:label: evaluations
+  schema:domainIncludes:
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Publication
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Protocol
+  - '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': schema:Review
+  - '@id': schema:Rating
+  - '@id': schema:AggregateRating

--- a/yaml/outbreak_Publication.json
+++ b/yaml/outbreak_Publication.json
@@ -1,167 +1,682 @@
 {
   "@context": {
-    "outbreak": "https://discovery.biothings.io/view/outbreak/",
-    "owl": "http://www.w3.org/2002/07/owl/",
-    "rdf": "http://www.w3.org/1999/02/22/-rdf-syntax-ns/",
-    "rdfs": "http://www.w3.org/2000/01/rdf/-schema/",
-    "schema": "http://schema.org/"
+    "schema": "http://schema.org/",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "outbreak": "http://discovery.biothings.io/view/"
   },
-  "@id": "https://discovery.biothings.io/view/outbreak/",
   "@graph": [
-    {
-      "@id": "outbreak:Organization",
-      "@type": "rdfs:Class",
-      "rdfs:label": "Organization",
-      "rdfs:comment": "This is the schema for describing the Organization schema used for outbreak.info.",
-      "rdfs:subClassOf": {
-        "@id": "schema:Organization"
-      },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
-      }
-    },
-    {"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"The name of the organization, team or group","rdfs:label":"name","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":{"@id":"outbreak:Organization"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:alternateName","@type":"rdf:Property","rdfs:comment":"Alternative names or commonly used abbreviations for the organization, team or group","rdfs:label":"alternateName","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:alternateName"},"schema:domainIncludes":{"@id":"outbreak:Organization"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:affiliation","@type":"rdf:Property","rdfs:comment":"An overarching consortia, multi-institutional team or group in which the organization\/team\/group is a member or affiliate","rdfs:label":"affiliation","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:affiliation"},"schema:domainIncludes":{"@id":"outbreak:Organization"},"schema:rangeIncludes":{"@id":"outbreak:Organization"}},{"@id":"outbreak:affiliationStatus","@type":"rdf:Property","rdfs:comment":"The status of the organization's membership or affiliation in the overarching consortial, multi-institutional team or group (current, past)","rdfs:label":"affiliationStatus","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":{"@id":"outbreak:Organization"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:members","@type":"rdf:Property","rdfs:comment":"Members of this organization, team, or group","rdfs:label":"members","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:members"},"schema:domainIncludes":{"@id":"outbreak:Organization"},"schema:rangeIncludes":[{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"}]},{"@id":"outbreak:membershipStatus","@type":"rdf:Property","rdfs:comment":"Status of the members of this organization","rdfs:label":"membershipStatus","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":{"@id":"outbreak:Organization"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:isRelatedTo","@type":"rdf:Property","rdfs:comment":"A resource which a person played a role","rdfs:label":"isRelatedTo","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:isRelatedTo"},"schema:domainIncludes":{"@id":"outbreak:Organization"},"schema:rangeIncludes":[{"@id":"schema:CreativeWork"},{"@id":"schema:HowTo"}]},{"@id":"outbreak:class","@type":"rdf:Property","rdfs:comment":"A classification of the organization by a resource. Eg- for ClinicalTrials funders, it's [\"U.S. National Institutes of Health\", \"Other U.S. Federal agencies\", \"Industry\", \"All others\"]","rdfs:label":"class","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:addtionalType"},"schema:domainIncludes":[{"@id":"schema:CreativeWork"},{"@id":"schema:HowTo"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:role","@type":"rdf:Property","rdfs:comment":"The role of an organization in its involvement with a resource","rdfs:label":"role","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":[{"@id":"schema:CreativeWork"},{"@id":"schema:HowTo"}],"schema:rangeIncludes":{"@id":"schema:Text"}},
     {
       "@id": "outbreak:Person",
       "@type": "rdfs:Class",
+      "rdfs:comment": "This is the Person schema for describing authors and people for outbreak.info resources",
       "rdfs:label": "Person",
-      "rdfs:comment": "This is the schema for describing the Person schema used for outbreak.info.",
       "rdfs:subClassOf": {
         "@id": "schema:Person"
       },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
+      "$validation": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "The name of the person.",
+            "type": "string"
+          },
+          "alternateName": {
+            "description": "An alias for the person.",
+            "type": "string"
+          },
+          "familyName": {
+            "description": "Family name. In the U.S., the last name of an Person. This can be used along with givenName instead of the name property.",
+            "type": "string"
+          },
+          "givenName": {
+            "description": "Given name. In the U.S., the first name of a Person. This can be used along with familyName instead of the name property.",
+            "type": "string"
+          },
+          "affiliation": {
+            "description": "An organization that this person is affiliated with. For example, a school/university, a club, or a team.",
+            "oneOf": [
+              {
+                "$ref": "#/definitions/baseOrgObject"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/baseOrgObject"
+                }
+              }
+            ]
+          },
+          "orcid": {
+            "description": "the ORCID ID of the person",
+            "type": "string"
+          },
+          "role": {
+            "description": "authorship, sponsorship, or other contribution role played by the person or organization in the creation of this resource",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            ]
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "definitions":{
+            "baseOrgObject": {
+                "@type": "outbreak:Organization",
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "alternateName": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ]   
+            }
+        }
       }
     },
-    {"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"The name of the person","rdfs:label":"name","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":{"@id":"outbreak:Person"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:alternateName","@type":"rdf:Property","rdfs:comment":"Alternative ways in which the person's name is included in a record","rdfs:label":"alternateName","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:alternateName"},"schema:domainIncludes":{"@id":"outbreak:Person"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:givenName","@type":"rdf:Property","rdfs:comment":"The given name of the person","rdfs:label":"givenName","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:givenName"},"schema:domainIncludes":{"@id":"outbreak:Person"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:familyName","@type":"rdf:Property","rdfs:comment":"The family name of the person","rdfs:label":"familyName","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:familyName"},"schema:domainIncludes":{"@id":"outbreak:Person"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:affiliation","@type":"rdf:Property","rdfs:comment":"The organization with which the person is affiliated or has membership in","rdfs:label":"affiliation","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:affiliation"},"schema:domainIncludes":{"@id":"outbreak:Person"},"schema:rangeIncludes":{"@id":"outbreak:Organization"}},{"@id":"outbreak:affiliationStatus","@type":"rdf:Property","rdfs:comment":"The status of the person's membership or affiliation in an organization, team or group (current, past)","rdfs:label":"affiliationStatus","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:addtionalType"},"schema:domainIncludes":{"@id":"outbreak:Person"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:orcid","@type":"rdf:Property","rdfs:comment":"The ORCID ID of the person","rdfs:label":"orcid","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":{"@id":"outbreak:Person"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:isRelatedTo","@type":"rdf:Property","rdfs:comment":"A resource which a person played a role","rdfs:label":"isRelatedTo","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:isRelatedTo"},"schema:domainIncludes":{"@id":"outbreak:Person"},"schema:rangeIncludes":[{"@id":"schema:CreativeWork"},{"@id":"schema:HowTo"}]},{"@id":"outbreak:role","@type":"rdf:Property","rdfs:comment":"The role a person played in the creation of a resource","rdfs:label":"role","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:addtionalType"},"schema:domainIncludes":[{"@id":"schema:CreativeWork"},{"@id":"schema:HowTo"}],"schema:rangeIncludes":{"@id":"schema:Text"}},
+    {
+      "@id": "outbreak:orcid",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "the ORCID ID of the person",
+      "rdfs:label": "orcid",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Person"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:Organization",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the organization schema for describing authors, funders and other organizations referenced by outbreak.info resources",
+      "rdfs:label": "Organization",
+      "rdfs:subClassOf": {
+        "@id": "schema:Organization"
+      },
+      "$validation": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "The name of the organization.",
+            "type": "string"
+          },
+          "alternateName": {
+            "description": "An alias or acronym for the organization.",
+            "type": "string"
+          },
+          "affiliation": {
+            "description": "consortia or other organizations with which this organization is affiliated",
+            "oneOf": [
+              {
+                "$ref": "#/definitions/baseOrgObject"
+              },
+              {
+                "type": "array",
+                "items": {
+                    "$ref": "#/definitions/baseOrgObject"
+                }
+              }
+            ]
+          },
+          "class": {
+            "description": "A classification of the organization by a resource. Eg- for ClinicalTrials funders, it's [U.S. National Institutes of Health, Other U.S. Federal agencies, Industry, All others]",
+            "type": "string"
+          },
+          "role": {
+            "description": "The role of an organization in its involvement with a resource",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+              }
+            ]
+          },
+          "members": {
+            "description": "Members of this organization, team, or group",
+            "oneOf": [
+              {
+                "$ref": "#/definitions/basePersonObject"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/basePersonObject"
+                }
+              }
+            ]
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "definitions": {
+            "baseOrgObject":{
+                "description": "Affiliated Organization",
+                "@type": "outbreak:Organization",
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "description": "name of the organization",
+                    "type": "string"
+                  },
+                  "alternateName": {
+                    "description": "Alternate name or Acronym for the organization.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ]              
+            },
+            "basePersonObject":{
+                "@type": "outbreak:Person",
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "alternateName": {
+                        "type": "string"
+                    },
+                    "givenName": {
+                        "type": "string"
+                    },
+                    "familyName": {
+                        "type": "string"
+                    },
+                    "orcid": {
+                        "type": "string"
+                    },
+                    "affiliation": {
+                        "description": "consortia or other organizations with which this person is affiliated",
+                        "oneOf": [
+                          {
+                            "$ref": "#/definitions/baseOrgObject"
+                          },
+                          {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/baseOrgObject"
+                            }
+                          }
+                        ]
+                      }
+                },
+                "required": [
+                    "name"
+                ]                
+            }
+        }
+      }
+    },
+    {
+      "@id": "outbreak:affiliation",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "consortia or other organizations with which this organization is affiliated",
+      "rdfs:label": "affiliation",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Organization"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "outbreak:Organization"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:members",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Members of this organization, team, or group",
+      "rdfs:label": "members",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Organization"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "outbreak:Person"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:class",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "A classification of the organization by a resource. Eg- for ClinicalTrials funders, it's [U.S. National Institutes of Health, Other U.S. Federal agencies, Industry, All others]",
+      "rdfs:label": "class",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Organization"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:role",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "authorship, sponsorship, or other contribution role played by the person or organization in the creation of this resource. In a Clinical Study/Trial ArmGroup, it's equivalent to the ArmType in ClinicalTrials.gov",
+      "rdfs:label": "role",
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Person"},
+        {"@id": "outbreak:Organization"},
+        {"@id": "outbreak:ArmGroup"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
     {
       "@id": "outbreak:MonetaryGrant",
       "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing the MonetaryGrant schema used for outbreak.info",
       "rdfs:label": "MonetaryGrant",
-      "rdfs:comment": "This is the schema for describing the MonetaryGrant schema used for outbreak.info.",
       "rdfs:subClassOf": {
         "@id": "schema:MonetaryGrant"
       },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
+      "$validation": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "The name of the grant or funding.",
+            "type": "string"
+          },
+          "identifier": {
+            "description": "The funding or grant id",
+            "type": "string"
+          },
+          "url": {
+            "description": "URL of the grant or funding award.",
+            "type": "string",
+            "format": "uri"
+          },
+          "funder": {
+            "description": "The organization(s) that supported (sponsored) the grant through some kind of financial contribution.",
+            "oneOf": [
+              {
+                "$ref": "#/definitions/baseOrgObject"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/baseOrgObject"
+                }
+              }
+            ]
+          },
+          "recipient": {
+            "description": "The person or organization to whom or to which the grant was awarded",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/basePersonObject"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/basePersonObject"
+                }
+              },
+              {
+                "$ref": "#/definitions/baseOrgObject"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/baseOrgObject"
+                }
+              }
+            ]
+          }   
+        },
+        "required": [
+          "funder"
+        ],
+        "definitions": {
+            "baseOrgObject":{
+                "description": "Affiliated Organization",
+                "@type": "outbreak:Organization",
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "description": "name of the organization",
+                    "type": "string"
+                  },
+                  "alternateName": {
+                    "description": "Alternate name or Acronym for the organization.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ]              
+            },
+            "basePersonObject":{
+                "@type": "outbreak:Person",
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "alternateName": {
+                        "type": "string"
+                    },
+                    "givenName": {
+                        "type": "string"
+                    },
+                    "familyName": {
+                        "type": "string"
+                    },
+                    "orcid": {
+                        "type": "string"
+                    },
+                    "affiliation": {
+                        "description": "consortia or other organizations with which this person is affiliated",
+                        "oneOf": [
+                          {
+                            "$ref": "#/definitions/baseOrgObject"
+                          },
+                          {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/baseOrgObject"
+                            }
+                          }
+                        ]
+                      }
+                },
+                "required": [
+                    "name"
+                ]                
+            }
+        }
       }
     },
-    {"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"The name of the monetary grant","rdfs:label":"name","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":{"@id":"outbreak:MonetaryGrant"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:identifier","@type":"rdf:Property","rdfs:comment":"The grant ID or an identifier associated with the grant","rdfs:label":"identifier","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":{"@id":"outbreak:MonetaryGrant"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:url","@type":"rdf:Property","rdfs:comment":"The url for the grant (if available)","rdfs:label":"url","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:url"},"schema:domainIncludes":{"@id":"outbreak:MonetaryGrant"},"schema:rangeIncludes":{"@id":"schema:URL"}},{"@id":"outbreak:funder","@type":"rdf:Property","rdfs:comment":"The funding organization of the grant","rdfs:label":"funder","owl:cardinality":"many","marginality":"required","rdfs:sameAs":{"@id":"schema:funder"},"schema:domainIncludes":{"@id":"outbreak:MonetaryGrant"},"schema:rangeIncludes":{"@id":"outbreak:Organization"}},{"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"The name of the funding organization","rdfs:label":"name","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":{"@id":"outbreak:Organization"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:recipient","@type":"rdf:Property","rdfs:comment":"The person or organization to whom or to which the grant was awarded","rdfs:label":"recipient","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:recipient"},"schema:domainIncludes":{"@id":"outbreak:MonetaryGrant"},"schema:rangeIncludes":[{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"}]},{"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"The name of the recipient of the grant","rdfs:label":"name","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":[{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:affiliation","@type":"rdf:Property","rdfs:comment":"The affiliation of the recipient of the grant","rdfs:label":"affiliation","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:affiliation"},"schema:domainIncludes":[{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"}],"schema:rangeIncludes":{"@id":"schema:Text"}},
     {
-      "@id": "outbreak:Correction",
-      "@type": "rdfs:Class",
-      "rdfs:label": "Correction",
-      "rdfs:comment": "This is the schema for describing the Correction schema used for outbreak.info.",
-      "rdfs:subClassOf": {
-        "@id": "schema:Thing"
+      "@id": "outbreak:recipient",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The person or organization to whom or to which the grant was awarded",
+      "rdfs:label": "recipient",
+      "schema:domainIncludes": {
+        "@id": "outbreak:MonetaryGrant"
       },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Person"
+        },
+        {
+          "@id": "schema:Organization"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:DataDownload",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing the DataDownload schema used for outbreak.info.",
+      "rdfs:label": "DataDownload",
+      "rdfs:subClassOf": {
+        "@id": "schema:DataDownload"
       }
     },
-    {"@id":"outbreak:correctionType","@type":"rdf:Property","rdfs:comment":"Type of notice: (correction, retraction, expression of convern, withdrawal, erratum, update, correction\/republication, preprint, peer reviewed version)","rdfs:label":"correctionType","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":{"@id":"outbreak:Correction"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:url","@type":"rdf:Property","rdfs:comment":"The url to the notice if available","rdfs:label":"url","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:url"},"schema:domainIncludes":{"@id":"outbreak:Correction"},"schema:rangeIncludes":{"@id":"schema:URL"}},{"@id":"outbreak:identifier","@type":"rdf:Property","rdfs:comment":"DOI (preferred) or PMID (e.g., 10.1126\/sciimmunol.aaw6329, PMID:31471352)","rdfs:label":"identifier","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":{"@id":"outbreak:Correction"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:doi","@type":"rdf:Property","rdfs:comment":"DOI","rdfs:label":"doi","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":{"@id":"outbreak:Correction"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:pmid","@type":"rdf:Property","rdfs:comment":"PMID","rdfs:label":"pmid","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":{"@id":"outbreak:Correction"},"schema:rangeIncludes":{"@id":"schema:Number"}},{"@id":"outbreak:datePublished","@type":"rdf:Property","rdfs:comment":"PublicationDate online if available","rdfs:label":"datePublished","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:datePublished"},"schema:domainIncludes":{"@id":"outbreak:Correction"},"schema:rangeIncludes":{"@id":"schema:Date"}},
     {
-      "@id": "outbreak:Analysis",
+      "@id": "outbreak:CitationObject",
       "@type": "rdfs:Class",
-      "rdfs:label": "Analysis",
-      "rdfs:comment": "This is the schema for describing the Analysis schema used for outbreak.info.",
+      "rdfs:comment": "A citation object for a resource which is cited by the subject (ie- is a derivative of the subject), related to the subject, or from which the subject was based on (ie- is derived from).",
+      "rdfs:label": "CitationObject",
       "rdfs:subClassOf": {
         "@id": "schema:CreativeWork"
       },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
+      "$validation": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "The name or title of the cited resource.",
+            "type": "string"
+          },
+          "url": {
+            "description": "URL of the cited resource.",
+            "type": "string",
+            "format": "uri"
+          },
+          "identifier": {
+            "description": "An identifier associated with the citation",
+            "type": "string"
+          },
+          "citeText": {
+            "description": "The bibliographic citation for the referenced resource as is provided",
+            "type": "string"
+          },
+          "versionDate": {
+            "description": "The version date of the resource used at the time of the creation of the citation as certain resources (protocols, datasets) may change frequently over time.",
+            "format": "date",
+            "type": "string"
+          },
+          "pmid": {
+            "description": "A pubmed identifier if available",
+            "type": "string"
+          },
+          "doi": {
+            "description": "A doi if available",
+            "type": "string"
+          },
+          "sourceType": {
+            "description": "The @type of resource",
+            "enum": [
+              "Dataset",
+              "Publication",
+              "ClinicalTrial",
+              "Analysis",
+              "Protocol",
+              "SoftwareApplication",
+              "CreativeWork"
+            ]
+          }
+        },
+        "required": [
+          "name",
+          "sourceType"
+        ]
       }
+    },
+    {
+      "@id": "outbreak:citeText",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The bibliographic citation for the referenced resource as is provided",
+      "rdfs:label": "citeText",
+      "schema:domainIncludes": {
+        "@id": "outbreak:CitationObject"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:versionDate",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The version date of the resource used at the time of the creation of the citation as certain resources (protocols, datasets) may change frequently over time.",
+      "rdfs:label": "versionDate",
+      "schema:domainIncludes": {
+        "@id": "outbreak:CitationObject"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Date"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:sourceType",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The type of resource",
+      "rdfs:label": "sourceType",
+      "schema:domainIncludes": {
+        "@id": "outbreak:CitationObject"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
     },
     {
       "@id": "outbreak:Dataset",
       "@type": "rdfs:Class",
-      "rdfs:label": "Dataset",
       "rdfs:comment": "This is the schema for describing the Dataset schema used for outbreak.info.",
+      "rdfs:label": "Dataset",
       "rdfs:subClassOf": {
         "@id": "schema:Dataset"
-      },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
       }
     },
     {
-      "@id": "outbreak:Protocol",
+      "@id": "outbreak:Correction",
       "@type": "rdfs:Class",
-      "rdfs:label": "Protocol",
-      "rdfs:comment": "This is the schema for describing the Protocol schema used for outbreak.info.",
+      "rdfs:comment": "This is the schema for describing a Correction used for outbreak.info. A Correction is a specialized subclass of the CitationObject",
+      "rdfs:label": "Correction",
       "rdfs:subClassOf": {
-        "@id": "schema:HowTo"
+        "@id": "schema:CreativeWork"
       },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
+      "$validation": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "doi": {
+            "description": "The DOI of the published correction or correction notice",
+            "type": "string"
+          },
+          "pmid": {
+            "description": "The PMID of the published correction or correction notice (if available)",
+            "type": "integer"
+          },
+          "correctionType": {
+            "description": "Type of notice or correction: (correction, retraction, expression of convern, withdrawal, erratum, update, correction/republication, preprint, peer reviewed version)",
+            "oneOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "correction",
+                  "retraction",
+                  "expression of concern",
+                  "withdrawal",
+                  "erratum",
+                  "update",
+                  "correction and re-publication",
+                  "peer reviewed version",
+                  "preprint"
+                ]
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "correction",
+                    "retraction",
+                    "expression of concern",
+                    "withdrawal",
+                    "erratum",
+                    "update",
+                    "correction and re-publication",
+                    "peer reviewed version",
+                    "preprint"
+                  ]
+                }
+              }
+            ]
+          },
+          "datePublished": {
+            "description": "Publication date of the correction or correction notice",
+            "format": "date",
+            "type": "string"
+          },
+          "identifier": {
+            "description": "An identifier for the published correction or correction notice. DOI (preferred) or PMID (e.g., 10.1126\/sciimmunol.aaw6329, PMID:31471352)",
+            "type": "string"
+          },
+          "url": {
+            "description": "URL of the item.",
+            "type": "string",
+            "format": "uri"
+          }
+        },
+        "required": []
       }
+    },
+    {
+      "@id": "outbreak:correctionType",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Type of notice or correction: (correction, retraction, expression of convern, withdrawal, erratum, update, correction/republication, preprint, peer reviewed version)",
+      "rdfs:label": "correctionType",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Correction"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
     },
     {
       "@id": "outbreak:Publication",
       "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing the Publication used for outbreak.info",
       "rdfs:label": "Publication",
-      "rdfs:comment": "This is the schema for describing the Publication schema used for outbreak.info.",
       "rdfs:subClassOf": {
-        "@id": "schema:ScholarlyArticle"
-      },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
+        "@id": "schema:MedicalScholarlyArticle"
       },
       "$validation": {
-          "$schema": "http://json-schema.org/draft-07/schema#",
-          "type": "object",
-          "properties": {
-            "name": {
-              "description": "Title of the article",
-              "type": "string"
-            },
-            "identifier": {
-              "description": "DOI (preferred) or PMID (e.g., 10.1126/sciimmunol.aaw6329, PMID:31471352)",
-              "type": "string"
-            },
-            "doi": {
-              "description": "DOI",
-              "type": "string"
-            },
-            "pmid": {
-              "description": "PMID",
-              "type": "integer"
-            },
-            "journalName": {
-              "description": "Journal or preprint server name",
-              "type": "string"
-            },
-            "journalNameAbbrevation": {
-              "description": "Abbreviated Journal Title (note, this should be autopopulated)",
-              "type": "string"
-            },
-            "volumeNumber": {
-              "description": "Volume number of journal in which the article was published",
-              "type": "string"
-            },
-            "issueNumber": {
-              "description": "Issue of journal in which the article was published",
-              "type": "string"
-            },
-            "pagination": {
-              "description": "Any description of pages for the article",
-              "type": "string"
-            },
-            "license": {
-              "description": "License",
-              "type": "string"
-            },
-            "abstract": {
-              "description": "Article abstract ",
-              "type": "string"
-            },
-            "datePublished": {
-              "description": "PublicationDate online if available",
-              "format": "date",
-              "type": "string"
-            },
-            "url": {
-              "description": "url where the article can be found",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "Title of the article or publication",
+            "type": "string"
+          },
+          "abstract": {
+            "description": "A short descriptive summary of the resource",
+            "type": "string"
+          },
+          "identifier": {
+            "description": "An identifier for the publication. DOI (preferred) or PMID (e.g., 10.1126/sciimmunol.aaw6329, PMID:31471352)",
+            "type": "string"
+          },
+          "pmid": {
+            "description": "The Pubmed identifier or PMID of the publication if available",
+            "type": "string"
+          },
+          "doi": {
+            "description": "The DOI of the publication if available",
+            "type": "string"
+          },
+          "url": {
+              "description": "url where the publication or article can be found",
               "oneOf": [
                 {
                   "type": "string",
@@ -176,21 +691,32 @@
                 }
               ]
             },
-            "publicationType": {
-              "description": "Type of publication such as preprint, research article, case report, etc",
-              "oneOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                }
-              ]
+          "journalName": {
+            "description": "The name of the journal (or publisher or preprint server if journal name not available)",
+            "type": "string"
+          },
+          "journalNameAbbrevation": {
+            "description": "abbreviated Journal Title (note, this should be autopopulated)",
+            "type": "string"
+          },
+          "volumeNumber": {
+            "description": "Volume number of journal in which the article was published",
+            "type": "string"
+          },
+          "issueNumber": {
+            "description": "Issue of journal in which the article was published",
+            "type": "string"
+          },
+          "pagination": {
+            "description": "Any description of pages for the article or publication",
+            "type": "string"
+          },
+          "datePublished": {
+              "description": "PublicationDate online if available",
+              "format": "date",
+              "type": "string"
             },
-            "dateModified": {
+          "dateModified": {
               "description": "Date of Version update",
               "oneOf": [
                 {
@@ -206,22 +732,8 @@
                 }
               ]
             },
-            "correction": {
-              "description": "Version number or correction statement",
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/correctionObject"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/correctionObject"
-                  }
-                }
-              ]
-            },
-            "keywords": {
-              "description": "Keywords",
+          "publicationType": {
+              "description": "Type of publication such as preprint, research article, case report, etc",
               "oneOf": [
                 {
                   "type": "string"
@@ -234,10 +746,100 @@
                 }
               ]
             },
-            "topicCategory": {
-              "description": "Applicable outbreak.info category",
+          "correction": {
+              "description": "Related corrections or correction notices for this resource (eg- retraction notice, etc.)",
               "oneOf": [
                 {
+                  "$ref": "#/definitions/correctionObject"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/correctionObject"
+                  }
+                }
+              ]
+            },
+          "author": {
+              "description": "Name of the author or organization that created the dataset.  Note: schema.org/creator and schema.org/organization have additional fields that can provide more information about the author/organization, if desired",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/person"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/person"
+                  }
+                },
+                {
+                  "$ref": "#/definitions/organization"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/organization"
+                  }
+                }
+              ]
+            },
+          "funding": {
+            "description": "Funding that supports (sponsors) the collection of this dataset through some kind of financial contribution",
+            "oneOf": [{
+                "$ref": "#/definitions/funding"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/funding"
+                }
+              }
+            ]
+          },
+          "topicCategory": {
+            "description": "Applicable outbreak.info category",
+            "oneOf": [
+              {
+                "enum": [
+                  "Clinical",
+                  "Case Descriptions",
+                  "Risk Factors",
+                  "Diagnosis",
+                  "Symptoms",
+                  "Rapid Diagnostics",
+                  "Antibody Detection",
+                  "Virus Detection",
+                  "Testing Prevalence",
+                  "Pathology/Radiology",
+                  "Forecasting",
+                  "Mechanism",
+                  "Virus Factors",
+                  "Host Factors",
+                  "Immunological Response",
+                  "Mechanism of Infection",
+                  "Mechanism of Transmission",
+                  "Prevention",
+                  "Public Health Interventions",
+                  "Individual Prevention",
+                  "Transmission",
+                  "Host/Intermediate Reservoirs",
+                  "Viral Shedding / Persistence",
+                  "Treatment",
+                  "Vaccines",
+                  "Pharmaceutical Treatments",
+                  "Medical Care",
+                  "Repurposing",
+                  "Biologics",
+                  "Behavioral Research",
+                  "Epidemiology",
+                  "Classical Epidemiology",
+                  "Molecular Epidemiology",
+                  "Information Sciences"
+                ]
+              },
+              {
+                "type": "array",
+                "items": {
                   "enum": [
                     "Clinical",
                     "Case Descriptions",
@@ -271,104 +873,28 @@
                     "Behavioral Research",
                     "Epidemiology",
                     "Classical Epidemiology",
-                    "Molecular Epidemiology"
+                    "Molecular Epidemiology",
+                    "Information Sciences"
                   ]
-                },
-                {
-                  "type": "array",
-                  "items": {
-                      "enum": [
-                        "Clinical",
-                        "Case Descriptions",
-                        "Risk Factors",
-                        "Diagnosis",
-                        "Symptoms",
-                        "Rapid Diagnostics",
-                        "Antibody Detection",
-                        "Virus Detection",
-                        "Testing Prevalence",
-                        "Pathology/Radiology",
-                        "Forecasting",
-                        "Mechanism",
-                        "Virus Factors",
-                        "Host Factors",
-                        "Immunological Response",
-                        "Mechanism of Infection",
-                        "Mechanism of Transmission",
-                        "Prevention",
-                        "Public Health Interventions",
-                        "Individual Prevention",
-                        "Transmission",
-                        "Host/Intermediate Reservoirs",
-                        "Viral Shedding / Persistence",
-                        "Treatment",
-                        "Vaccines",
-                        "Pharmaceutical Treatments",
-                        "Medical Care",
-                        "Repurposing",
-                        "Biologics",
-                        "Behavioral Research",
-                        "Epidemiology",
-                        "Classical Epidemiology",
-                        "Molecular Epidemiology"
-                      ]
-                  }
                 }
-              ]
-
-            },
-            "author": {
-              "description": "Name of the author or organization that created the dataset.  Note: schema.org/creator and schema.org/organization have additional fields that can provide more information about the author/organization, if desired",
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/person"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/person"
-                  }
-                },
-                {
-                  "$ref": "#/definitions/organization"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/organization"
-                  }
+              }
+            ]
+          },
+          "keywords": {
+            "description": "Keywords or tags used to describe this content. Multiple entries in a keywords list are typically delimited by commas.",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
                 }
-              ]
-            },
-            "funding": {
-              "description": "The funder of the study",
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/funding"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/funding"
-                  }
-                }
-              ]
-            },
-            "citedBy": {
-              "description": "other articles or resources that cite this publication",
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/citation"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/citation"
-                  }
-                }
-              ]
-            },
-            "isBasedOn": {
+              }
+            ]
+          },
+          "isBasedOn": {
               "description": "Associated datasets, software, protocols, etc. used by the work described in this publication, including reference publications",
               "oneOf": [
                 {
@@ -382,21 +908,33 @@
                 }
               ]
             },
-            "isRelatedTo": {
-              "description": "Related articles or resources such as pre-prints, comments, editorial summaries of the article, etc. Helpful for de-duplication between pre-print and peer-reviewed version",
-              "oneOf": [
-                {
+          "citedBy": {
+            "description": "A citation to a resource (eg- publication, protocol, etc.) which is derived from this publication (stored as an object, not a string)",
+            "oneOf": [{
+                "$ref": "#/definitions/citation"
+              },
+              {
+                "type": "array",
+                "items": {
                   "$ref": "#/definitions/citation"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/citation"
-                  }
                 }
-              ]
-            },
-            "curatedBy": {
+              }
+            ]
+          },
+          "isRelatedTo": {
+            "description": "A citation to a resource (eg- publication, protocol, etc.) which is related to the publication but is not a derivative nor was derived from the publication (stored as an object, not a string)",
+            "oneOf": [{
+                "$ref": "#/definitions/citation"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/citation"
+                }
+              }
+            ]
+          },
+          "curatedBy": {
             "description": "The source from which this Publication was identified for inclusion into Outbreak.info. Provides provenance for a resource which was curated by another.",
             "anyOf": [{
                 "$ref": "#/definitions/citation"
@@ -427,12 +965,17 @@
               }
             ]
           },
-            "curationDate":{
+          "curationDate":{
             "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
             "type": "string",
             "format": "date"
           },
-            "evaluations":{
+          "license": {
+            "description": "Licensing that applies to this content, typically indicated by URL.",
+            "type": "string"
+          },
+          "evaluations":{
+              "description": "Reviews, Ratings, or other types of evaluations on this resource",
               "anyOf":[
               {
                 "type": "array",
@@ -454,138 +997,175 @@
               }
             ]
             }
-          },
-          "required": [
-            "name",
-            "identifier",
-            "datePublished",
-            "journalName",
-            "url",
-            "author"
-          ],
-          "definitions": {
-            "baseOrgObject":{
-                "description": "A barebones Organization object to work around recursion issues in DDE",
-                "@type": "Organization",
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "description": "name of the organization",
-                    "type": "string"
-                  },
-                  "alternateName": {
-                    "description": "Alternate name or Acronym for the organization.",
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "name"
-                ]              
-              }, 
-            "person": {
-                  "description": "Reusable person definition",
-                  "@type": "Person",
-                  "type": "object",
-                  "properties": {
-                    "name": {
-                      "type": "string"
-                    },
-                    "givenName": {
-                      "type": "string"
-                    },
-                    "familyName": {
-                      "type": "string"
-                    },
-                    "orcid": {
-                      "type": "string"
-                    },
-                    "affiliation": {
-                      "oneOf": [
-                        {
-                          "$ref": "#/definitions/baseOrgObject"
-                        },
-                        {
-                          "type": "array",
-                          "items": {
-                            "$ref": "#/definitions/baseOrgObject"
-                          }
-                        }
-                      ]
-                    }
-                  },
-                  "required": [
-                    "name"
-                  ]
-                },
-            "memberObject": {
-                  "description": "Reusable person definition accounting for recursion issues in DDE",
-                  "@type": "Person",
-                  "type": "object",
-                  "properties": {
-                    "name": {
-                      "type": "string"
-                    },
-                    "givenName": {
-                      "type": "string"
-                    },
-                    "familyName": {
-                      "type": "string"
-                    },
-                    "orcid": {
-                      "type": "string"
-                    },
-                    "affiliation": {
-                      "oneOf": [
-                        {
-                          "$ref": "#/definitions/baseOrgObject"
-                        },
-                        {
-                          "type": "array",
-                          "items": {
-                            "$ref": "#/definitions/baseOrgObject"
-                          }
-                        }
-                      ]
-                    }
-                  },
-                  "required": [
-                    "name"
-                  ]
-                },
-            "organization": {
-                "description": "Reusable organization definition",
-                "@type": "Organization",
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": "string"
-                  },
-                  "alternateName": {
-                    "type": "string"
-                  },
-                  "affiliation": {
-                    "$ref": "#/definitions/baseOrgObject"
-                  },
-                  "members": {
-                     "oneOf": [
-                        {
-                          "$ref": "#/definitions/memberObject"
-                        },
-                        {
-                          "type": "array",
-                          "items": {
-                            "$ref": "#/definitions/memberObject"
-                          }
-                        }
-                      ]
-                  }
-                },
-                "required": [
-                  "name"
-                ]
+        },
+        "required": [
+          "journalName",
+          "identifier",
+          "name",
+          "url",
+          "author",
+          "datePublished"
+        ],
+        "definitions": {
+          "baseOrgObject":{
+            "description": "A barebones Organization object to work around recursion issues in DDE",
+            "@type": "outbreak:Organization",
+            "type": "object",
+            "properties": {
+              "name": {
+                "description": "name of the organization",
+                "type": "string"
               },
-            "correctionObject":{
-              "@type": "Correction",
+              "alternateName": {
+                "description": "Alternate name or Acronym for the organization.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ]              
+          }, 
+          "person": {
+              "description": "Reusable person definition",
+              "@type": "outbreak:Person",
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "givenName": {
+                  "type": "string"
+                },
+                "familyName": {
+                  "type": "string"
+                },
+                "orcid": {
+                  "type": "string"
+                },
+                "affiliation": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/definitions/baseOrgObject"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/baseOrgObject"
+                      }
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "name"
+              ]
+            },
+          "memberObject": {
+              "description": "Reusable person definition accounting for recursion issues in DDE",
+              "@type": "outbreak:Person",
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "givenName": {
+                  "type": "string"
+                },
+                "familyName": {
+                  "type": "string"
+                },
+                "orcid": {
+                  "type": "string"
+                },
+                "affiliation": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/definitions/baseOrgObject"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/baseOrgObject"
+                      }
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "name"
+              ]
+            },
+          "organization": {
+            "description": "Reusable organization definition",
+            "@type": "outbreak:Organization",
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "alternateName": {
+                "type": "string"
+              },
+              "affiliation": {
+                "$ref": "#/definitions/baseOrgObject"
+              },
+              "members": {
+                 "oneOf": [
+                    {
+                      "$ref": "#/definitions/memberObject"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/memberObject"
+                      }
+                    }
+                  ]
+              }
+            },
+            "required": [
+              "name"
+            ]
+          },
+          "funding": {
+            "type": "object",
+            "@type": "outbreak:MonetaryGrant",
+            "description": "Information about funding support",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "The name of the monetary grant that funded/funds the Dataset"
+              },
+              "identifier": {
+                "type": "string",
+                "description": "Unique identifier(s) for the grant(s) used to fund the Dataset"
+              },
+              "funder": {
+                "description": "name of the funding organization",
+                "oneOf": [
+              {
+                "$ref": "#/definitions/baseOrgObject"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/baseOrgObject"
+                }
+              }
+            ]
+              },
+              "url": {
+                "type": "string",
+                "format": "uri",
+                "description": "award URL"
+              }
+            },
+            "required": [
+              "funder"
+            ]
+          },
+          "correctionObject": {
+              "@type": "outbreak:Correction",
               "type": "object",
               "properties": {
                 "url": {
@@ -624,102 +1204,82 @@
                   "url",
                   "correctionType"
               ]
-            },  
-            "citation": {
-              "description": "A citation object for a resource which is cited by the publication (ie- is a derivative of the publication) , related to the publication, or from which the publication was based on (ie- is derived from).",
-              "@type": "CreativeWork",
-              "type": "object",
-              "properties": {
-                "name": {
-                  "description": "name of the referenced resource",
-                  "type": "string"
-                },
-                "identifier": {
-                  "type": "string"
-                },
-                "doi": {
-                  "type": "string"
-                },
-                "pmid": {
-                  "type": "integer"
-                },
-                "type": {
-                  "enum": [
-                    "ClinicalStudy",
-                    "Analysis",
-                    "Publication",
-                    "Dataset",
-                    "Protocol",
-                    "SoftwareApplication",
-                    "Other"
-                  ]
-                },
-                "url": {
-                  "type": "string",
-                  "format": "uri"
-                },
-                "versionDate": {
-                  "description": "Date of the version of the resource that is referenced",
-                  "type": "string",
-                  "format": "date"
-                },
-                "citeText": {
-                  "description": "The bibliographic citation for the referenced resource as is provided",
-                  "type": "string"
-                }
-              },
-              "required": [
-                "name",
-                "type"
-              ]
             },
-            "funding": {
-              "type": "object",
-              "@type": "MonetaryGrant",
-              "description": "Information about funding support",
-              "properties": {
-                "name": {
-                  "type": "string",
-                  "description": "The name of the monetary grant that funded/funds the publication"
-                },
-                "identifier": {
-                  "type": "string",
-                  "description": "Unique identifier(s) for the grant(s) used to fund the publication"
-                },
-                "funder": {
-                  "description": "name of the funding organization",
-                  "type": "array",
-                  "oneOf": [
-                    {
-                      "$ref": "#/definitions/baseOrgObject"
-                    },
-                    {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/definitions/baseOrgObject"
-                      }
-                    }
-                  ]
-                },
-                "url": {
-                  "type": "string",
-                  "description": "award URL"
-                }
+          "citation": {
+            "description": "A citation object for a resource which is cited by the publication (ie- is a derivative of the publication) , related to the publication, or from which the publication was based on (ie- is derived from).",
+            "@type": "outbreak:CitationObject",
+            "type": "object",
+            "properties": {
+              "name": {
+                "description": "Name of or title of the citation",
+                "type": "string"
               },
-              "required": [
-                "funder"
-              ]
+              "identifier": {
+                "description": "An identifier associated with the citation",
+                "type": "string"
+              },
+              "pmid": {
+                "description": "A pubmed identifier if available",
+                "type": "string"
+              },
+              "doi": {
+                "description": "A doi if available",
+                "type": "string"
+              },
+              "sourceType": {
+                "description": "The type of resource",
+                "enum": [
+                  "Dataset",
+                  "Publication",
+                  "ClinicalTrial", 
+                  "Analysis",
+                  "Protocol", 
+                  "SoftwareApplication",
+                  "CreativeWork"
+                  ]
+              },
+              "url": {
+                "description": "The url of the resource cited.",
+                "type": "string",
+                "format": "uri"
+              },
+              "versionDate": {
+                "description": "The version date of the resource used at the time of the creation of the citation as certain resources (protocols, datasets) may change frequently over time.",
+                "type": "string",
+                "format": "date"
+              },
+              "citeText": {
+                "description": "The bibliographic citation for the referenced resource as is provided",
+                "type": "string"
+              }
             },
-            "reviewObject":{
-                "description": "A review or descriptive evaluation of the resource",
-                "@type": "schema:Review",
-                "type": "object",
-                "properties": {
-                  "name": {
+            "required": [
+              "name",
+              "sourceType"
+            ]
+          },
+          "reviewObject": {
+            "description": "A review or descriptive evaluation of the resource",
+            "@type": "Review",
+            "type": "object",
+            "properties": {
+              "name": {
                     "type": "string",
                     "description": "The name of the review"
                   },
-                  "author": {
+              "reviewAspect":{
+                    "description": "This Review or Rating is relevant to this part or facet of the itemReviewed",
+                    "type": "string"
+                  },
+              "reviewBody": {
+                      "description": "The actual body of the review.",
+                      "type": "string"
+                  },
+              "reviewRating": {
+                "description": "The rating given in this review",
+                    "$ref": "#/definitions/ratingObject"      
+                },
+              "author": {
                     "description": "The author of this content or rating.",
                     "anyOf": [
                       {
@@ -742,66 +1302,35 @@
                 }
               ]
             },
-                  "curationDate":{
+              "curationDate":{
                     "description": "The date this evaluation was added into outbreak.info, or was updated in outbreak.info.",
                     "type": "string",
                     "format": "date"
                   }
                 },
-                "required": [
-                  "name"
-                ]
+              "required": [
+              ]
             },
-            "ratingObject":{
+          "ratingObject": {
                 "description": "A rating or categorical evaluation of the resource",
-                "@type": "schema:Rating",
+                "@type": "Rating",
                 "type": "object",
                 "properties": {
                   "name": {
                     "type": "string",
                     "description": "The name of the rating"
                   },
-                  "author": {
-                    "description": "The author of this content or rating.",
-                    "anyOf": [
-                      {
-                        "$ref": "#/definitions/person"
-                      },
-                      {
-                        "type": "array",
-                        "items": {
-                          "$ref": "#/definitions/person"
-                      }
-                      },
-                      {
-                        "$ref": "#/definitions/organization"
-                      },
-                      {
-                        "type": "array",
-                        "items": {
-                          "$ref": "#/definitions/organization"
-                      }
-                }
-              ]
-            },
-                  "curationDate":{
-                    "description": "The date this evaluation was added into outbreak.info, or was updated in outbreak.info.",
+                  "ratingExplanation": {
                     "type": "string",
-                    "format": "date"
-                  }
-                },
-                "required": [
-                  "name"
-                ]
-            },
-            "aggregateRatingObject":{
-                "description": "A cumulative evaluation of the resource",
-                "@type": "schema:AggregateRating",
-                "type": "object",
-                "properties": {
-                  "name": {
+                    "description": "An explanation of the rating"    
+                  },
+                  "ratingValue": {
                     "type": "string",
-                    "description": "The name of the aggregate rating"
+                    "description": "The rating for the content."
+                  },
+                  "reviewAspect": {
+                    "type": "string",
+                    "description": "This Review or Rating is relevant to this part or facet of the itemReviewed"
                   },
                   "author": {
                     "description": "The author of this content or rating.",
@@ -833,38 +1362,1536 @@
                   }
                 },
                 "required": [
-                  "name"
                 ]
-            }                 
+            },
+          "aggregateRatingObject": {
+              "description": "A cumulative evaluation of the resource",
+              "@type": "AggregateRating",
+              "type": "object",
+              "properties": {
+                "name": {
+                "type": "string",
+                "description": "The name of the aggregate rating"
+                },
+                "ratingValue": {
+                    "type": "string",
+                    "description": "The rating for the content."
+                },
+                "reviewAspect":{
+                  "description": "This Review or Rating is relevant to this part or facet of the itemReviewed",
+                  "type": "string"
+                },
+                "author": {
+                    "description": "The author of this content or rating.",
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/person"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/person"
+                      }
+                      },
+                      {
+                        "$ref": "#/definitions/organization"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/organization"
+                      }
+                }
+              ]
+            },
+                "curationDate": {
+                    "description": "The date this evaluation was added into outbreak.info, or was updated in outbreak.info.",
+                    "type": "string",
+                    "format": "date"
+                  },
+                "reviews": {
+                  "anyOf": [
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/reviewObject"
+                        }
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/definitions/ratingObject"
+                        }
+                      }
+                      
+                  ]
+                }
+                },
+            "required": [
+            ]
           }
         }
+      }
     },
-    {"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"Title of the article","rdfs:label":"name","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":{"@id":"outbreak:Publication"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:identifier","@type":"rdf:Property","rdfs:comment":"DOI (preferred) or PMID (e.g., 10.1126\/sciimmunol.aaw6329, PMID:31471352)","rdfs:label":"identifier","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":{"@id":"outbreak:Publication"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:doi","@type":"rdf:Property","rdfs:comment":"DOI","rdfs:label":"doi","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":{"@id":"outbreak:Publication"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:pmid","@type":"rdf:Property","rdfs:comment":"PMID","rdfs:label":"pmid","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":{"@id":"outbreak:Publication"},"schema:rangeIncludes":{"@id":"schema:Number"}},{"@id":"outbreak:datePublished","@type":"rdf:Property","rdfs:comment":"PublicationDate online if available","rdfs:label":"datePublished","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:datePublished"},"schema:domainIncludes":{"@id":"outbreak:Publication"},"schema:rangeIncludes":{"@id":"schema:Date"}},{"@id":"outbreak:journalName","@type":"rdf:Property","rdfs:comment":"Journal or preprint server name","rdfs:label":"journalName","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":{"@id":"outbreak:Publication"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:journalName","@type":"rdf:Property","rdfs:comment":"Journal or preprint server name","rdfs:label":"journalName","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":{"@id":"outbreak:Publication"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:journalNameAbbrevation","@type":"rdf:Property","rdfs:comment":"Abbreviated Journal Title (note, this should be autopopulated)","rdfs:label":"journalNameAbbrevation","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":{"@id":"outbreak:Publication"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:volumeNumber","@type":"rdf:Property","rdfs:comment":"Volume number of journal in which the article was published","rdfs:label":"volumeNumber","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:volumeNumber"},"schema:domainIncludes":{"@id":"outbreak:Publication"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:issueNumber","@type":"rdf:Property","rdfs:comment":"Issue of journal in which the article was published","rdfs:label":"issueNumber","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:issueNumber"},"schema:domainIncludes":{"@id":"outbreak:Publication"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:author","@type":"rdf:Property","rdfs:comment":"Name of the author or organization that created the dataset.  Note: schema.org\/creator and schema.org\/organization have additional fields that can provide more information about the author\/organization, if desired","rdfs:label":"author","owl:cardinality":"many","marginality":"required","rdfs:sameAs":{"@id":"schema:author"},"schema:domainIncludes":{"@id":"outbreak:Publication"},"schema:rangeIncludes":[{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"}]},{"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"The author's name (as provided by the resource)","rdfs:label":"name","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":[{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:givenName","@type":"rdf:Property","rdfs:comment":"The author's given name (if available)","rdfs:label":"givenName","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:givenName"},"schema:domainIncludes":[{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:familyName","@type":"rdf:Property","rdfs:comment":"The author's family name (if available)","rdfs:label":"familyName","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:familyName"},"schema:domainIncludes":[{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:affiliation","@type":"rdf:Property","rdfs:comment":"The author's affiliation(s)","rdfs:label":"affiliation","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:affiliation"},"schema:domainIncludes":[{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:orcid","@type":"rdf:Property","rdfs:comment":"The orcid identifier for the author","rdfs:label":"orcid","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":[{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:pagination","@type":"rdf:Property","rdfs:comment":"Any description of pages for the article","rdfs:label":"pagination","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:pagination"},"schema:domainIncludes":{"@id":"outbreak:Publication"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:license","@type":"rdf:Property","rdfs:comment":"License","rdfs:label":"license","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:license"},"schema:domainIncludes":{"@id":"outbreak:Publication"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:url","@type":"rdf:Property","rdfs:comment":"url where the article can be found","rdfs:label":"url","owl:cardinality":"many","marginality":"required","rdfs:sameAs":{"@id":"schema:url"},"schema:domainIncludes":{"@id":"outbreak:Publication"},"schema:rangeIncludes":{"@id":"schema:URL"}},{"@id":"outbreak:abstract","@type":"rdf:Property","rdfs:comment":"Article abstract ","rdfs:label":"abstract","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:abstract"},"schema:domainIncludes":{"@id":"outbreak:Publication"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:publicationType","@type":"rdf:Property","rdfs:comment":"Type of publication such as preprint, research article, case report, etc","rdfs:label":"publicationType","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:publicationType"},"schema:domainIncludes":{"@id":"outbreak:Publication"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:dateModified","@type":"rdf:Property","rdfs:comment":"Date of Version update","rdfs:label":"dateModified","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:dateModified"},"schema:domainIncludes":{"@id":"outbreak:Publication"},"schema:rangeIncludes":{"@id":"schema:Date"}},
-    {"@id":"outbreak:correction","@type":"rdf:Property","rdfs:comment":"A special citation object for notices of author withdrawal, editorial retractions, errata, expressions of concerns, preprints, peer reviewed versions, etc.","rdfs:label":"correction","owl:cardinality":"many","marginality":"optional","schema:domainIncludes":{"@id":"outbreak:Publication"},"schema:rangeIncludes":{"@id":"outbreak:Correction"}},
-    {"@id":"outbreak:correctionType","@type":"rdf:Property","rdfs:comment":"Type of notice: (correction, retraction, expression of concern, withdrawal, erratum, update, correction\/republication, preprint, peer reviewed version)","rdfs:label":"correctionType","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:category"},"schema:domainIncludes":{"@id":"outbreak:Correction"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:url","@type":"rdf:Property","rdfs:comment":"The url to the notice if available","rdfs:label":"url","owl:cardinality":"one","marginality":"required","rdfs:sameAs":{"@id":"schema:url"},"schema:domainIncludes":{"@id":"outbreak:Correction"},"schema:rangeIncludes":{"@id":"schema:URL"}},
-    {"@id":"outbreak:identifier","@type":"rdf:Property","rdfs:comment":"DOI (preferred) or PMID (e.g., 10.1126\/sciimmunol.aaw6329, PMID:31471352)","rdfs:label":"identifier","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":{"@id":"outbreak:Correction"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:doi","@type":"rdf:Property","rdfs:comment":"DOI","rdfs:label":"doi","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":{"@id":"outbreak:Correction"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:pmid","@type":"rdf:Property","rdfs:comment":"PMID","rdfs:label":"pmid","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":{"@id":"outbreak:Correction"},"schema:rangeIncludes":{"@id":"schema:Number"}},{"@id":"outbreak:datePublished","@type":"rdf:Property","rdfs:comment":"PublicationDate online if available","rdfs:label":"datePublished","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:datePublished"},"schema:domainIncludes":{"@id":"outbreak:Correction"},"schema:rangeIncludes":{"@id":"schema:Date"}},
-    {"@id":"outbreak:funding","@type":"rdf:Property","rdfs:comment":"The funder of the study","rdfs:label":"funding","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:funder"},"schema:domainIncludes":{"@id":"outbreak:Publication"},"schema:rangeIncludes":{"@id":"outbreak:MonetaryGrant"}},{"@id":"outbreak:identifier","@type":"rdf:Property","rdfs:comment":"The identifier of the grant (if available)","rdfs:label":"identifier","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":{"@id":"outbreak:MonetaryGrant"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:citedBy","@type":"rdf:Property","rdfs:comment":"other articles or resources that cite this publication","rdfs:label":"citedBy","owl:cardinality":"many","marginality":"optional","owl:inverseOf":{"@id":"schema:isBasedOn"},"schema:domainIncludes":{"@id":"outbreak:Publication"},"schema:rangeIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}]},{"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"name of the citedBy resource","rdfs:label":"name","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:type","@type":"rdf:Property","rdfs:comment":"type (publicatoin, protocol, dataset, code, etc.) of the citedBy resource","rdfs:label":"type","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:additionalType"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:identifier","@type":"rdf:Property","rdfs:comment":"identifier (pmid, WHO protocol id, etc.) of the citedby resource","rdfs:label":"identifier","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:isBasedOn","@type":"rdf:Property","rdfs:comment":"Associated datasets, software, protocols, etc. used by the work described in this publication, including reference publications","rdfs:label":"isBasedOn","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:isBasedOn"},"schema:domainIncludes":{"@id":"outbreak:Publication"},"schema:rangeIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}]},{"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"name of the associated dataset, software, protocols, etc used by the work described in this publication","rdfs:label":"name","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:type","@type":"rdf:Property","rdfs:comment":"type of the associated resource (dataset, protocols, analysis, etc.) used by the work described in this publication","rdfs:label":"type","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:additionalType"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:identifier","@type":"rdf:Property","rdfs:comment":"Identifier of the associated datasets, software, protocols, etc.","rdfs:label":"identifier","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:versionDate","@type":"rdf:Property","rdfs:comment":"date of the version of the resource from which this publication was derived. Note this is NOT the same as dateModified, as the protocol may be based on an earlier 'dateModified' than is what is available from the resource","rdfs:label":"versionDate","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:releaseDate"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Date"}},
-    {"@id":"outbreak:isRelatedTo","@type":"rdf:Property","rdfs:comment":"Related articles or resources such as pre-prints, comments, editorial summaries of the article, etc. Helpful for de-duplication between pre-print and peer-reviewed version","rdfs:label":"isRelatedTo","owl:cardinality":"many","marginality":"optional","rdfs:sameAs":{"@id":"schema:isRelatedTo"},"schema:domainIncludes":{"@id":"outbreak:Publication"},"schema:rangeIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}]},{"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"name of related resource","rdfs:label":"name","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:type","@type":"rdf:Property","rdfs:comment":"type of related resource","rdfs:label":"type","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:additionalType"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:identifier","@type":"rdf:Property","rdfs:comment":"Identifier of related articles or resources such as pre-prints, comments, editorial summaries","rdfs:label":"identifier","owl:cardinality":"one","marginality":"optional","rdfs:sameAs":{"@id":"schema:identifier"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:keywords","@type":"rdf:Property","rdfs:comment":null,"rdfs:label":"keywords","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:keywords"},"schema:domainIncludes":{"@id":"outbreak:Publication"},"schema:rangeIncludes":{"@id":"schema:Text"}},{"@id":"outbreak:topicCategory","@type":"rdf:Property","rdfs:comment":"Applicable outbreak.info category","rdfs:label":"topicCategory","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:about"},"schema:domainIncludes":{"@id":"outbreak:Publication"},"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:curatedBy","@type":"rdf:Property","rdfs:comment":"The source from which this publication was identified for inclusion into Outbreak.info. Provides provenance for a resource which was curated by another","rdfs:label":"curatedBy","owl:cardinality":"many","marginality":"recommended","rdfs:sameAs":{"@id":"schema:citation"},"schema:domainIncludes":{"@id":"outbreak:Publication"},"schema:rangeIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"},{"@id":"schema:Thing"}]},
-    {"@id":"outbreak:name","@type":"rdf:Property","rdfs:comment":"name of the source from which this publication was identified for inclusion","rdfs:label":"name","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:name"},"schema:domainIncludes":[{"@id":"outbreak:ClinicalTrial"},{"@id":"outbreak:Analysis"},{"@id":"outbreak:Publication"},{"@id":"outbreak:Dataset"},{"@id":"outbreak:Protocol"},{"@id":"schema:SoftwareApplication"},{"@id":"outbreak:Person"},{"@id":"outbreak:Organization"},{"@id":"schema:Thing"}],"schema:rangeIncludes":{"@id":"schema:Text"}},
-    {"@id":"outbreak:curationDate","@type":"rdf:Property","rdfs:comment":"The date this resource was added to outbreak.info, or the date when this resource was updated in outbreak.info","rdfs:label":"curationDate","owl:cardinality":"one","marginality":"recommended","rdfs:sameAs":{"@id":"schema:releaseDate"},"schema:domainIncludes":{"@id":"outbreak:Publication"},"schema:rangeIncludes":{"@id":"schema:Date"}},
-    {"@id":"outbreak:evaluations","@type":"rdf:Property","rdfs:comment":"One or more reviews, ratings, or other evaluations of this resource","rdfs:label":"evaluations","owl:cardinality":"many","marginality":"optional","schema:domainIncludes":{"@id":"outbreak:Publication"},"schema:rangeIncludes":[{"@id":"schema:Review"},{"@id":"schema:Rating"},{"@id":"schema:AggregateRating"}]},
     {
+      "@id": "outbreak:journalName",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The name of the journal (or publisher if journal name not available)",
+      "rdfs:label": "journalName",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Publication"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:journalNameAbbrevation",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "abbreviated Journal Title (note, this should be autopopulated)",
+      "rdfs:label": "journalNameAbbrevation",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Publication"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:volumeNumber",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Volume number of journal in which the article was published",
+      "rdfs:label": "volumeNumber",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Publication"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:issueNumber",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Issue of journal in which the article was published",
+      "rdfs:label": "issueNumber",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Publication"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:Analysis",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing an Analysis for inclusion in outbreak.info resources",
+      "rdfs:label": "Analysis",
+      "rdfs:subClassOf": {
+        "@id": "schema:CreativeWork"
+      }
+        },
+    {
+      "@id": "outbreak:domainUrl",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The domain name or main site on which webpage or specific url can be found",
+      "rdfs:label": "domainUrl",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Analysis"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:URL"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:assumption",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Statement of assumptions / limitations of the model",
+      "rdfs:label": "assumption",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Analysis"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:analysisTechnique",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "A technique or technology used in a analysis",
+      "rdfs:label": "analysisTechnique",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Analysis"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:analysisTopic",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The underlying question, goal, or aim of the analysis",
+      "rdfs:label": "analysisTopic",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Analysis"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:Product",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing a reagent, material, sample, or some other product used in a protocol resource in outbreak.info",
+      "rdfs:label": "Product",
+      "rdfs:subClassOf": {
+        "@id": "schema:Product"
+      }
+    },
+    {
+      "@id": "outbreak:Instrument",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing an instrument used in a protocol resource listed in outbreak.info",
+      "rdfs:label": "Instrument",
+      "rdfs:subClassOf": {
+        "@id": "schema:Product"
+      }
+    },
+    {
+      "@id": "outbreak:Protocol",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing the Protocols for outbreak.info Resources.",
+      "rdfs:label": "Protocol",
+      "rdfs:subClassOf": {
+        "@id": "schema:HowTo"
+      }
+    },
+    {
+      "@id": "outbreak:warning",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Precautions, warnings, and/or safety warnings associated with or highlighted by the protocol",
+      "rdfs:label": "warning",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Protocol"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:correctionNote",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "statement of what was updated/changed since prior version",
+      "rdfs:label": "correctionNote",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Protocol"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:protocolStatus",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The status of the protocol",
+      "rdfs:label": "protocolStatus",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Protocol"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:instrument",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "A laboratory equipment use by a person to follow one or more steps described in this Protocol",
+      "rdfs:label": "instrument",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Protocol"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "outbreak:Instrument"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:protocolSetting",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The type of 'protocol' based on setting in which it would apply",
+      "rdfs:label": "protocolSetting",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Protocol"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:protocolCategory",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The type of 'protocol' based on degree of specificity and purpose",
+      "rdfs:label": "protocolCategory",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Protocol"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:usedToGenerate",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Type of evidence/data generated by the protocol",
+      "rdfs:label": "usedToGenerate",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Protocol"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:inComplianceWith",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Guidelines or Standards to which these protocols adhere. ie- GMP, GCP, other EQUATOR guidelines. Useful for selecting protocols where certain standards/guidelines must be met",
+      "rdfs:label": "inComplianceWith",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Protocol"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    }, 
+    {
+      "@id": "outbreak:StudyEvent",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing StudyEvents, a class that describes categorical events in Clinical Trials added to outbreak.info",
+      "rdfs:label": "StudyEvent",
+      "rdfs:subClassOf": {
+        "@id": "schema:Thing"
+      }
+    },
+    {
+      "@id": "outbreak:studyEventType",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Type of the event status such as StudyStart, PrimaryCompletion, Completion, StudyFirstSubmit, StudyFirstSubmitQC, LastUpdateSubmit",
+      "rdfs:label": "studyEventType",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyEvent"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:studyEventDate",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The corresponding/actual date of the study event (ie- the StartDate, Primary CompletionDate, CompletionDate, StudyFirstSubmitDate, StudyFirstSubmitQCDate, LastUpdateSubmitDate)",
+      "rdfs:label": "studyEventDate",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyEvent"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Date"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:studyEventDateType",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "the type of date provided (actual, anticipated, or estimated)",
+      "rdfs:label": "studyEventDateType",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyEvent"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },  
+    {
+      "@id": "outbreak:StudyStatus",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing the status of a ClinicalTrial resource in outbreak.info",
+      "rdfs:label": "StudyStatus",
+      "rdfs:subClassOf": {
+        "@id": "schema:Thing"
+      }
+    },
+    {
+      "@id": "outbreak:status",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The recruitment status of the study",
+      "rdfs:label": "status",
+      "rdfs:sameAs":{"@id":"schema:status"},
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyStatus"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:statusExpandedAccess",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Flag for whether or not the study has expanded Access status",
+      "rdfs:label": "statusExpandedAccess",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyStatus"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Boolean"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:statusDate",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The date that the status was verified. Equivalent to NCT's StatusVerifiedDate",
+      "rdfs:label": "statusDate",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyStatus"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Date"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:enrollmentCount",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The number of participants enrolled in the study",
+      "rdfs:label": "enrollmentCount",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyStatus"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Number"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:enrollmentType",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The type of estimation used to determine the enrollmentCount (actual counts, target size, etc.)",
+      "rdfs:label": "enrollmentType",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyStatus"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:whyStopped",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "A brief explanation of the reason(s) why such clinical study was stopped (for a clinical study that is Suspended, Terminated, or Withdrawn prior to its planned completion as anticipated by the protocol)",
+      "rdfs:label": "whyStopped",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyStatus"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:StudyDesign",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing the study design of a clinical trial/study for inclusion into outbreak.info resources",
+      "rdfs:label": "StudyDesign",
+      "rdfs:subClassOf": {
+        "@id": "schema:Thing"
+      }
+    },
+    {
+      "@id": "outbreak:studyType",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Type of human study, can be subtypes of observational study or interventional studies and may include the temporal relationship of observation period to time of participant enrollment.",
+      "rdfs:label": "studyType",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyDesign"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:phase",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Stage or phase of the study in the U.S. if applicable",
+      "rdfs:label": "phase",
+      "rdfs:sameAs":{"@id":"schema:phase"},
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyDesign"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:phaseNumber",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The number of the phase or stage of the study",
+      "rdfs:label": "phaseNumber",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyDesign"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Number"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:designAllocation",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The method by which the study participants were allocated into groups",
+      "rdfs:label": "designAllocation",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyDesign"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:designModel",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The general design of the strategy for assigning interventions to participants in a clinical intervention study OR the general design of the strategy for identifying and following up with participants during an observational study",
+      "rdfs:label": "designModel",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyDesign"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:designPrimaryPurpose",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The primary purpose of the study",
+      "rdfs:label": "designPrimaryPurpose",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyDesign"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:designWhoMasked",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The people who do not know which participants have been assigned to which interventions",
+      "rdfs:label": "designWhoMasked",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyDesign"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:designStudyText",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "String description of the study design if structured information not available",
+      "rdfs:label": "designStudyText",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyDesign"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:Intervention",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "a schema to describe Interventions discussed in Clinical Studies/Trials for inclusion in outbreak.info Resources",
+      "rdfs:label": "Intervention",
+      "rdfs:subClassOf": {
+        "@id": "schema:Thing"
+      }
+    },
+    {
+      "@id": "outbreak:category",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The category of an intervention in the study",
+      "rdfs:label": "category",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Intervention"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:ArmGroup",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing arm groups in clinical studies/trials for inclusion in outbreak.info Resources",
+      "rdfs:label": "ArmGroup",
+      "rdfs:subClassOf": {
+        "@id": "schema:Thing"
+      },
+      "$validation": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "role": {
+            "description": "The role of the arm or factor in the study this is equivalent to the ArmType in ClinicalTrials.gov",
+            "enum": [
+                "experimental arm",
+                "active comparator arm",
+                "placebo comparator arm",
+                "sham comparator arm",
+                "no intervention arm"
+            ]
+          },
+          "intervention": {
+            "description": "The interventions (if any) in this ArmGroup",
+            "type": "array",
+            "oneOf": [
+                {
+                  "$ref": "#/definitions/intervention"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/intervention"
+                  }
+                }
+            ]
+          },
+          "name": {
+            "description": "The name of the arm or factor (can include a specific intervention, a placebo or even a lack of intervention, ie- 'no intervention' group)",
+            "type": "string"
+          },
+          "description": {
+            "description": "A description of the arm or factor",
+            "type": "string"
+          }
+        },
+        "required": [],
+        "definitions":{
+          "intervention": {
+              "type": "object",
+              "@type": "outbreak:Intervention",
+              "properties": {
+                "name": {
+                  "description": "The name of the intervention in the study",
+                  "type": "string"
+                },
+                "description": {
+                  "description": "A description of the intervention in the study",
+                  "type": "string"
+                },
+                "category": {
+                  "description": "The category of an intervention in the study",
+                  "enum": [
+                    "drugs",
+                    "medical devices",
+                    "procedures",
+                    "vaccines",
+                    "education",
+                    "behavioral modification",
+                    "diet",
+                    "exercise",
+                    "counseling",
+                    "placebo",
+                    "other"
+                  ]
+                }
+              }
+            }  
+        }
+      }
+    },
+    {
+      "@id": "outbreak:intervention",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The interventions (if any) in this ArmGroup",
+      "rdfs:label": "intervention",
+      "schema:domainIncludes": {
+        "@id": "outbreak:ArmGroup"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "outbreak:Intervention"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:Outcome",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing a Clinical Trial/Study Outcome for inclusion in  outbreak.info Resources",
+      "rdfs:label": "Outcome",
+      "rdfs:subClassOf": {
+        "@id": "schema:Thing"
+      }
+    },
+    {
+      "@id": "outbreak:outcomeMeasure",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The outcome measure for the study",
+      "rdfs:label": "outcomeMeasure",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Outcome"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:outcomeTimeFrame",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The specific time point(s) and overall duration of evaluation must be specified in this section",
+      "rdfs:label": "outcomeTimeFrame",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Outcome"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Duration"
+        },
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:outcomeType",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The classification of the outcome measure as either primary, secondary, or exploratory",
+      "rdfs:label": "outcomeType",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Outcome"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:Eligibility",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing information about Clinical Trials/Studies eligibility criteria for inclusion in outbreak.info Resources",
+      "rdfs:label": "Eligibility",
+      "rdfs:subClassOf": {
+        "@id": "schema:Thing"
+      }
+    },
+    {
+      "@id": "outbreak:inclusionCriteria",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "\"criteria for inclusion in the study",
+      "rdfs:label": "inclusionCriteria",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Eligibility"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:minimumAge",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "the minimum age for a participant to be included in the study",
+      "rdfs:label": "minimumAge",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Eligibility"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:maximumAge",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "the maximum age for a participant to be included in the study",
+      "rdfs:label": "maximumAge",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Eligibility"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:gender",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "the sex requirement to be included in the study",
+      "rdfs:label": "gender",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Eligibility"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:genderBased",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Boolean for whether or not participation is based on gender",
+      "rdfs:label": "genderBased",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Eligibility"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Boolean"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:healthyVolunteers",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Boolean to indicate whether or not healthy volunteers may be included in the study",
+      "rdfs:label": "healthyVolunteers",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Eligibility"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Boolean"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:stdAge",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "the age category of a participant to be included in the study if a minimum and maximum age is not specified",
+      "rdfs:label": "stdAge",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Eligibility"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:exclusionCriteria",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "criteria for exclusion from the study",
+      "rdfs:label": "exclusionCriteria",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Eligibility"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:criteriaText",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The descriptive criteria as published for the Clinical Trial",
+      "rdfs:label": "criteriaText",
+      "schema:domainIncludes": {
+        "@id": "outbreak:Eligibility"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:StudyLocation",
+      "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing Clinical Trial/Study locations for inclusion in outbreak.info Resources",
+      "rdfs:label": "StudyLocation",
+      "rdfs:subClassOf": {
+        "@id": "schema:Place"
+      }
+    },
+    {
+      "@id": "outbreak:studyLocation",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The location of the study",
+      "rdfs:label": "studyLocation",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyLocation"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Place"
+        },
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:studyLocationCity",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The city in which the facility used for the study is located",
+      "rdfs:label": "studyLocationCity",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyLocation"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:City"
+        },
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:studyLocationState",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The state or province in which the facility used for the study is located",
+      "rdfs:label": "studyLocationState",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyLocation"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:State"
+        },
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:studyLocationCountry",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The country in which the facility used for the study is located",
+      "rdfs:label": "studyLocationCountry",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyLocation"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Country"
+        },
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:studyLocationStatus",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The recruitment status of the study at the specific study site",
+      "rdfs:label": "studyLocationStatus",
+      "schema:domainIncludes": {
+        "@id": "outbreak:StudyLocation"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+{
       "@id": "outbreak:ClinicalTrial",
       "@type": "rdfs:Class",
+      "rdfs:comment": "This is the schema for describing the Clinical Trials and other medical studies used for outbreak.info Resources",
       "rdfs:label": "ClinicalTrial",
-      "rdfs:comment": "This is the schema for describing the ClinicalTrial schema used for outbreak.info.",
       "rdfs:subClassOf": {
         "@id": "schema:MedicalStudy"
-      },
-      "schema:isPartOf": {
-        "@id": "https://discovery.biothings.io/view/outbreak/"
       }
+    },
+    {
+      "@id": "outbreak:identifierSource",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Source of identifier assignment or type of identifier (NCTid, China CTRid, EudraCT Number, etc.)",
+      "rdfs:label": "identifierSource",
+      "schema:domainIncludes": {
+        "@id": "outbreak:ClinicalTrial"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:dateModifiedType",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The type of date. Equivalent to NCT's LastUpdatePostDateType",
+      "rdfs:label": "dateModifiedType",
+      "schema:domainIncludes": {
+        "@id": "outbreak:ClinicalTrial"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:healthConditionIdentifier",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Ontological or controlled vocabulary identifier for the health condition or disease",
+      "rdfs:label": "healthConditionIdentifier",
+      "schema:domainIncludes": {
+        "@id": "outbreak:ClinicalTrial"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        },
+        {
+          "@id": "schema:DefinedTerm"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:hasResults",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Boolean for if the clinical trial has published any results",
+      "rdfs:label": "hasResults",
+      "schema:domainIncludes": {
+        "@id": "outbreak:ClinicalTrial"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Boolean"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:studyEvent",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "an event status such as StudyStart, PrimaryCompletion, Completion, StudyFirstSubmit, StudyFirstSubmitQC, LastUpdateSubmit",
+      "rdfs:label": "studyEvent",
+      "schema:domainIncludes": {
+        "@id": "outbreak:ClinicalTrial"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "outbreak:StudyEvent"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:studyStatus",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The status of the study",
+      "rdfs:label": "studyStatus",
+      "schema:domainIncludes": {
+        "@id": "outbreak:ClinicalTrial"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "outbreak:StudyStatus"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:studyDesign",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The general design of the study",
+      "rdfs:label": "studyDesign",
+      "schema:domainIncludes": {
+        "@id": "outbreak:ClinicalTrial"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "outbreak:StudyDesign"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:armGroup",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The arm or factor of an interventional study",
+      "rdfs:label": "armGroup",
+      "schema:domainIncludes": {
+        "@id": "outbreak:ClinicalTrial"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "outbreak:ArmGroup"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:outcome",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The arm or factor of an interventional study",
+      "rdfs:label": "outcome",
+      "schema:domainIncludes": {
+        "@id": "outbreak:ClinicalTrial"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "outbreak:Outcome"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:eligibilityCriteria",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "eligibility criteria",
+      "rdfs:label": "eligibilityCriteria",
+      "schema:domainIncludes": {
+        "@id": "outbreak:ClinicalTrial"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "outbreak:Eligibility"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:author",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The author of this resource, content, or rating",
+      "rdfs:label": "author",
+      "rdfs:sameAs": {"@id":"schema:author"},
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "outbreak:Person"
+        },
+        {
+          "@id": "outbreak:Organization"
+        }  
+      ]
+    },
+    {
+      "@id": "outbreak:dateCreated",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Date the record was created",
+      "rdfs:label": "dateCreated",
+      "rdfs:sameAs": {"@id":"schema:dateCreated"},
+      "schema:domainIncludes": [
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Date"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:datePublished",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Date of first broadcast/publication",
+      "rdfs:label": "datePublished",
+      "rdfs:sameAs": {"@id":"schema:datePublished"},
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Date"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:dateModified",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The date on which the CreativeWork was most recently modified or when the item's entry was modified within a DataFeed",
+      "rdfs:label": "dateModified",
+      "rdfs:sameAs": {"@id":"schema:dateModified"},
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Date"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:keywords",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "keywords for describing the record",
+      "rdfs:label": "keywords",
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:abstract",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "A short descriptive summary of the publication or study",
+      "rdfs:label": "abstract",
+      "rdfs:sameAs": {"@id":"schema:abstract"},
+      "schema:domainIncludes": [
+          {"@id": "outbreak:Publication"},
+          {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:pmid",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "A pubmed identifier if available",
+      "rdfs:label": "pmid",
+      "schema:domainIncludes": [
+          {"@id": "outbreak:CitationObject"},
+          {"@id": "outbreak:Correction"},
+          {"@id": "outbreak:Publication"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Integer"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:doi",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "A doi if available",
+      "rdfs:label": "doi",
+      "schema:domainIncludes": [
+          {"@id": "outbreak:CitationObject"},
+          {"@id": "outbreak:Correction"},
+          {"@id": "outbreak:Dataset"},
+          {"@id": "outbreak:Publication"},
+          {"@id": "outbreak:Analysis"},
+          {"@id": "outbreak:Protocol"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:funding",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Funding that supports (sponsors) the collection of this dataset through some kind of financial contribution",
+      "rdfs:label": "funding",
+      "schema:domainIncludes": [
+          {"@id": "outbreak:Dataset"},
+          {"@id": "outbreak:Publication"},
+          {"@id": "outbreak:Analysis"},
+          {"@id": "outbreak:Protocol"},
+          {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:MonetaryGrant"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:measurementTechnique",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "A technique or technology used in this resource",
+      "rdfs:label": "measurementTechnique",
+      "rdfs:sameAs": {"@id":"schema:measurementTechnique"},
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Protocol"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        },
+        {
+          "@id": "schema:DefinedTerm"
+        }  
+      ]
+    },
+    {
+      "@id": "outbreak:species",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Species(es) from which dataset has been collected",
+      "rdfs:label": "species",
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Analysis"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        },
+        {
+          "@id": "schema:DefinedTerm"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:infectiousAgent",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "infectious agents(s) which are the focus of the dataset",
+      "rdfs:label": "infectiousAgent",
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Analysis"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        },
+        {
+          "@id": "schema:DefinedTerm"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:infectiousDisease",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The disease or medical conditions caused by the infectious agent. Important as some agents may cause multiple diseases",
+      "rdfs:label": "infectiousDisease",
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Analysis"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        },
+        {
+          "@id": "schema:DefinedTerm"
+        }
+      ]
+    },
+    {
+      "@id": "outbreak:topicCategory",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "Applicable outbreak.info category",
+      "rdfs:label": "topicCategory",
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:Text"
+        }
+      ]
+    },
+
+    {
+      "@id": "outbreak:isBasedOn",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "A citation to a resource (eg- publication, protocol, etc.) on which this resource was derived (stored as an object, not a string)",
+      "rdfs:label": "isBasedOn",
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {"@id": "outbreak:CitationObject"},
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:ClinicalTrial"},
+        {"@id": "schema:SoftwareApplication"},
+        {"@id": "schema:CreativeWork"}
+      ]
+    },
+    {
+      "@id": "outbreak:isRelatedTo",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "A citation to a resource (eg- publication, protocol, etc.) which is related to the resource but is not a derivative nor was derived from the resource (stored as an object, not a string)",
+      "rdfs:label": "isRelatedTo",
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {"@id": "outbreak:CitationObject"},
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:ClinicalTrial"},
+        {"@id": "schema:SoftwareApplication"},
+        {"@id": "schema:CreativeWork"}
+      ]
+    },
+    {
+      "@id": "outbreak:citedBy",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "A citation to a resource (eg- publication, protocol, etc.) which is derived from this resource (stored as an object, not a string)",
+      "rdfs:label": "citedBy",
+      "rdfs:sameAs":{"@id":"owl:inverseOf: outbreak:isBasedOn"},
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {"@id": "outbreak:CitationObject"},
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:ClinicalTrial"},
+        {"@id": "schema:SoftwareApplication"},
+        {"@id": "schema:CreativeWork"}
+      ]
+    },
+    {
+      "@id": "outbreak:curatedBy",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The source from which this Dataset was identified for inclusion into Outbreak.info. Provides provenance for a resource which was curated by another.",
+      "rdfs:label": "curatedBy",
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {"@id": "outbreak:Person"},
+        {"@id": "outbreak:Organization"},
+        {"@id": "outbreak:CitationObject"},
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:ClinicalTrial"},
+        {"@id": "schema:SoftwareApplication"},
+        {"@id": "schema:CreativeWork"}
+      ]
+    },
+    {
+      "@id": "outbreak:curationDate",
+      "@type": "rdfs:Property",
+      "rdfs:comment": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
+      "rdfs:label": "curationDate",
+      "schema:domainIncludes": [
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes": [
+        {"@id": "schema:Date"}
+      ]
+    },
+    {
+      "@id": "outbreak:evaluations",
+      "@type": "rdf:Property",
+      "rdfs:comment":"One or more reviews, ratings, or other evaluations of this resource",
+      "rdfs:label": "evaluations",
+      "schema:domainIncludes":[
+        {"@id": "outbreak:Dataset"},
+        {"@id": "outbreak:Publication"},
+        {"@id": "outbreak:Analysis"},
+        {"@id": "outbreak:Protocol"},
+        {"@id": "outbreak:ClinicalTrial"}
+      ],
+      "schema:rangeIncludes":[
+        {"@id": "schema:Review"},
+        {"@id": "schema:Rating"},
+        {"@id": "schema:AggregateRating"}
+      ]
     }
   ]
 }

--- a/yaml/outbreak_Publication.yml
+++ b/yaml/outbreak_Publication.yml
@@ -1,476 +1,103 @@
 '@context':
-  outbreak: https://discovery.biothings.io/view/outbreak/
-  owl: http://www.w3.org/2002/07/owl/
-  rdf: http://www.w3.org/1999/02/22/-rdf-syntax-ns/
-  rdfs: http://www.w3.org/2000/01/rdf/-schema/
+  outbreak: http://discovery.biothings.io/view/
+  rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
+  rdfs: http://www.w3.org/2000/01/rdf-schema#
   schema: http://schema.org/
 '@graph':
-- '@id': outbreak:Organization
-  '@type': rdfs:Class
-  rdfs:comment: This is the schema for describing the Organization schema used for
-    outbreak.info.
-  rdfs:label: Organization
-  rdfs:subClassOf:
-    '@id': schema:Organization
-  schema:isPartOf:
-    '@id': https://discovery.biothings.io/view/outbreak/
-- '@id': outbreak:name
-  '@type': rdf:Property
-  marginality: required
-  owl:cardinality: one
-  rdfs:comment: The name of the organization, team or group
-  rdfs:label: name
-  rdfs:sameAs:
-    '@id': schema:name
-  schema:domainIncludes:
-    '@id': outbreak:Organization
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:alternateName
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: Alternative names or commonly used abbreviations for the organization,
-    team or group
-  rdfs:label: alternateName
-  rdfs:sameAs:
-    '@id': schema:alternateName
-  schema:domainIncludes:
-    '@id': outbreak:Organization
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:affiliation
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: An overarching consortia, multi-institutional team or group in which
-    the organization/team/group is a member or affiliate
-  rdfs:label: affiliation
-  rdfs:sameAs:
-    '@id': schema:affiliation
-  schema:domainIncludes:
-    '@id': outbreak:Organization
-  schema:rangeIncludes:
-    '@id': outbreak:Organization
-- '@id': outbreak:affiliationStatus
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The status of the organization's membership or affiliation in the
-    overarching consortial, multi-institutional team or group (current, past)
-  rdfs:label: affiliationStatus
-  rdfs:sameAs:
-    '@id': schema:additionalType
-  schema:domainIncludes:
-    '@id': outbreak:Organization
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:members
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: Members of this organization, team, or group
-  rdfs:label: members
-  rdfs:sameAs:
-    '@id': schema:members
-  schema:domainIncludes:
-    '@id': outbreak:Organization
-  schema:rangeIncludes:
-  - '@id': outbreak:Person
-  - '@id': outbreak:Organization
-- '@id': outbreak:membershipStatus
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: Status of the members of this organization
-  rdfs:label: membershipStatus
-  rdfs:sameAs:
-    '@id': schema:additionalType
-  schema:domainIncludes:
-    '@id': outbreak:Organization
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:relatedTo
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: many
-  rdfs:comment: A resource which a person played a role
-  rdfs:label: relatedTo
-  rdfs:sameAs:
-    '@id': schema:relatedTo
-  schema:domainIncludes:
-    '@id': outbreak:Organization
-  schema:rangeIncludes:
-  - '@id': schema:CreativeWork
-  - '@id': schema:HowTo
-- '@id': outbreak:class
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: many
-  rdfs:comment: A classification of the organization by a resource. Eg- for ClinicalTrials
-    funders, it's ["U.S. National Institutes of Health", "Other U.S. Federal agencies",
-    "Industry", "All others"]
-  rdfs:label: class
-  rdfs:sameAs:
-    '@id': schema:addtionalType
-  schema:domainIncludes:
-  - '@id': schema:CreativeWork
-  - '@id': schema:HowTo
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:role
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: many
-  rdfs:comment: The role of an organization in its involvement with a resource
-  rdfs:label: role
-  rdfs:sameAs:
-    '@id': schema:additionalType
-  schema:domainIncludes:
-  - '@id': schema:CreativeWork
-  - '@id': schema:HowTo
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:Person
-  '@type': rdfs:Class
-  rdfs:comment: This is the schema for describing the Person schema used for outbreak.info.
-  rdfs:label: Person
-  rdfs:subClassOf:
-    '@id': schema:Person
-  schema:isPartOf:
-    '@id': https://discovery.biothings.io/view/outbreak/
-- '@id': outbreak:name
-  '@type': rdf:Property
-  marginality: required
-  owl:cardinality: one
-  rdfs:comment: The name of the person
-  rdfs:label: name
-  rdfs:sameAs:
-    '@id': schema:name
-  schema:domainIncludes:
-    '@id': outbreak:Person
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:alternateName
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: Alternative ways in which the person's name is included in a record
-  rdfs:label: alternateName
-  rdfs:sameAs:
-    '@id': schema:alternateName
-  schema:domainIncludes:
-    '@id': outbreak:Person
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:givenName
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The given name of the person
-  rdfs:label: givenName
-  rdfs:sameAs:
-    '@id': schema:givenName
-  schema:domainIncludes:
-    '@id': outbreak:Person
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:familyName
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The family name of the person
-  rdfs:label: familyName
-  rdfs:sameAs:
-    '@id': schema:familyName
-  schema:domainIncludes:
-    '@id': outbreak:Person
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:affiliation
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: The organization with which the person is affiliated or has membership
-    in
-  rdfs:label: affiliation
-  rdfs:sameAs:
-    '@id': schema:affiliation
-  schema:domainIncludes:
-    '@id': outbreak:Person
-  schema:rangeIncludes:
-    '@id': outbreak:Organization
-- '@id': outbreak:affiliationStatus
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The status of the person's membership or affiliation in an organization,
-    team or group (current, past)
-  rdfs:label: affiliationStatus
-  rdfs:sameAs:
-    '@id': schema:addtionalType
-  schema:domainIncludes:
-    '@id': outbreak:Person
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:orcid
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The ORCID ID of the person
-  rdfs:label: orcid
-  rdfs:sameAs:
-    '@id': schema:identifier
-  schema:domainIncludes:
-    '@id': outbreak:Person
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:relatedTo
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: many
-  rdfs:comment: A resource which a person played a role
-  rdfs:label: relatedTo
-  rdfs:sameAs:
-    '@id': schema:relatedTo
-  schema:domainIncludes:
-    '@id': outbreak:Person
-  schema:rangeIncludes:
-  - '@id': schema:CreativeWork
-  - '@id': schema:HowTo
-- '@id': outbreak:role
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: The role a person played in the creation of a resource
-  rdfs:label: role
-  rdfs:sameAs:
-    '@id': schema:addtionalType
-  schema:domainIncludes:
-  - '@id': schema:CreativeWork
-  - '@id': schema:HowTo
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:MonetaryGrant
-  '@type': rdfs:Class
-  rdfs:comment: This is the schema for describing the MonetaryGrant schema used for
-    outbreak.info.
-  rdfs:label: MonetaryGrant
-  rdfs:subClassOf:
-    '@id': schema:MonetaryGrant
-  schema:isPartOf:
-    '@id': https://discovery.biothings.io/view/outbreak/
-- '@id': outbreak:name
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The name of the monetary grant
-  rdfs:label: name
-  rdfs:sameAs:
-    '@id': schema:name
-  schema:domainIncludes:
-    '@id': outbreak:MonetaryGrant
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:identifier
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The grant ID or an identifier associated with the grant
-  rdfs:label: identifier
-  rdfs:sameAs:
-    '@id': schema:identifier
-  schema:domainIncludes:
-    '@id': outbreak:MonetaryGrant
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:url
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The url for the grant (if available)
-  rdfs:label: url
-  rdfs:sameAs:
-    '@id': schema:url
-  schema:domainIncludes:
-    '@id': outbreak:MonetaryGrant
-  schema:rangeIncludes:
-    '@id': schema:URL
-- '@id': outbreak:funder
-  '@type': rdf:Property
-  marginality: required
-  owl:cardinality: many
-  rdfs:comment: The funding organization of the grant
-  rdfs:label: funder
-  rdfs:sameAs:
-    '@id': schema:funder
-  schema:domainIncludes:
-    '@id': outbreak:MonetaryGrant
-  schema:rangeIncludes:
-    '@id': outbreak:Organization
-- '@id': outbreak:name
-  '@type': rdf:Property
-  marginality: required
-  owl:cardinality: one
-  rdfs:comment: The name of the funding organization
-  rdfs:label: name
-  rdfs:sameAs:
-    '@id': schema:name
-  schema:domainIncludes:
-    '@id': outbreak:Organization
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:recipient
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: The person or organization to whom or to which the grant was awarded
-  rdfs:label: recipient
-  rdfs:sameAs:
-    '@id': schema:recipient
-  schema:domainIncludes:
-    '@id': outbreak:MonetaryGrant
-  schema:rangeIncludes:
-  - '@id': outbreak:Person
-  - '@id': outbreak:Organization
-- '@id': outbreak:name
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The name of the recipient of the grant
-  rdfs:label: name
-  rdfs:sameAs:
-    '@id': schema:name
-  schema:domainIncludes:
-  - '@id': outbreak:Person
-  - '@id': outbreak:Organization
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:affiliation
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: The affiliation of the recipient of the grant
-  rdfs:label: affiliation
-  rdfs:sameAs:
-    '@id': schema:affiliation
-  schema:domainIncludes:
-  - '@id': outbreak:Person
-  - '@id': outbreak:Organization
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:Analysis
-  '@type': rdfs:Class
-  rdfs:comment: This is the schema for describing the Analysis schema used for outbreak.info.
-  rdfs:label: Analysis
-  rdfs:subClassOf:
-    '@id': schema:CreativeWork
-  schema:isPartOf:
-    '@id': https://discovery.biothings.io/view/outbreak/
-- '@id': outbreak:Dataset
-  '@type': rdfs:Class
-  rdfs:comment: This is the schema for describing the Dataset schema used for outbreak.info.
-  rdfs:label: Dataset
-  rdfs:subClassOf:
-    '@id': schema:Dataset
-  schema:isPartOf:
-    '@id': https://discovery.biothings.io/view/outbreak/
-- '@id': outbreak:Protocol
-  '@type': rdfs:Class
-  rdfs:comment: This is the schema for describing the Protocol schema used for outbreak.info.
-  rdfs:label: Protocol
-  rdfs:subClassOf:
-    '@id': schema:HowTo
-  schema:isPartOf:
-    '@id': https://discovery.biothings.io/view/outbreak/
 - $validation:
     $schema: http://json-schema.org/draft-07/schema#
     definitions:
-      citation:
-        '@type': CreativeWork
-        description: A citation object for a resource which is cited by the publication
-          (ie- is a derivative of the publication) , related to the publication, or
-          from which the publication was based on (ie- is derived from).
+      baseOrgObject:
+        '@type': outbreak:Organization
         properties:
-          citeText:
-            description: The bibliographic citation for the referenced resource as
-              is provided
-            type: string
-          doi:
-            type: string
-          identifier:
-            type: string
-          name:
-            description: name of the referenced resource
-            type: string
-          pmid:
-            type: integer
-          type:
-            enum:
-            - ClinicalStudy
-            - Analysis
-            - Publication
-            - Dataset
-            - Protocol
-            - SoftwareApplication
-            - Other
-          url:
-            format: uri
-            type: string
-          versionDate:
-            description: Date of the version of the resource that is referenced
-            format: date
-            type: string
-        required:
-        - name
-        - type
-        type: object
-      funding:
-        '@type': MonetaryGrant
-        description: Information about funding support
-        properties:
-          funder:
-            description: name of the funding organization
-            oneOf:
-            - $ref: '#/definitions/organization'
-            - items:
-                $ref: '#/definitions/organization'
-              type: array
-            type: array
-          identifier:
-            description: Unique identifier(s) for the grant(s) used to fund the Dataset
-            type: string
-          name:
-            description: The name of the monetary grant that funded/funds the Dataset
-            type: string
-          url:
-            description: award URL
-            type: string
-        required:
-        - funder
-        type: object
-      organization:
-        '@type': Organization
-        description: Reusable organization definition
-        properties:
-          affiliation:
+          alternateName:
             type: string
           name:
             type: string
         required:
         - name
         type: object
-      person:
-        '@type': Person
-        description: Reusable person definition
+    properties:
+      affiliation:
+        description: An organization that this person is affiliated with. For example,
+          a school/university, a club, or a team.
+        oneOf:
+        - $ref: '#/definitions/baseOrgObject'
+        - items:
+            $ref: '#/definitions/baseOrgObject'
+          type: array
+      alternateName:
+        description: An alias for the person.
+        type: string
+      familyName:
+        description: Family name. In the U.S., the last name of an Person. This can
+          be used along with givenName instead of the name property.
+        type: string
+      givenName:
+        description: Given name. In the U.S., the first name of a Person. This can
+          be used along with familyName instead of the name property.
+        type: string
+      name:
+        description: The name of the person.
+        type: string
+      orcid:
+        description: the ORCID ID of the person
+        type: string
+      role:
+        description: authorship, sponsorship, or other contribution role played by
+          the person or organization in the creation of this resource
+        oneOf:
+        - type: string
+        - items:
+            type: string
+          type: array
+    required:
+    - name
+    type: object
+  '@id': outbreak:Person
+  '@type': rdfs:Class
+  rdfs:comment: This is the Person schema for describing authors and people for outbreak.info
+    resources
+  rdfs:label: Person
+  rdfs:subClassOf:
+    '@id': schema:Person
+- '@id': outbreak:orcid
+  '@type': rdfs:Property
+  rdfs:comment: the ORCID ID of the person
+  rdfs:label: orcid
+  schema:domainIncludes:
+    '@id': outbreak:Person
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- $validation:
+    $schema: http://json-schema.org/draft-07/schema#
+    definitions:
+      baseOrgObject:
+        '@type': outbreak:Organization
+        description: Affiliated Organization
+        properties:
+          alternateName:
+            description: Alternate name or Acronym for the organization.
+            type: string
+          name:
+            description: name of the organization
+            type: string
+        required:
+        - name
+        type: object
+      basePersonObject:
+        '@type': outbreak:Person
         properties:
           affiliation:
+            description: consortia or other organizations with which this person is
+              affiliated
             oneOf:
-            - $ref: '#/definitions/organization'
+            - $ref: '#/definitions/baseOrgObject'
             - items:
-                $ref: '#/definitions/organization'
+                $ref: '#/definitions/baseOrgObject'
               type: array
-            type: array
+          alternateName:
+            type: string
           familyName:
             type: string
           givenName:
@@ -483,14 +110,633 @@
         - name
         type: object
     properties:
+      affiliation:
+        description: consortia or other organizations with which this organization
+          is affiliated
+        oneOf:
+        - $ref: '#/definitions/baseOrgObject'
+        - items:
+            $ref: '#/definitions/baseOrgObject'
+          type: array
+      alternateName:
+        description: An alias or acronym for the organization.
+        type: string
+      class:
+        description: A classification of the organization by a resource. Eg- for ClinicalTrials
+          funders, it's [U.S. National Institutes of Health, Other U.S. Federal agencies,
+          Industry, All others]
+        type: string
+      members:
+        description: Members of this organization, team, or group
+        oneOf:
+        - $ref: '#/definitions/basePersonObject'
+        - items:
+            $ref: '#/definitions/basePersonObject'
+          type: array
+      name:
+        description: The name of the organization.
+        type: string
+      role:
+        description: The role of an organization in its involvement with a resource
+        oneOf:
+        - type: string
+        - items:
+            type: string
+          type: array
+    required:
+    - name
+    type: object
+  '@id': outbreak:Organization
+  '@type': rdfs:Class
+  rdfs:comment: This is the organization schema for describing authors, funders and
+    other organizations referenced by outbreak.info resources
+  rdfs:label: Organization
+  rdfs:subClassOf:
+    '@id': schema:Organization
+- '@id': outbreak:affiliation
+  '@type': rdfs:Property
+  rdfs:comment: consortia or other organizations with which this organization is affiliated
+  rdfs:label: affiliation
+  schema:domainIncludes:
+    '@id': outbreak:Organization
+  schema:rangeIncludes:
+  - '@id': outbreak:Organization
+- '@id': outbreak:members
+  '@type': rdfs:Property
+  rdfs:comment: Members of this organization, team, or group
+  rdfs:label: members
+  schema:domainIncludes:
+    '@id': outbreak:Organization
+  schema:rangeIncludes:
+  - '@id': outbreak:Person
+- '@id': outbreak:class
+  '@type': rdfs:Property
+  rdfs:comment: A classification of the organization by a resource. Eg- for ClinicalTrials
+    funders, it's [U.S. National Institutes of Health, Other U.S. Federal agencies,
+    Industry, All others]
+  rdfs:label: class
+  schema:domainIncludes:
+    '@id': outbreak:Organization
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:role
+  '@type': rdfs:Property
+  rdfs:comment: authorship, sponsorship, or other contribution role played by the
+    person or organization in the creation of this resource. In a Clinical Study/Trial
+    ArmGroup, it's equivalent to the ArmType in ClinicalTrials.gov
+  rdfs:label: role
+  schema:domainIncludes:
+  - '@id': outbreak:Person
+  - '@id': outbreak:Organization
+  - '@id': outbreak:ArmGroup
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- $validation:
+    $schema: http://json-schema.org/draft-07/schema#
+    definitions:
+      baseOrgObject:
+        '@type': outbreak:Organization
+        description: Affiliated Organization
+        properties:
+          alternateName:
+            description: Alternate name or Acronym for the organization.
+            type: string
+          name:
+            description: name of the organization
+            type: string
+        required:
+        - name
+        type: object
+      basePersonObject:
+        '@type': outbreak:Person
+        properties:
+          affiliation:
+            description: consortia or other organizations with which this person is
+              affiliated
+            oneOf:
+            - $ref: '#/definitions/baseOrgObject'
+            - items:
+                $ref: '#/definitions/baseOrgObject'
+              type: array
+          alternateName:
+            type: string
+          familyName:
+            type: string
+          givenName:
+            type: string
+          name:
+            type: string
+          orcid:
+            type: string
+        required:
+        - name
+        type: object
+    properties:
+      funder:
+        description: The organization(s) that supported (sponsored) the grant through
+          some kind of financial contribution.
+        oneOf:
+        - $ref: '#/definitions/baseOrgObject'
+        - items:
+            $ref: '#/definitions/baseOrgObject'
+          type: array
+      identifier:
+        description: The funding or grant id
+        type: string
+      name:
+        description: The name of the grant or funding.
+        type: string
+      recipient:
+        anyOf:
+        - $ref: '#/definitions/basePersonObject'
+        - items:
+            $ref: '#/definitions/basePersonObject'
+          type: array
+        - $ref: '#/definitions/baseOrgObject'
+        - items:
+            $ref: '#/definitions/baseOrgObject'
+          type: array
+        description: The person or organization to whom or to which the grant was
+          awarded
+      url:
+        description: URL of the grant or funding award.
+        format: uri
+        type: string
+    required:
+    - funder
+    type: object
+  '@id': outbreak:MonetaryGrant
+  '@type': rdfs:Class
+  rdfs:comment: This is the schema for describing the MonetaryGrant schema used for
+    outbreak.info
+  rdfs:label: MonetaryGrant
+  rdfs:subClassOf:
+    '@id': schema:MonetaryGrant
+- '@id': outbreak:recipient
+  '@type': rdfs:Property
+  rdfs:comment: The person or organization to whom or to which the grant was awarded
+  rdfs:label: recipient
+  schema:domainIncludes:
+    '@id': outbreak:MonetaryGrant
+  schema:rangeIncludes:
+  - '@id': schema:Person
+  - '@id': schema:Organization
+- '@id': outbreak:DataDownload
+  '@type': rdfs:Class
+  rdfs:comment: This is the schema for describing the DataDownload schema used for
+    outbreak.info.
+  rdfs:label: DataDownload
+  rdfs:subClassOf:
+    '@id': schema:DataDownload
+- $validation:
+    $schema: http://json-schema.org/draft-07/schema#
+    properties:
+      citeText:
+        description: The bibliographic citation for the referenced resource as is
+          provided
+        type: string
+      doi:
+        description: A doi if available
+        type: string
+      identifier:
+        description: An identifier associated with the citation
+        type: string
+      name:
+        description: The name or title of the cited resource.
+        type: string
+      pmid:
+        description: A pubmed identifier if available
+        type: string
+      sourceType:
+        description: The @type of resource
+        enum:
+        - Dataset
+        - Publication
+        - ClinicalTrial
+        - Analysis
+        - Protocol
+        - SoftwareApplication
+        - CreativeWork
+      url:
+        description: URL of the cited resource.
+        format: uri
+        type: string
+      versionDate:
+        description: The version date of the resource used at the time of the creation
+          of the citation as certain resources (protocols, datasets) may change frequently
+          over time.
+        format: date
+        type: string
+    required:
+    - name
+    - sourceType
+    type: object
+  '@id': outbreak:CitationObject
+  '@type': rdfs:Class
+  rdfs:comment: A citation object for a resource which is cited by the subject (ie-
+    is a derivative of the subject), related to the subject, or from which the subject
+    was based on (ie- is derived from).
+  rdfs:label: CitationObject
+  rdfs:subClassOf:
+    '@id': schema:CreativeWork
+- '@id': outbreak:citeText
+  '@type': rdfs:Property
+  rdfs:comment: The bibliographic citation for the referenced resource as is provided
+  rdfs:label: citeText
+  schema:domainIncludes:
+    '@id': outbreak:CitationObject
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:versionDate
+  '@type': rdfs:Property
+  rdfs:comment: The version date of the resource used at the time of the creation
+    of the citation as certain resources (protocols, datasets) may change frequently
+    over time.
+  rdfs:label: versionDate
+  schema:domainIncludes:
+    '@id': outbreak:CitationObject
+  schema:rangeIncludes:
+  - '@id': schema:Date
+- '@id': outbreak:sourceType
+  '@type': rdfs:Property
+  rdfs:comment: The type of resource
+  rdfs:label: sourceType
+  schema:domainIncludes:
+    '@id': outbreak:CitationObject
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:Dataset
+  '@type': rdfs:Class
+  rdfs:comment: This is the schema for describing the Dataset schema used for outbreak.info.
+  rdfs:label: Dataset
+  rdfs:subClassOf:
+    '@id': schema:Dataset
+- $validation:
+    $schema: http://json-schema.org/draft-07/schema#
+    properties:
+      correctionType:
+        description: 'Type of notice or correction: (correction, retraction, expression
+          of convern, withdrawal, erratum, update, correction/republication, preprint,
+          peer reviewed version)'
+        oneOf:
+        - enum:
+          - correction
+          - retraction
+          - expression of concern
+          - withdrawal
+          - erratum
+          - update
+          - correction and re-publication
+          - peer reviewed version
+          - preprint
+          type: string
+        - items:
+            enum:
+            - correction
+            - retraction
+            - expression of concern
+            - withdrawal
+            - erratum
+            - update
+            - correction and re-publication
+            - peer reviewed version
+            - preprint
+            type: string
+          type: array
+      datePublished:
+        description: Publication date of the correction or correction notice
+        format: date
+        type: string
+      doi:
+        description: The DOI of the published correction or correction notice
+        type: string
+      identifier:
+        description: An identifier for the published correction or correction notice.
+          DOI (preferred) or PMID (e.g., 10.1126/sciimmunol.aaw6329, PMID:31471352)
+        type: string
+      pmid:
+        description: The PMID of the published correction or correction notice (if
+          available)
+        type: integer
+      url:
+        description: URL of the item.
+        format: uri
+        type: string
+    required: []
+    type: object
+  '@id': outbreak:Correction
+  '@type': rdfs:Class
+  rdfs:comment: This is the schema for describing a Correction used for outbreak.info.
+    A Correction is a specialized subclass of the CitationObject
+  rdfs:label: Correction
+  rdfs:subClassOf:
+    '@id': schema:CreativeWork
+- '@id': outbreak:correctionType
+  '@type': rdfs:Property
+  rdfs:comment: 'Type of notice or correction: (correction, retraction, expression
+    of convern, withdrawal, erratum, update, correction/republication, preprint, peer
+    reviewed version)'
+  rdfs:label: correctionType
+  schema:domainIncludes:
+    '@id': outbreak:Correction
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- $validation:
+    $schema: http://json-schema.org/draft-07/schema#
+    definitions:
+      aggregateRatingObject:
+        '@type': AggregateRating
+        description: A cumulative evaluation of the resource
+        properties:
+          author:
+            anyOf:
+            - $ref: '#/definitions/person'
+            - items:
+                $ref: '#/definitions/person'
+              type: array
+            - $ref: '#/definitions/organization'
+            - items:
+                $ref: '#/definitions/organization'
+              type: array
+            description: The author of this content or rating.
+          curationDate:
+            description: The date this evaluation was added into outbreak.info, or
+              was updated in outbreak.info.
+            format: date
+            type: string
+          name:
+            description: The name of the aggregate rating
+            type: string
+          ratingValue:
+            description: The rating for the content.
+            type: string
+          reviewAspect:
+            description: This Review or Rating is relevant to this part or facet of
+              the itemReviewed
+            type: string
+          reviews:
+            anyOf:
+            - items:
+                $ref: '#/definitions/reviewObject'
+              type: array
+            - items:
+                $ref: '#/definitions/ratingObject'
+              type: array
+        required: []
+        type: object
+      baseOrgObject:
+        '@type': outbreak:Organization
+        description: A barebones Organization object to work around recursion issues
+          in DDE
+        properties:
+          alternateName:
+            description: Alternate name or Acronym for the organization.
+            type: string
+          name:
+            description: name of the organization
+            type: string
+        required:
+        - name
+        type: object
+      citation:
+        '@type': outbreak:CitationObject
+        description: A citation object for a resource which is cited by the publication
+          (ie- is a derivative of the publication) , related to the publication, or
+          from which the publication was based on (ie- is derived from).
+        properties:
+          citeText:
+            description: The bibliographic citation for the referenced resource as
+              is provided
+            type: string
+          doi:
+            description: A doi if available
+            type: string
+          identifier:
+            description: An identifier associated with the citation
+            type: string
+          name:
+            description: Name of or title of the citation
+            type: string
+          pmid:
+            description: A pubmed identifier if available
+            type: string
+          sourceType:
+            description: The type of resource
+            enum:
+            - Dataset
+            - Publication
+            - ClinicalTrial
+            - Analysis
+            - Protocol
+            - SoftwareApplication
+            - CreativeWork
+          url:
+            description: The url of the resource cited.
+            format: uri
+            type: string
+          versionDate:
+            description: The version date of the resource used at the time of the
+              creation of the citation as certain resources (protocols, datasets)
+              may change frequently over time.
+            format: date
+            type: string
+        required:
+        - name
+        - sourceType
+        type: object
+      correctionObject:
+        '@type': outbreak:Correction
+        properties:
+          correctionType:
+            enum:
+            - correction
+            - retraction
+            - expression of concern
+            - withdrawal
+            - erratum
+            - update
+            - correction and re-publication
+            - peer reviewed version
+            - preprint
+          datePublished:
+            description: publication date of the correction notice or publication
+            format: date
+            type: string
+          doi:
+            type: string
+          identifier:
+            type: string
+          pmid:
+            type: integer
+          url:
+            format: uri
+            type: string
+        required:
+        - url
+        - correctionType
+        type: object
+      funding:
+        '@type': outbreak:MonetaryGrant
+        description: Information about funding support
+        properties:
+          funder:
+            description: name of the funding organization
+            oneOf:
+            - $ref: '#/definitions/baseOrgObject'
+            - items:
+                $ref: '#/definitions/baseOrgObject'
+              type: array
+          identifier:
+            description: Unique identifier(s) for the grant(s) used to fund the Dataset
+            type: string
+          name:
+            description: The name of the monetary grant that funded/funds the Dataset
+            type: string
+          url:
+            description: award URL
+            format: uri
+            type: string
+        required:
+        - funder
+        type: object
+      memberObject:
+        '@type': outbreak:Person
+        description: Reusable person definition accounting for recursion issues in
+          DDE
+        properties:
+          affiliation:
+            oneOf:
+            - $ref: '#/definitions/baseOrgObject'
+            - items:
+                $ref: '#/definitions/baseOrgObject'
+              type: array
+          familyName:
+            type: string
+          givenName:
+            type: string
+          name:
+            type: string
+          orcid:
+            type: string
+        required:
+        - name
+        type: object
+      organization:
+        '@type': outbreak:Organization
+        description: Reusable organization definition
+        properties:
+          affiliation:
+            $ref: '#/definitions/baseOrgObject'
+          alternateName:
+            type: string
+          members:
+            oneOf:
+            - $ref: '#/definitions/memberObject'
+            - items:
+                $ref: '#/definitions/memberObject'
+              type: array
+          name:
+            type: string
+        required:
+        - name
+        type: object
+      person:
+        '@type': outbreak:Person
+        description: Reusable person definition
+        properties:
+          affiliation:
+            oneOf:
+            - $ref: '#/definitions/baseOrgObject'
+            - items:
+                $ref: '#/definitions/baseOrgObject'
+              type: array
+          familyName:
+            type: string
+          givenName:
+            type: string
+          name:
+            type: string
+          orcid:
+            type: string
+        required:
+        - name
+        type: object
+      ratingObject:
+        '@type': Rating
+        description: A rating or categorical evaluation of the resource
+        properties:
+          author:
+            anyOf:
+            - $ref: '#/definitions/person'
+            - items:
+                $ref: '#/definitions/person'
+              type: array
+            - $ref: '#/definitions/organization'
+            - items:
+                $ref: '#/definitions/organization'
+              type: array
+            description: The author of this content or rating.
+          curationDate:
+            description: The date this evaluation was added into outbreak.info, or
+              was updated in outbreak.info.
+            format: date
+            type: string
+          name:
+            description: The name of the rating
+            type: string
+          ratingExplanation:
+            description: An explanation of the rating
+            type: string
+          ratingValue:
+            description: The rating for the content.
+            type: string
+          reviewAspect:
+            description: This Review or Rating is relevant to this part or facet of
+              the itemReviewed
+            type: string
+        required: []
+        type: object
+      reviewObject:
+        '@type': Review
+        description: A review or descriptive evaluation of the resource
+        properties:
+          author:
+            anyOf:
+            - $ref: '#/definitions/person'
+            - items:
+                $ref: '#/definitions/person'
+              type: array
+            - $ref: '#/definitions/organization'
+            - items:
+                $ref: '#/definitions/organization'
+              type: array
+            description: The author of this content or rating.
+          curationDate:
+            description: The date this evaluation was added into outbreak.info, or
+              was updated in outbreak.info.
+            format: date
+            type: string
+          name:
+            description: The name of the review
+            type: string
+          reviewAspect:
+            description: This Review or Rating is relevant to this part or facet of
+              the itemReviewed
+            type: string
+          reviewBody:
+            description: The actual body of the review.
+            type: string
+          reviewRating:
+            $ref: '#/definitions/ratingObject'
+            description: The rating given in this review
+        required: []
+        type: object
+    properties:
       abstract:
-        description: 'Article abstract '
+        description: A short descriptive summary of the resource
         type: string
       author:
-        description: 'Name of the author or organization that created the dataset.  Note:
-          schema.org/creator and schema.org/organization have additional fields that
-          can provide more information about the author/organization, if desired'
-        oneOf:
+        anyOf:
         - $ref: '#/definitions/person'
         - items:
             $ref: '#/definitions/person'
@@ -499,25 +745,27 @@
         - items:
             $ref: '#/definitions/organization'
           type: array
+        description: 'Name of the author or organization that created the dataset.  Note:
+          schema.org/creator and schema.org/organization have additional fields that
+          can provide more information about the author/organization, if desired'
       citedBy:
-        description: other articles or resources that cite this publication
+        description: A citation to a resource (eg- publication, protocol, etc.) which
+          is derived from this publication (stored as an object, not a string)
         oneOf:
         - $ref: '#/definitions/citation'
         - items:
             $ref: '#/definitions/citation'
           type: array
       correction:
-        description: Version number or correction statement
+        description: Related corrections or correction notices for this resource (eg-
+          retraction notice, etc.)
         oneOf:
-        - type: string
+        - $ref: '#/definitions/correctionObject'
         - items:
-            type: string
+            $ref: '#/definitions/correctionObject'
           type: array
       curatedBy:
-        description: The source from which this Publication was identified for inclusion
-          into Outbreak.info. Provides provenance for a resource which was curated
-          by another.
-        oneOf:
+        anyOf:
         - $ref: '#/definitions/citation'
         - $ref: '#/definitions/person'
         - $ref: '#/definitions/organization'
@@ -530,6 +778,9 @@
         - items:
             $ref: '#/definitions/citation'
           type: array
+        description: The source from which this Publication was identified for inclusion
+          into Outbreak.info. Provides provenance for a resource which was curated
+          by another.
       curationDate:
         description: The date this resource was added into outbreak.info, or was updated
           in outbreak.info.
@@ -549,17 +800,31 @@
         format: date
         type: string
       doi:
-        description: DOI
+        description: The DOI of the publication if available
         type: string
+      evaluations:
+        anyOf:
+        - items:
+            $ref: '#/definitions/reviewObject'
+          type: array
+        - items:
+            $ref: '#/definitions/ratingObject'
+          type: array
+        - items:
+            $ref: '#/definitions/aggregateRatingObject'
+          type: array
+        description: Reviews, Ratings, or other types of evaluations on this resource
       funding:
-        description: The funder of the study
+        description: Funding that supports (sponsors) the collection of this dataset
+          through some kind of financial contribution
         oneOf:
         - $ref: '#/definitions/funding'
         - items:
             $ref: '#/definitions/funding'
           type: array
       identifier:
-        description: DOI (preferred) or PMID (e.g., 10.1126/sciimmunol.aaw6329, PMID:31471352)
+        description: An identifier for the publication. DOI (preferred) or PMID (e.g.,
+          10.1126/sciimmunol.aaw6329, PMID:31471352)
         type: string
       isBasedOn:
         description: Associated datasets, software, protocols, etc. used by the work
@@ -569,34 +834,46 @@
         - items:
             $ref: '#/definitions/citation'
           type: array
+      isRelatedTo:
+        description: A citation to a resource (eg- publication, protocol, etc.) which
+          is related to the publication but is not a derivative nor was derived from
+          the publication (stored as an object, not a string)
+        oneOf:
+        - $ref: '#/definitions/citation'
+        - items:
+            $ref: '#/definitions/citation'
+          type: array
       issueNumber:
         description: Issue of journal in which the article was published
         type: string
       journalName:
-        description: Journal or preprint server name
+        description: The name of the journal (or publisher or preprint server if journal
+          name not available)
         type: string
       journalNameAbbrevation:
-        description: Abbreviated Journal Title (note, this should be autopopulated)
+        description: abbreviated Journal Title (note, this should be autopopulated)
         type: string
       keywords:
-        description: Keywords
+        description: Keywords or tags used to describe this content. Multiple entries
+          in a keywords list are typically delimited by commas.
         oneOf:
         - type: string
         - items:
             type: string
           type: array
       license:
-        description: License
+        description: Licensing that applies to this content, typically indicated by
+          URL.
         type: string
       name:
-        description: Title of the article
+        description: Title of the article or publication
         type: string
       pagination:
-        description: Any description of pages for the article
+        description: Any description of pages for the article or publication
         type: string
       pmid:
-        description: PMID
-        type: integer
+        description: The Pubmed identifier or PMID of the publication if available
+        type: string
       publicationType:
         description: Type of publication such as preprint, research article, case
           report, etc
@@ -604,15 +881,6 @@
         - type: string
         - items:
             type: string
-          type: array
-      relatedTo:
-        description: Related articles or resources such as pre-prints, comments, editorial
-          summaries of the article, etc. Helpful for de-duplication between pre-print
-          and peer-reviewed version
-        oneOf:
-        - $ref: '#/definitions/citation'
-        - items:
-            $ref: '#/definitions/citation'
           type: array
       topicCategory:
         description: Applicable outbreak.info category
@@ -651,6 +919,7 @@
           - Epidemiology
           - Classical Epidemiology
           - Molecular Epidemiology
+          - Information Sciences
         - items:
             enum:
             - Clinical
@@ -686,9 +955,10 @@
             - Epidemiology
             - Classical Epidemiology
             - Molecular Epidemiology
+            - Information Sciences
           type: array
       url:
-        description: url where the article can be found
+        description: url where the publication or article can be found
         oneOf:
         - format: uri
           type: string
@@ -700,691 +970,972 @@
         description: Volume number of journal in which the article was published
         type: string
     required:
-    - name
-    - identifier
-    - datePublished
     - journalName
+    - identifier
+    - name
     - url
     - author
+    - datePublished
     type: object
   '@id': outbreak:Publication
   '@type': rdfs:Class
-  rdfs:comment: This is the schema for describing the Publication schema used for
-    outbreak.info.
+  rdfs:comment: This is the schema for describing the Publication used for outbreak.info
   rdfs:label: Publication
   rdfs:subClassOf:
-    '@id': schema:ScholarlyArticle
-  schema:isPartOf:
-    '@id': https://discovery.biothings.io/view/outbreak/
-- '@id': outbreak:name
-  '@type': rdf:Property
-  marginality: required
-  owl:cardinality: one
-  rdfs:comment: Title of the article
-  rdfs:label: name
-  rdfs:sameAs:
-    '@id': schema:name
-  schema:domainIncludes:
-    '@id': outbreak:Publication
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:identifier
-  '@type': rdf:Property
-  marginality: required
-  owl:cardinality: one
-  rdfs:comment: DOI (preferred) or PMID (e.g., 10.1126/sciimmunol.aaw6329, PMID:31471352)
-  rdfs:label: identifier
-  rdfs:sameAs:
-    '@id': schema:identifier
-  schema:domainIncludes:
-    '@id': outbreak:Publication
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:doi
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: DOI
-  rdfs:label: doi
-  rdfs:sameAs:
-    '@id': schema:identifier
-  schema:domainIncludes:
-    '@id': outbreak:Publication
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:pmid
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: PMID
-  rdfs:label: pmid
-  rdfs:sameAs:
-    '@id': schema:identifier
-  schema:domainIncludes:
-    '@id': outbreak:Publication
-  schema:rangeIncludes:
-    '@id': schema:Number
-- '@id': outbreak:datePublished
-  '@type': rdf:Property
-  marginality: required
-  owl:cardinality: one
-  rdfs:comment: PublicationDate online if available
-  rdfs:label: datePublished
-  rdfs:sameAs:
-    '@id': schema:datePublished
-  schema:domainIncludes:
-    '@id': outbreak:Publication
-  schema:rangeIncludes:
-    '@id': schema:Date
+    '@id': schema:MedicalScholarlyArticle
 - '@id': outbreak:journalName
-  '@type': rdf:Property
-  marginality: required
-  owl:cardinality: one
-  rdfs:comment: Journal or preprint server name
+  '@type': rdfs:Property
+  rdfs:comment: The name of the journal (or publisher if journal name not available)
   rdfs:label: journalName
-  rdfs:sameAs:
-    '@id': schema:name
   schema:domainIncludes:
     '@id': outbreak:Publication
   schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:journalName
-  '@type': rdf:Property
-  marginality: required
-  owl:cardinality: one
-  rdfs:comment: Journal or preprint server name
-  rdfs:label: journalName
-  rdfs:sameAs:
-    '@id': schema:name
-  schema:domainIncludes:
-    '@id': outbreak:Publication
-  schema:rangeIncludes:
-    '@id': schema:Text
+  - '@id': schema:Text
 - '@id': outbreak:journalNameAbbrevation
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: Abbreviated Journal Title (note, this should be autopopulated)
+  '@type': rdfs:Property
+  rdfs:comment: abbreviated Journal Title (note, this should be autopopulated)
   rdfs:label: journalNameAbbrevation
-  rdfs:sameAs:
-    '@id': schema:name
   schema:domainIncludes:
     '@id': outbreak:Publication
   schema:rangeIncludes:
-    '@id': schema:Text
+  - '@id': schema:Text
 - '@id': outbreak:volumeNumber
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
+  '@type': rdfs:Property
   rdfs:comment: Volume number of journal in which the article was published
   rdfs:label: volumeNumber
-  rdfs:sameAs:
-    '@id': schema:volumeNumber
   schema:domainIncludes:
     '@id': outbreak:Publication
   schema:rangeIncludes:
-    '@id': schema:Text
+  - '@id': schema:Text
 - '@id': outbreak:issueNumber
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
+  '@type': rdfs:Property
   rdfs:comment: Issue of journal in which the article was published
   rdfs:label: issueNumber
-  rdfs:sameAs:
-    '@id': schema:issueNumber
   schema:domainIncludes:
     '@id': outbreak:Publication
   schema:rangeIncludes:
-    '@id': schema:Text
+  - '@id': schema:Text
+- '@id': outbreak:Analysis
+  '@type': rdfs:Class
+  rdfs:comment: This is the schema for describing an Analysis for inclusion in outbreak.info
+    resources
+  rdfs:label: Analysis
+  rdfs:subClassOf:
+    '@id': schema:CreativeWork
+- '@id': outbreak:domainUrl
+  '@type': rdfs:Property
+  rdfs:comment: The domain name or main site on which webpage or specific url can
+    be found
+  rdfs:label: domainUrl
+  schema:domainIncludes:
+    '@id': outbreak:Analysis
+  schema:rangeIncludes:
+  - '@id': schema:URL
+- '@id': outbreak:assumption
+  '@type': rdfs:Property
+  rdfs:comment: Statement of assumptions / limitations of the model
+  rdfs:label: assumption
+  schema:domainIncludes:
+    '@id': outbreak:Analysis
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:analysisTechnique
+  '@type': rdfs:Property
+  rdfs:comment: A technique or technology used in a analysis
+  rdfs:label: analysisTechnique
+  schema:domainIncludes:
+    '@id': outbreak:Analysis
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:analysisTopic
+  '@type': rdfs:Property
+  rdfs:comment: The underlying question, goal, or aim of the analysis
+  rdfs:label: analysisTopic
+  schema:domainIncludes:
+    '@id': outbreak:Analysis
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:Product
+  '@type': rdfs:Class
+  rdfs:comment: This is the schema for describing a reagent, material, sample, or
+    some other product used in a protocol resource in outbreak.info
+  rdfs:label: Product
+  rdfs:subClassOf:
+    '@id': schema:Product
+- '@id': outbreak:Instrument
+  '@type': rdfs:Class
+  rdfs:comment: This is the schema for describing an instrument used in a protocol
+    resource listed in outbreak.info
+  rdfs:label: Instrument
+  rdfs:subClassOf:
+    '@id': schema:Product
+- '@id': outbreak:Protocol
+  '@type': rdfs:Class
+  rdfs:comment: This is the schema for describing the Protocols for outbreak.info
+    Resources.
+  rdfs:label: Protocol
+  rdfs:subClassOf:
+    '@id': schema:HowTo
+- '@id': outbreak:warning
+  '@type': rdfs:Property
+  rdfs:comment: Precautions, warnings, and/or safety warnings associated with or highlighted
+    by the protocol
+  rdfs:label: warning
+  schema:domainIncludes:
+    '@id': outbreak:Protocol
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:correctionNote
+  '@type': rdfs:Property
+  rdfs:comment: statement of what was updated/changed since prior version
+  rdfs:label: correctionNote
+  schema:domainIncludes:
+    '@id': outbreak:Protocol
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:protocolStatus
+  '@type': rdfs:Property
+  rdfs:comment: The status of the protocol
+  rdfs:label: protocolStatus
+  schema:domainIncludes:
+    '@id': outbreak:Protocol
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:instrument
+  '@type': rdfs:Property
+  rdfs:comment: A laboratory equipment use by a person to follow one or more steps
+    described in this Protocol
+  rdfs:label: instrument
+  schema:domainIncludes:
+    '@id': outbreak:Protocol
+  schema:rangeIncludes:
+  - '@id': outbreak:Instrument
+- '@id': outbreak:protocolSetting
+  '@type': rdfs:Property
+  rdfs:comment: The type of 'protocol' based on setting in which it would apply
+  rdfs:label: protocolSetting
+  schema:domainIncludes:
+    '@id': outbreak:Protocol
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:protocolCategory
+  '@type': rdfs:Property
+  rdfs:comment: The type of 'protocol' based on degree of specificity and purpose
+  rdfs:label: protocolCategory
+  schema:domainIncludes:
+    '@id': outbreak:Protocol
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:usedToGenerate
+  '@type': rdfs:Property
+  rdfs:comment: Type of evidence/data generated by the protocol
+  rdfs:label: usedToGenerate
+  schema:domainIncludes:
+    '@id': outbreak:Protocol
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:inComplianceWith
+  '@type': rdfs:Property
+  rdfs:comment: Guidelines or Standards to which these protocols adhere. ie- GMP,
+    GCP, other EQUATOR guidelines. Useful for selecting protocols where certain standards/guidelines
+    must be met
+  rdfs:label: inComplianceWith
+  schema:domainIncludes:
+    '@id': outbreak:Protocol
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:StudyEvent
+  '@type': rdfs:Class
+  rdfs:comment: This is the schema for describing StudyEvents, a class that describes
+    categorical events in Clinical Trials added to outbreak.info
+  rdfs:label: StudyEvent
+  rdfs:subClassOf:
+    '@id': schema:Thing
+- '@id': outbreak:studyEventType
+  '@type': rdfs:Property
+  rdfs:comment: Type of the event status such as StudyStart, PrimaryCompletion, Completion,
+    StudyFirstSubmit, StudyFirstSubmitQC, LastUpdateSubmit
+  rdfs:label: studyEventType
+  schema:domainIncludes:
+    '@id': outbreak:StudyEvent
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:studyEventDate
+  '@type': rdfs:Property
+  rdfs:comment: The corresponding/actual date of the study event (ie- the StartDate,
+    Primary CompletionDate, CompletionDate, StudyFirstSubmitDate, StudyFirstSubmitQCDate,
+    LastUpdateSubmitDate)
+  rdfs:label: studyEventDate
+  schema:domainIncludes:
+    '@id': outbreak:StudyEvent
+  schema:rangeIncludes:
+  - '@id': schema:Date
+- '@id': outbreak:studyEventDateType
+  '@type': rdfs:Property
+  rdfs:comment: the type of date provided (actual, anticipated, or estimated)
+  rdfs:label: studyEventDateType
+  schema:domainIncludes:
+    '@id': outbreak:StudyEvent
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:StudyStatus
+  '@type': rdfs:Class
+  rdfs:comment: This is the schema for describing the status of a ClinicalTrial resource
+    in outbreak.info
+  rdfs:label: StudyStatus
+  rdfs:subClassOf:
+    '@id': schema:Thing
+- '@id': outbreak:status
+  '@type': rdfs:Property
+  rdfs:comment: The recruitment status of the study
+  rdfs:label: status
+  rdfs:sameAs:
+    '@id': schema:status
+  schema:domainIncludes:
+    '@id': outbreak:StudyStatus
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:statusExpandedAccess
+  '@type': rdfs:Property
+  rdfs:comment: Flag for whether or not the study has expanded Access status
+  rdfs:label: statusExpandedAccess
+  schema:domainIncludes:
+    '@id': outbreak:StudyStatus
+  schema:rangeIncludes:
+  - '@id': schema:Boolean
+- '@id': outbreak:statusDate
+  '@type': rdfs:Property
+  rdfs:comment: The date that the status was verified. Equivalent to NCT's StatusVerifiedDate
+  rdfs:label: statusDate
+  schema:domainIncludes:
+    '@id': outbreak:StudyStatus
+  schema:rangeIncludes:
+  - '@id': schema:Date
+- '@id': outbreak:enrollmentCount
+  '@type': rdfs:Property
+  rdfs:comment: The number of participants enrolled in the study
+  rdfs:label: enrollmentCount
+  schema:domainIncludes:
+    '@id': outbreak:StudyStatus
+  schema:rangeIncludes:
+  - '@id': schema:Number
+- '@id': outbreak:enrollmentType
+  '@type': rdfs:Property
+  rdfs:comment: The type of estimation used to determine the enrollmentCount (actual
+    counts, target size, etc.)
+  rdfs:label: enrollmentType
+  schema:domainIncludes:
+    '@id': outbreak:StudyStatus
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:whyStopped
+  '@type': rdfs:Property
+  rdfs:comment: A brief explanation of the reason(s) why such clinical study was stopped
+    (for a clinical study that is Suspended, Terminated, or Withdrawn prior to its
+    planned completion as anticipated by the protocol)
+  rdfs:label: whyStopped
+  schema:domainIncludes:
+    '@id': outbreak:StudyStatus
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:StudyDesign
+  '@type': rdfs:Class
+  rdfs:comment: This is the schema for describing the study design of a clinical trial/study
+    for inclusion into outbreak.info resources
+  rdfs:label: StudyDesign
+  rdfs:subClassOf:
+    '@id': schema:Thing
+- '@id': outbreak:studyType
+  '@type': rdfs:Property
+  rdfs:comment: Type of human study, can be subtypes of observational study or interventional
+    studies and may include the temporal relationship of observation period to time
+    of participant enrollment.
+  rdfs:label: studyType
+  schema:domainIncludes:
+    '@id': outbreak:StudyDesign
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:phase
+  '@type': rdfs:Property
+  rdfs:comment: Stage or phase of the study in the U.S. if applicable
+  rdfs:label: phase
+  rdfs:sameAs:
+    '@id': schema:phase
+  schema:domainIncludes:
+    '@id': outbreak:StudyDesign
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:phaseNumber
+  '@type': rdfs:Property
+  rdfs:comment: The number of the phase or stage of the study
+  rdfs:label: phaseNumber
+  schema:domainIncludes:
+    '@id': outbreak:StudyDesign
+  schema:rangeIncludes:
+  - '@id': schema:Number
+- '@id': outbreak:designAllocation
+  '@type': rdfs:Property
+  rdfs:comment: The method by which the study participants were allocated into groups
+  rdfs:label: designAllocation
+  schema:domainIncludes:
+    '@id': outbreak:StudyDesign
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:designModel
+  '@type': rdfs:Property
+  rdfs:comment: The general design of the strategy for assigning interventions to
+    participants in a clinical intervention study OR the general design of the strategy
+    for identifying and following up with participants during an observational study
+  rdfs:label: designModel
+  schema:domainIncludes:
+    '@id': outbreak:StudyDesign
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:designPrimaryPurpose
+  '@type': rdfs:Property
+  rdfs:comment: The primary purpose of the study
+  rdfs:label: designPrimaryPurpose
+  schema:domainIncludes:
+    '@id': outbreak:StudyDesign
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:designWhoMasked
+  '@type': rdfs:Property
+  rdfs:comment: The people who do not know which participants have been assigned to
+    which interventions
+  rdfs:label: designWhoMasked
+  schema:domainIncludes:
+    '@id': outbreak:StudyDesign
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:designStudyText
+  '@type': rdfs:Property
+  rdfs:comment: String description of the study design if structured information not
+    available
+  rdfs:label: designStudyText
+  schema:domainIncludes:
+    '@id': outbreak:StudyDesign
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:Intervention
+  '@type': rdfs:Class
+  rdfs:comment: a schema to describe Interventions discussed in Clinical Studies/Trials
+    for inclusion in outbreak.info Resources
+  rdfs:label: Intervention
+  rdfs:subClassOf:
+    '@id': schema:Thing
+- '@id': outbreak:category
+  '@type': rdfs:Property
+  rdfs:comment: The category of an intervention in the study
+  rdfs:label: category
+  schema:domainIncludes:
+    '@id': outbreak:Intervention
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- $validation:
+    $schema: http://json-schema.org/draft-07/schema#
+    definitions:
+      intervention:
+        '@type': outbreak:Intervention
+        properties:
+          category:
+            description: The category of an intervention in the study
+            enum:
+            - drugs
+            - medical devices
+            - procedures
+            - vaccines
+            - education
+            - behavioral modification
+            - diet
+            - exercise
+            - counseling
+            - placebo
+            - other
+          description:
+            description: A description of the intervention in the study
+            type: string
+          name:
+            description: The name of the intervention in the study
+            type: string
+        type: object
+    properties:
+      description:
+        description: A description of the arm or factor
+        type: string
+      intervention:
+        description: The interventions (if any) in this ArmGroup
+        oneOf:
+        - $ref: '#/definitions/intervention'
+        - items:
+            $ref: '#/definitions/intervention'
+          type: array
+        type: array
+      name:
+        description: The name of the arm or factor (can include a specific intervention,
+          a placebo or even a lack of intervention, ie- 'no intervention' group)
+        type: string
+      role:
+        description: The role of the arm or factor in the study this is equivalent
+          to the ArmType in ClinicalTrials.gov
+        enum:
+        - experimental arm
+        - active comparator arm
+        - placebo comparator arm
+        - sham comparator arm
+        - no intervention arm
+    required: []
+    type: object
+  '@id': outbreak:ArmGroup
+  '@type': rdfs:Class
+  rdfs:comment: This is the schema for describing arm groups in clinical studies/trials
+    for inclusion in outbreak.info Resources
+  rdfs:label: ArmGroup
+  rdfs:subClassOf:
+    '@id': schema:Thing
+- '@id': outbreak:intervention
+  '@type': rdfs:Property
+  rdfs:comment: The interventions (if any) in this ArmGroup
+  rdfs:label: intervention
+  schema:domainIncludes:
+    '@id': outbreak:ArmGroup
+  schema:rangeIncludes:
+  - '@id': outbreak:Intervention
+- '@id': outbreak:Outcome
+  '@type': rdfs:Class
+  rdfs:comment: This is the schema for describing a Clinical Trial/Study Outcome for
+    inclusion in  outbreak.info Resources
+  rdfs:label: Outcome
+  rdfs:subClassOf:
+    '@id': schema:Thing
+- '@id': outbreak:outcomeMeasure
+  '@type': rdfs:Property
+  rdfs:comment: The outcome measure for the study
+  rdfs:label: outcomeMeasure
+  schema:domainIncludes:
+    '@id': outbreak:Outcome
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:outcomeTimeFrame
+  '@type': rdfs:Property
+  rdfs:comment: The specific time point(s) and overall duration of evaluation must
+    be specified in this section
+  rdfs:label: outcomeTimeFrame
+  schema:domainIncludes:
+    '@id': outbreak:Outcome
+  schema:rangeIncludes:
+  - '@id': schema:Duration
+  - '@id': schema:Text
+- '@id': outbreak:outcomeType
+  '@type': rdfs:Property
+  rdfs:comment: The classification of the outcome measure as either primary, secondary,
+    or exploratory
+  rdfs:label: outcomeType
+  schema:domainIncludes:
+    '@id': outbreak:Outcome
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:Eligibility
+  '@type': rdfs:Class
+  rdfs:comment: This is the schema for describing information about Clinical Trials/Studies
+    eligibility criteria for inclusion in outbreak.info Resources
+  rdfs:label: Eligibility
+  rdfs:subClassOf:
+    '@id': schema:Thing
+- '@id': outbreak:inclusionCriteria
+  '@type': rdfs:Property
+  rdfs:comment: '"criteria for inclusion in the study'
+  rdfs:label: inclusionCriteria
+  schema:domainIncludes:
+    '@id': outbreak:Eligibility
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:minimumAge
+  '@type': rdfs:Property
+  rdfs:comment: the minimum age for a participant to be included in the study
+  rdfs:label: minimumAge
+  schema:domainIncludes:
+    '@id': outbreak:Eligibility
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:maximumAge
+  '@type': rdfs:Property
+  rdfs:comment: the maximum age for a participant to be included in the study
+  rdfs:label: maximumAge
+  schema:domainIncludes:
+    '@id': outbreak:Eligibility
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:gender
+  '@type': rdfs:Property
+  rdfs:comment: the sex requirement to be included in the study
+  rdfs:label: gender
+  schema:domainIncludes:
+    '@id': outbreak:Eligibility
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:genderBased
+  '@type': rdfs:Property
+  rdfs:comment: Boolean for whether or not participation is based on gender
+  rdfs:label: genderBased
+  schema:domainIncludes:
+    '@id': outbreak:Eligibility
+  schema:rangeIncludes:
+  - '@id': schema:Boolean
+- '@id': outbreak:healthyVolunteers
+  '@type': rdfs:Property
+  rdfs:comment: Boolean to indicate whether or not healthy volunteers may be included
+    in the study
+  rdfs:label: healthyVolunteers
+  schema:domainIncludes:
+    '@id': outbreak:Eligibility
+  schema:rangeIncludes:
+  - '@id': schema:Boolean
+- '@id': outbreak:stdAge
+  '@type': rdfs:Property
+  rdfs:comment: the age category of a participant to be included in the study if a
+    minimum and maximum age is not specified
+  rdfs:label: stdAge
+  schema:domainIncludes:
+    '@id': outbreak:Eligibility
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:exclusionCriteria
+  '@type': rdfs:Property
+  rdfs:comment: criteria for exclusion from the study
+  rdfs:label: exclusionCriteria
+  schema:domainIncludes:
+    '@id': outbreak:Eligibility
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:criteriaText
+  '@type': rdfs:Property
+  rdfs:comment: The descriptive criteria as published for the Clinical Trial
+  rdfs:label: criteriaText
+  schema:domainIncludes:
+    '@id': outbreak:Eligibility
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:StudyLocation
+  '@type': rdfs:Class
+  rdfs:comment: This is the schema for describing Clinical Trial/Study locations for
+    inclusion in outbreak.info Resources
+  rdfs:label: StudyLocation
+  rdfs:subClassOf:
+    '@id': schema:Place
+- '@id': outbreak:studyLocation
+  '@type': rdfs:Property
+  rdfs:comment: The location of the study
+  rdfs:label: studyLocation
+  schema:domainIncludes:
+    '@id': outbreak:StudyLocation
+  schema:rangeIncludes:
+  - '@id': schema:Place
+  - '@id': schema:Text
+- '@id': outbreak:studyLocationCity
+  '@type': rdfs:Property
+  rdfs:comment: The city in which the facility used for the study is located
+  rdfs:label: studyLocationCity
+  schema:domainIncludes:
+    '@id': outbreak:StudyLocation
+  schema:rangeIncludes:
+  - '@id': schema:City
+  - '@id': schema:Text
+- '@id': outbreak:studyLocationState
+  '@type': rdfs:Property
+  rdfs:comment: The state or province in which the facility used for the study is
+    located
+  rdfs:label: studyLocationState
+  schema:domainIncludes:
+    '@id': outbreak:StudyLocation
+  schema:rangeIncludes:
+  - '@id': schema:State
+  - '@id': schema:Text
+- '@id': outbreak:studyLocationCountry
+  '@type': rdfs:Property
+  rdfs:comment: The country in which the facility used for the study is located
+  rdfs:label: studyLocationCountry
+  schema:domainIncludes:
+    '@id': outbreak:StudyLocation
+  schema:rangeIncludes:
+  - '@id': schema:Country
+  - '@id': schema:Text
+- '@id': outbreak:studyLocationStatus
+  '@type': rdfs:Property
+  rdfs:comment: The recruitment status of the study at the specific study site
+  rdfs:label: studyLocationStatus
+  schema:domainIncludes:
+    '@id': outbreak:StudyLocation
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:ClinicalTrial
+  '@type': rdfs:Class
+  rdfs:comment: This is the schema for describing the Clinical Trials and other medical
+    studies used for outbreak.info Resources
+  rdfs:label: ClinicalTrial
+  rdfs:subClassOf:
+    '@id': schema:MedicalStudy
+- '@id': outbreak:identifierSource
+  '@type': rdfs:Property
+  rdfs:comment: Source of identifier assignment or type of identifier (NCTid, China
+    CTRid, EudraCT Number, etc.)
+  rdfs:label: identifierSource
+  schema:domainIncludes:
+    '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:dateModifiedType
+  '@type': rdfs:Property
+  rdfs:comment: The type of date. Equivalent to NCT's LastUpdatePostDateType
+  rdfs:label: dateModifiedType
+  schema:domainIncludes:
+    '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:healthConditionIdentifier
+  '@type': rdfs:Property
+  rdfs:comment: Ontological or controlled vocabulary identifier for the health condition
+    or disease
+  rdfs:label: healthConditionIdentifier
+  schema:domainIncludes:
+    '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': schema:Text
+  - '@id': schema:DefinedTerm
+- '@id': outbreak:hasResults
+  '@type': rdfs:Property
+  rdfs:comment: Boolean for if the clinical trial has published any results
+  rdfs:label: hasResults
+  schema:domainIncludes:
+    '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': schema:Boolean
+- '@id': outbreak:studyEvent
+  '@type': rdfs:Property
+  rdfs:comment: an event status such as StudyStart, PrimaryCompletion, Completion,
+    StudyFirstSubmit, StudyFirstSubmitQC, LastUpdateSubmit
+  rdfs:label: studyEvent
+  schema:domainIncludes:
+    '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': outbreak:StudyEvent
+- '@id': outbreak:studyStatus
+  '@type': rdfs:Property
+  rdfs:comment: The status of the study
+  rdfs:label: studyStatus
+  schema:domainIncludes:
+    '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': outbreak:StudyStatus
+- '@id': outbreak:studyDesign
+  '@type': rdfs:Property
+  rdfs:comment: The general design of the study
+  rdfs:label: studyDesign
+  schema:domainIncludes:
+    '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': outbreak:StudyDesign
+- '@id': outbreak:armGroup
+  '@type': rdfs:Property
+  rdfs:comment: The arm or factor of an interventional study
+  rdfs:label: armGroup
+  schema:domainIncludes:
+    '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': outbreak:ArmGroup
+- '@id': outbreak:outcome
+  '@type': rdfs:Property
+  rdfs:comment: The arm or factor of an interventional study
+  rdfs:label: outcome
+  schema:domainIncludes:
+    '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': outbreak:Outcome
+- '@id': outbreak:eligibilityCriteria
+  '@type': rdfs:Property
+  rdfs:comment: eligibility criteria
+  rdfs:label: eligibilityCriteria
+  schema:domainIncludes:
+    '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': outbreak:Eligibility
 - '@id': outbreak:author
-  '@type': rdf:Property
-  marginality: required
-  owl:cardinality: many
-  rdfs:comment: 'Name of the author or organization that created the dataset.  Note:
-    schema.org/creator and schema.org/organization have additional fields that can
-    provide more information about the author/organization, if desired'
+  '@type': rdfs:Property
+  rdfs:comment: The author of this resource, content, or rating
   rdfs:label: author
   rdfs:sameAs:
     '@id': schema:author
   schema:domainIncludes:
-    '@id': outbreak:Publication
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Protocol
+  - '@id': outbreak:Publication
+  - '@id': outbreak:ClinicalTrial
   schema:rangeIncludes:
   - '@id': outbreak:Person
   - '@id': outbreak:Organization
-- '@id': outbreak:name
-  '@type': rdf:Property
-  marginality: required
-  owl:cardinality: one
-  rdfs:comment: The author's name (as provided by the resource)
-  rdfs:label: name
+- '@id': outbreak:dateCreated
+  '@type': rdfs:Property
+  rdfs:comment: Date the record was created
+  rdfs:label: dateCreated
   rdfs:sameAs:
-    '@id': schema:name
+    '@id': schema:dateCreated
   schema:domainIncludes:
-  - '@id': outbreak:Person
-  - '@id': outbreak:Organization
+  - '@id': outbreak:ClinicalTrial
   schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:givenName
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The author's given name (if available)
-  rdfs:label: givenName
+  - '@id': schema:Date
+- '@id': outbreak:datePublished
+  '@type': rdfs:Property
+  rdfs:comment: Date of first broadcast/publication
+  rdfs:label: datePublished
   rdfs:sameAs:
-    '@id': schema:givenName
+    '@id': schema:datePublished
   schema:domainIncludes:
-  - '@id': outbreak:Person
-  - '@id': outbreak:Organization
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Protocol
+  - '@id': outbreak:Publication
+  - '@id': outbreak:ClinicalTrial
   schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:familyName
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The author's family name (if available)
-  rdfs:label: familyName
-  rdfs:sameAs:
-    '@id': schema:familyName
-  schema:domainIncludes:
-  - '@id': outbreak:Person
-  - '@id': outbreak:Organization
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:affiliation
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: The author's affiliation(s)
-  rdfs:label: affiliation
-  rdfs:sameAs:
-    '@id': schema:affiliation
-  schema:domainIncludes:
-  - '@id': outbreak:Person
-  - '@id': outbreak:Organization
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:orcid
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The orcid identifier for the author
-  rdfs:label: orcid
-  rdfs:sameAs:
-    '@id': schema:identifier
-  schema:domainIncludes:
-  - '@id': outbreak:Person
-  - '@id': outbreak:Organization
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:pagination
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: Any description of pages for the article
-  rdfs:label: pagination
-  rdfs:sameAs:
-    '@id': schema:pagination
-  schema:domainIncludes:
-    '@id': outbreak:Publication
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:license
-  '@type': rdf:Property
-  marginality: required
-  owl:cardinality: one
-  rdfs:comment: License
-  rdfs:label: license
-  rdfs:sameAs:
-    '@id': schema:license
-  schema:domainIncludes:
-    '@id': outbreak:Publication
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:url
-  '@type': rdf:Property
-  marginality: required
-  owl:cardinality: many
-  rdfs:comment: url where the article can be found
-  rdfs:label: url
-  rdfs:sameAs:
-    '@id': schema:url
-  schema:domainIncludes:
-    '@id': outbreak:Publication
-  schema:rangeIncludes:
-    '@id': schema:URL
-- '@id': outbreak:abstract
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: 'Article abstract '
-  rdfs:label: abstract
-  rdfs:sameAs:
-    '@id': schema:abstract
-  schema:domainIncludes:
-    '@id': outbreak:Publication
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:publicationType
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: Type of publication such as preprint, research article, case report,
-    etc
-  rdfs:label: publicationType
-  rdfs:sameAs:
-    '@id': schema:publicationType
-  schema:domainIncludes:
-    '@id': outbreak:Publication
-  schema:rangeIncludes:
-    '@id': schema:Text
+  - '@id': schema:Date
 - '@id': outbreak:dateModified
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: many
-  rdfs:comment: Date of Version update
+  '@type': rdfs:Property
+  rdfs:comment: The date on which the CreativeWork was most recently modified or when
+    the item's entry was modified within a DataFeed
   rdfs:label: dateModified
   rdfs:sameAs:
     '@id': schema:dateModified
   schema:domainIncludes:
-    '@id': outbreak:Publication
-  schema:rangeIncludes:
-    '@id': schema:Date
-- '@id': outbreak:correction
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: many
-  rdfs:comment: Version number or correction statement
-  rdfs:label: correction
-  rdfs:sameAs:
-    '@id': schema:correction
-  schema:domainIncludes:
-    '@id': outbreak:Publication
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:funding
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: The funder of the study
-  rdfs:label: funding
-  rdfs:sameAs:
-    '@id': schema:funder
-  schema:domainIncludes:
-    '@id': outbreak:Publication
-  schema:rangeIncludes:
-    '@id': outbreak:MonetaryGrant
-- '@id': outbreak:identifier
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: The identifier of the grant (if available)
-  rdfs:label: identifier
-  rdfs:sameAs:
-    '@id': schema:identifier
-  schema:domainIncludes:
-    '@id': outbreak:MonetaryGrant
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:citedBy
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: many
-  owl:inverseOf:
-    '@id': schema:isBasedOn
-  rdfs:comment: other articles or resources that cite this publication
-  rdfs:label: citedBy
-  schema:domainIncludes:
-    '@id': outbreak:Publication
-  schema:rangeIncludes:
-  - '@id': outbreak:ClinicalTrial
   - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
   - '@id': outbreak:Dataset
   - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-- '@id': outbreak:name
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: name of the citedBy resource
-  rdfs:label: name
-  rdfs:sameAs:
-    '@id': schema:name
-  schema:domainIncludes:
-  - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
   - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:type
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: type (publicatoin, protocol, dataset, code, etc.) of the citedBy resource
-  rdfs:label: type
-  rdfs:sameAs:
-    '@id': schema:additionalType
-  schema:domainIncludes:
   - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
   schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:identifier
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: identifier (pmid, WHO protocol id, etc.) of the citedby resource
-  rdfs:label: identifier
-  rdfs:sameAs:
-    '@id': schema:identifier
-  schema:domainIncludes:
-  - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:isBasedOn
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: many
-  rdfs:comment: Associated datasets, software, protocols, etc. used by the work described
-    in this publication, including reference publications
-  rdfs:label: isBasedOn
-  rdfs:sameAs:
-    '@id': schema:isBasedOn
-  schema:domainIncludes:
-    '@id': outbreak:Publication
-  schema:rangeIncludes:
-  - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-- '@id': outbreak:name
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: name of the associated dataset, software, protocols, etc used by the
-    work described in this publication
-  rdfs:label: name
-  rdfs:sameAs:
-    '@id': schema:name
-  schema:domainIncludes:
-  - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:type
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: type of the associated resource (dataset, protocols, analysis, etc.)
-    used by the work described in this publication
-  rdfs:label: type
-  rdfs:sameAs:
-    '@id': schema:additionalType
-  schema:domainIncludes:
-  - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:identifier
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: Identifier of the associated datasets, software, protocols, etc.
-  rdfs:label: identifier
-  rdfs:sameAs:
-    '@id': schema:identifier
-  schema:domainIncludes:
-  - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:versionDate
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: date of the version of the resource from which this publication was
-    derived. Note this is NOT the same as dateModified, as the protocol may be based
-    on an earlier 'dateModified' than is what is available from the resource
-  rdfs:label: versionDate
-  rdfs:sameAs:
-    '@id': schema:releaseDate
-  schema:domainIncludes:
-  - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-  schema:rangeIncludes:
-    '@id': schema:Date
-- '@id': outbreak:relatedTo
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: many
-  rdfs:comment: Related articles or resources such as pre-prints, comments, editorial
-    summaries of the article, etc. Helpful for de-duplication between pre-print and
-    peer-reviewed version
-  rdfs:label: relatedTo
-  rdfs:sameAs:
-    '@id': schema:relatedTo
-  schema:domainIncludes:
-    '@id': outbreak:Publication
-  schema:rangeIncludes:
-  - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-- '@id': outbreak:name
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: name of related resource
-  rdfs:label: name
-  rdfs:sameAs:
-    '@id': schema:name
-  schema:domainIncludes:
-  - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:type
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: type of related resource
-  rdfs:label: type
-  rdfs:sameAs:
-    '@id': schema:additionalType
-  schema:domainIncludes:
-  - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:identifier
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: Identifier of related articles or resources such as pre-prints, comments,
-    editorial summaries
-  rdfs:label: identifier
-  rdfs:sameAs:
-    '@id': schema:identifier
-  schema:domainIncludes:
-  - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-  schema:rangeIncludes:
-    '@id': schema:Text
+  - '@id': schema:Date
 - '@id': outbreak:keywords
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
-  rdfs:comment: null
+  '@type': rdfs:Property
+  rdfs:comment: keywords for describing the record
   rdfs:label: keywords
-  rdfs:sameAs:
-    '@id': schema:keywords
   schema:domainIncludes:
-    '@id': outbreak:Publication
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Protocol
+  - '@id': outbreak:Publication
+  - '@id': outbreak:ClinicalTrial
   schema:rangeIncludes:
-    '@id': schema:Text
+  - '@id': schema:Text
+- '@id': outbreak:abstract
+  '@type': rdfs:Property
+  rdfs:comment: A short descriptive summary of the publication or study
+  rdfs:label: abstract
+  rdfs:sameAs:
+    '@id': schema:abstract
+  schema:domainIncludes:
+  - '@id': outbreak:Publication
+  - '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:pmid
+  '@type': rdfs:Property
+  rdfs:comment: A pubmed identifier if available
+  rdfs:label: pmid
+  schema:domainIncludes:
+  - '@id': outbreak:CitationObject
+  - '@id': outbreak:Correction
+  - '@id': outbreak:Publication
+  schema:rangeIncludes:
+  - '@id': schema:Integer
+- '@id': outbreak:doi
+  '@type': rdfs:Property
+  rdfs:comment: A doi if available
+  rdfs:label: doi
+  schema:domainIncludes:
+  - '@id': outbreak:CitationObject
+  - '@id': outbreak:Correction
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Publication
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Protocol
+  schema:rangeIncludes:
+  - '@id': schema:Text
+- '@id': outbreak:funding
+  '@type': rdfs:Property
+  rdfs:comment: Funding that supports (sponsors) the collection of this dataset through
+    some kind of financial contribution
+  rdfs:label: funding
+  schema:domainIncludes:
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Publication
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Protocol
+  - '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': schema:MonetaryGrant
+- '@id': outbreak:measurementTechnique
+  '@type': rdfs:Property
+  rdfs:comment: A technique or technology used in this resource
+  rdfs:label: measurementTechnique
+  rdfs:sameAs:
+    '@id': schema:measurementTechnique
+  schema:domainIncludes:
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Protocol
+  schema:rangeIncludes:
+  - '@id': schema:Text
+  - '@id': schema:DefinedTerm
+- '@id': outbreak:species
+  '@type': rdfs:Property
+  rdfs:comment: Species(es) from which dataset has been collected
+  rdfs:label: species
+  schema:domainIncludes:
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Analysis
+  schema:rangeIncludes:
+  - '@id': schema:Text
+  - '@id': schema:DefinedTerm
+- '@id': outbreak:infectiousAgent
+  '@type': rdfs:Property
+  rdfs:comment: infectious agents(s) which are the focus of the dataset
+  rdfs:label: infectiousAgent
+  schema:domainIncludes:
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Analysis
+  schema:rangeIncludes:
+  - '@id': schema:Text
+  - '@id': schema:DefinedTerm
+- '@id': outbreak:infectiousDisease
+  '@type': rdfs:Property
+  rdfs:comment: The disease or medical conditions caused by the infectious agent.
+    Important as some agents may cause multiple diseases
+  rdfs:label: infectiousDisease
+  schema:domainIncludes:
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Analysis
+  schema:rangeIncludes:
+  - '@id': schema:Text
+  - '@id': schema:DefinedTerm
 - '@id': outbreak:topicCategory
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: many
+  '@type': rdfs:Property
   rdfs:comment: Applicable outbreak.info category
   rdfs:label: topicCategory
-  rdfs:sameAs:
-    '@id': schema:about
   schema:domainIncludes:
-    '@id': outbreak:Publication
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Publication
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Protocol
+  - '@id': outbreak:ClinicalTrial
   schema:rangeIncludes:
-    '@id': schema:Text
+  - '@id': schema:Text
+- '@id': outbreak:isBasedOn
+  '@type': rdfs:Property
+  rdfs:comment: A citation to a resource (eg- publication, protocol, etc.) on which
+    this resource was derived (stored as an object, not a string)
+  rdfs:label: isBasedOn
+  schema:domainIncludes:
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Publication
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Protocol
+  - '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': outbreak:CitationObject
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Publication
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Protocol
+  - '@id': outbreak:ClinicalTrial
+  - '@id': schema:SoftwareApplication
+  - '@id': schema:CreativeWork
+- '@id': outbreak:isRelatedTo
+  '@type': rdfs:Property
+  rdfs:comment: A citation to a resource (eg- publication, protocol, etc.) which is
+    related to the resource but is not a derivative nor was derived from the resource
+    (stored as an object, not a string)
+  rdfs:label: isRelatedTo
+  schema:domainIncludes:
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Publication
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Protocol
+  - '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': outbreak:CitationObject
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Publication
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Protocol
+  - '@id': outbreak:ClinicalTrial
+  - '@id': schema:SoftwareApplication
+  - '@id': schema:CreativeWork
+- '@id': outbreak:citedBy
+  '@type': rdfs:Property
+  rdfs:comment: A citation to a resource (eg- publication, protocol, etc.) which is
+    derived from this resource (stored as an object, not a string)
+  rdfs:label: citedBy
+  rdfs:sameAs:
+    '@id': 'owl:inverseOf: outbreak:isBasedOn'
+  schema:domainIncludes:
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Publication
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Protocol
+  - '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': outbreak:CitationObject
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Publication
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Protocol
+  - '@id': outbreak:ClinicalTrial
+  - '@id': schema:SoftwareApplication
+  - '@id': schema:CreativeWork
 - '@id': outbreak:curatedBy
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  owl:inverseOf:
-    '@id': schema:isBasedOn
-  rdfs:comment: The source from which this Analysis was identified for inclusion into
-    Outbreak.info. Provides provenance for a resource which was curated by another
+  '@type': rdfs:Property
+  rdfs:comment: The source from which this Dataset was identified for inclusion into
+    Outbreak.info. Provides provenance for a resource which was curated by another.
   rdfs:label: curatedBy
   schema:domainIncludes:
-    '@id': outbreak:Publication
-  schema:rangeIncludes:
-  - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
   - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-- '@id': outbreak:name
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: name of the source from which this Analysis was identified for inclusion
-  rdfs:label: name
-  rdfs:sameAs:
-    '@id': schema:name
-  schema:domainIncludes:
-  - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
   - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:url
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The corresponding url for the item in the source from which this Analysis
-    was identified (if available)
-  rdfs:label: url
-  rdfs:sameAs:
-    '@id': schema:url
-  schema:domainIncludes:
-  - '@id': outbreak:ClinicalTrial
   - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
   - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
-  schema:rangeIncludes:
-    '@id': schema:Text
-- '@id': outbreak:versionDate
-  '@type': rdf:Property
-  marginality: optional
-  owl:cardinality: one
-  rdfs:comment: The last date when items were pulled from the source
-  rdfs:label: versionDate
-  rdfs:sameAs:
-    '@id': schema:releaseDate
-  schema:domainIncludes:
   - '@id': outbreak:ClinicalTrial
-  - '@id': outbreak:Analysis
-  - '@id': outbreak:Publication
-  - '@id': outbreak:Dataset
-  - '@id': outbreak:Protocol
-  - '@id': schema:SoftwareApplication
-  - '@id': schema:Thing
   schema:rangeIncludes:
-    '@id': schema:Date
+  - '@id': outbreak:Person
+  - '@id': outbreak:Organization
+  - '@id': outbreak:CitationObject
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Publication
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Protocol
+  - '@id': outbreak:ClinicalTrial
+  - '@id': schema:SoftwareApplication
+  - '@id': schema:CreativeWork
 - '@id': outbreak:curationDate
-  '@type': rdf:Property
-  marginality: recommended
-  owl:cardinality: one
-  rdfs:comment: The date this resource was added to outbreak.info, or the date when
-    this resource was updated in outbreak.info
+  '@type': rdfs:Property
+  rdfs:comment: The date this resource was added into outbreak.info, or was updated
+    in outbreak.info.
   rdfs:label: curationDate
-  rdfs:sameAs:
-    '@id': schema:releaseDate
   schema:domainIncludes:
-    '@id': outbreak:Publication
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Publication
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Protocol
+  - '@id': outbreak:ClinicalTrial
   schema:rangeIncludes:
-    '@id': schema:Date
-- '@id': outbreak:ClinicalTrial
-  '@type': rdfs:Class
-  rdfs:comment: This is the schema for describing the ClinicalTrial schema used for
-    outbreak.info.
-  rdfs:label: ClinicalTrial
-  rdfs:subClassOf:
-    '@id': schema:MedicalStudy
-  schema:isPartOf:
-    '@id': https://discovery.biothings.io/view/outbreak/
-'@id': https://discovery.biothings.io/view/outbreak/
+  - '@id': schema:Date
+- '@id': outbreak:evaluations
+  '@type': rdf:Property
+  rdfs:comment: One or more reviews, ratings, or other evaluations of this resource
+  rdfs:label: evaluations
+  schema:domainIncludes:
+  - '@id': outbreak:Dataset
+  - '@id': outbreak:Publication
+  - '@id': outbreak:Analysis
+  - '@id': outbreak:Protocol
+  - '@id': outbreak:ClinicalTrial
+  schema:rangeIncludes:
+  - '@id': schema:Review
+  - '@id': schema:Rating
+  - '@id': schema:AggregateRating


### PR DESCRIPTION
Updated outbreak.info schemas. Changes include:

-  Removal of `marginality` from property definitions as DDE handles marginality only in the class validation
-  CitationObject its own class
-  CitationObject property 'type' changed to sourceType
-  Inclusion of re-usable evaluation property, for adding assessments on quality of a resource
-  Inclusion of schema:Review, schema:Rating, schema:AggregateRating object in validation
-  Creation of validation for subclasses such as ArmGroup, Person, Organization, etc.
-  Protocol.status changed to Protocol.protocolStatus
-  Product.type changed to Product.category
-  Addition of `Information Sciences` to topicCategories