### PR TITLE
Defined term details

### DIFF
--- a/yaml/outbreak.json
+++ b/yaml/outbreak.json
@@ -530,6 +530,11 @@
               "SoftwareApplication",
               "CreativeWork"
             ]
+          },
+          "curationDate":{
+            "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
+            "type": "string",
+            "format": "date"
           }
         },
         "required": [
@@ -900,11 +905,6 @@
                 }
               }
             ]
-          },
-          "curationDate":{
-            "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
-            "type": "string",
-            "format": "date"
           },
           "license": {
             "description": "A license document that applies to this content, typically indicated by URL.",
@@ -1349,19 +1349,14 @@
                         "type": "array",
                         "items": {
                           "$ref": "#/definitions/organization"
-                      }
-                }
-              ]
+                        }
+                        }
+                    ]
+              }
             },
-              "curationDate":{
-                    "description": "The date this evaluation was added into outbreak.info, or was updated in outbreak.info.",
-                    "type": "string",
-                    "format": "date"
-                  }
-                },
-              "required": [
-              ]
-            },
+            "required": [
+            ]
+          },
           "ratingObject": {
                 "description": "A rating or categorical evaluation of the resource",
                 "@type": "Rating",
@@ -1405,12 +1400,7 @@
                       }
                 }
               ]
-            },
-                  "curationDate":{
-                    "description": "The date this evaluation was added into outbreak.info, or was updated in outbreak.info.",
-                    "type": "string",
-                    "format": "date"
-                  }
+            }
                 },
                 "required": [
                 ]
@@ -1455,11 +1445,6 @@
                 }
               ]
             },
-                "curationDate": {
-                    "description": "The date this evaluation was added into outbreak.info, or was updated in outbreak.info.",
-                    "type": "string",
-                    "format": "date"
-                  },
                 "reviews": {
                   "anyOf": [
                       {
@@ -1477,9 +1462,9 @@
                       
                   ]
                 }
-                },
-            "required": [
-            ]
+              },
+              "required": [
+              ]
           }
         }
       }
@@ -1894,11 +1879,6 @@
               }
             ]
           },
-          "curationDate":{
-            "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
-            "type": "string",
-            "format": "date"
-          },
           "license": {
             "description": "Licensing that applies to this content, typically indicated by URL.",
             "type": "string"
@@ -2242,16 +2222,11 @@
                         "type": "array",
                         "items": {
                           "$ref": "#/definitions/organization"
+                        }
                       }
+                    ]
                 }
-              ]
-            },
-              "curationDate":{
-                    "description": "The date this evaluation was added into outbreak.info, or was updated in outbreak.info.",
-                    "type": "string",
-                    "format": "date"
-                  }
-                },
+              },
               "required": [
               ]
             },
@@ -2295,19 +2270,14 @@
                         "type": "array",
                         "items": {
                           "$ref": "#/definitions/organization"
+                        }
                       }
+                    ]
                 }
-              ]
-            },
-                  "curationDate":{
-                    "description": "The date this evaluation was added into outbreak.info, or was updated in outbreak.info.",
-                    "type": "string",
-                    "format": "date"
-                  }
                 },
                 "required": [
                 ]
-            },
+          },
           "aggregateRatingObject": {
               "description": "A cumulative evaluation of the resource",
               "@type": "AggregateRating",
@@ -2348,11 +2318,6 @@
                 }
               ]
             },
-                "curationDate": {
-                    "description": "The date this evaluation was added into outbreak.info, or was updated in outbreak.info.",
-                    "type": "string",
-                    "format": "date"
-                  },
                 "reviews": {
                   "anyOf": [
                       {
@@ -2770,11 +2735,6 @@
               }
             ]
           },
-          "curationDate":{
-            "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
-            "type": "string",
-            "format": "date"
-          },
           "license": {
             "description": "A license document that applies to this content, typically indicated by URL.",
             "type": "string"
@@ -2912,23 +2872,23 @@
               }
             },
             "baseOrgObject":{
-            "description": "A barebones Organization object to work around recursion issues in DDE",
-            "@type": "outbreak:Organization",
-            "type": "object",
-            "properties": {
-              "name": {
-                "description": "name of the organization",
-                "type": "string"
-              },
-              "alternateName": {
-                "description": "Alternate name or Acronym for the organization.",
-                "type": "string"
-              }
-            },
-            "required": [
-              "name"
-            ]              
-          }, 
+                "description": "A barebones Organization object to work around recursion issues in DDE",
+                "@type": "outbreak:Organization",
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "description": "name of the organization",
+                    "type": "string"
+                  },
+                  "alternateName": {
+                    "description": "Alternate name or Acronym for the organization.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ]              
+            }, 
             "person": {
               "description": "Reusable person definition",
               "@type": "outbreak:Person",
@@ -3079,10 +3039,10 @@
             ]
           },
             "citation": {
-                "description": "A citation object for a resource which is cited by the analysis (ie- is a derivative of the publication) , related to the analysis, or from which the analysis was based on (ie- is derived from).",
-                "@type": "outbreak:CitationObject",
-                "type": "object",
-                "properties": {
+              "description": "A citation object for a resource which is cited by the analysis (ie- is a derivative of the publication) , related to the analysis, or from which the analysis was based on (ie- is derived from).",
+              "@type": "outbreak:CitationObject",
+              "type": "object",
+              "properties": {
                 "name": {
                     "description": "Name of or title of the citation",
                     "type": "string"
@@ -3111,25 +3071,25 @@
                       "CreativeWork"
                       ]
                 },
-              "url": {
-                "description": "The url of the resource cited.",
-                "type": "string",
-                "format": "uri"
-              },
-              "versionDate": {
-                "description": "The version date of the resource used at the time of the creation of the citation as certain resources (protocols, datasets) may change frequently over time.",
-                "type": "string",
-                "format": "date"
-              },
-              "citeText": {
-                "description": "The bibliographic citation for the referenced resource as is provided",
-                "type": "string"
-              },
-              "curationDate":{
-                "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
-                "type": "string",
-                "format": "date"
-              }
+                "url": {
+                  "description": "The url of the resource cited.",
+                  "type": "string",
+                  "format": "uri"
+                },
+                "versionDate": {
+                  "description": "The version date of the resource used at the time of the creation of the citation as certain resources (protocols, datasets) may change frequently over time.",
+                  "type": "string",
+                  "format": "date"
+                },
+                "citeText": {
+                  "description": "The bibliographic citation for the referenced resource as is provided",
+                  "type": "string"
+                },
+                "curationDate":{
+                  "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
+                  "type": "string",
+                  "format": "date"
+                }
             },
             "required": [
               "name",
@@ -3179,12 +3139,7 @@
                       }
                 }
               ]
-            },
-                "curationDate":{
-                    "description": "The date this evaluation was added into outbreak.info, or was updated in outbreak.info.",
-                    "type": "string",
-                    "format": "date"
-                }
+            }
               },
               "required": [
               ]
@@ -3232,12 +3187,7 @@
                       }
                 }
               ]
-            },
-                  "curationDate":{
-                    "description": "The date this evaluation was added into outbreak.info, or was updated in outbreak.info.",
-                    "type": "string",
-                    "format": "date"
-                  }
+            }
                 },
                 "required": [
                 ]
@@ -3282,11 +3232,6 @@
                 }
               ]
             },
-                "curationDate": {
-                    "description": "The date this evaluation was added into outbreak.info, or was updated in outbreak.info.",
-                    "type": "string",
-                    "format": "date"
-                  },
                 "reviews": {
                   "anyOf": [
                       {
@@ -3869,11 +3814,6 @@
               }
             ]
           },
-          "curationDate":{
-            "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
-            "type": "string",
-            "format": "date"
-          },
           "evaluations":{
               "description": "Reviews, Ratings, or other types of evaluations on this resource",
               "anyOf":[
@@ -4301,16 +4241,11 @@
                       }
                 }
               ]
+            }
             },
-              "curationDate":{
-                    "description": "The date this evaluation was added into outbreak.info, or was updated in outbreak.info.",
-                    "type": "string",
-                    "format": "date"
-                  }
-                },
-              "required": [
-              ]
-            },
+            "required": [
+            ]
+          },
           "ratingObject": {
             "description": "A rating or categorical evaluation of the resource",
             "@type": "Rating",
@@ -4354,13 +4289,8 @@
                       }
                 }
               ]
+            }
             },
-                  "curationDate":{
-                    "description": "The date this evaluation was added into outbreak.info, or was updated in outbreak.info.",
-                    "type": "string",
-                    "format": "date"
-                  }
-                },
             "required": [
             ]
           },
@@ -4404,11 +4334,6 @@
                 }
               ]
             },
-                "curationDate": {
-                    "description": "The date this evaluation was added into outbreak.info, or was updated in outbreak.info.",
-                    "type": "string",
-                    "format": "date"
-                  },
                 "reviews": {
                   "anyOf": [
                       {
@@ -6101,11 +6026,6 @@
               }
             ]
           },
-          "curationDate":{
-            "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
-            "type": "string",
-            "format": "date"
-          },
           "evaluations":{
               "description": "Reviews, Ratings, or other types of evaluations on this resource",
               "anyOf":[
@@ -6941,16 +6861,11 @@
                       }
                 }
               ]
+            }
             },
-              "curationDate":{
-                    "description": "The date this evaluation was added into outbreak.info, or was updated in outbreak.info.",
-                    "type": "string",
-                    "format": "date"
-                  }
-                },
-              "required": [
-              ]
-            },
+            "required": [
+            ]
+          },
           "ratingObject": {
             "description": "A rating or categorical evaluation of the resource",
             "@type": "Rating",
@@ -6994,13 +6909,8 @@
                       }
                 }
               ]
+            }
             },
-                  "curationDate":{
-                    "description": "The date this evaluation was added into outbreak.info, or was updated in outbreak.info.",
-                    "type": "string",
-                    "format": "date"
-                  }
-                },
             "required": [
             ]
           },
@@ -7044,29 +6954,13 @@
                 }
               ]
             },
-                "curationDate": {
-                    "description": "The date this evaluation was added into outbreak.info, or was updated in outbreak.info.",
-                    "type": "string",
-                    "format": "date"
-                  },
                 "reviews": {
-                  "oneOf": [
-                      {
-                        "$ref": "#/definitions/reviewObject"
-                      },
+                  "anyOf": [
                       {
                         "type": "array",
                         "items": {
                           "$ref": "#/definitions/reviewObject"
                         }
-                      }
-                      
-                  ]
-                },
-                "ratings": {
-                  "oneOf": [
-                      {
-                        "$ref": "#/definitions/ratingObject"
                       },
                       {
                         "type": "array",
@@ -7077,7 +6971,7 @@
                       
                   ]
                 }
-                },
+            },
             "required": [
             ]
           }
@@ -7585,11 +7479,7 @@
         {"@id": "outbreak:Person"},
         {"@id": "outbreak:Organization"},
         {"@id": "outbreak:CitationObject"},
-        {"@id": "outbreak:Dataset"},
-        {"@id": "outbreak:Publication"},
-        {"@id": "outbreak:Analysis"},
-        {"@id": "outbreak:Protocol"},
-        {"@id": "outbreak:ClinicalTrial"}
+        {"@id": "schema:CreativeWork"}
       ],
       "schema:rangeIncludes": [
         {"@id": "schema:Date"}

--- a/yaml/outbreak.json
+++ b/yaml/outbreak.json
@@ -65,6 +65,11 @@
                 }
               }
             ]
+          },
+          "curationDate":{
+            "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
+            "type": "string",
+            "format": "date"
           }
         },
         "required": [
@@ -168,6 +173,11 @@
                 }
               }
             ]
+          },
+          "curationDate":{
+            "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
+            "type": "string",
+            "format": "date"
           }
         },
         "required": [
@@ -938,7 +948,19 @@
             "vocabulary": {
               "ontology": ["efo", "ncit","obi"],
               "children_of": ["https://www.ebi.ac.uk/efo/EFO_0002694", "http://purl.obolibrary.org/obo/NCIT_C20368",
-                             "http://purl.obolibrary.org/obo/OBI_0000011"]
+                             "http://purl.obolibrary.org/obo/OBI_0000011"],
+              "property": {
+                "name": {
+                  "type" : "string"
+                },
+                "url": {
+                  "type": "string",
+                  "format": "uri"
+                },
+                "identifier": {
+                  "type": "string"
+                }
+              }
             },
             "strict": false
           },
@@ -948,7 +970,19 @@
             "type": "string",
             "vocabulary": {
               "ontology": ["ncbitaxon"],
-              "children_of": ["http://purl.obolibrary.org/obo/NCBITaxon_10239"]
+              "children_of": ["http://purl.obolibrary.org/obo/NCBITaxon_10239"],
+              "property": {
+                "name": {
+                  "type" : "string"
+                },
+                "url": {
+                  "type": "string",
+                  "format": "uri"
+                },
+                "identifier": {
+                  "type": "string"
+                }
+              }
             },
             "strict": false
           },
@@ -958,7 +992,19 @@
             "type": "string",
             "vocabulary": {
               "ontology": ["ncbitaxon"],
-              "children_of": ["http://purl.obolibrary.org/obo/NCBITaxon_131567"]
+              "children_of": ["http://purl.obolibrary.org/obo/NCBITaxon_131567"],
+              "property": {
+                "name": {
+                  "type" : "string"
+                },
+                "url": {
+                  "type": "string",
+                  "format": "uri"
+                },
+                "identifier": {
+                  "type": "string"
+                }
+              }
             },
               "strict": false
           },
@@ -968,7 +1014,19 @@
             "type": "string",
             "vocabulary": {
               "ontology": ["mondo"],
-              "children_of": ["http://purl.obolibrary.org/obo/MONDO_0000001"]
+              "children_of": ["http://purl.obolibrary.org/obo/MONDO_0000001"],
+              "property": {
+                "name": {
+                  "type" : "string"
+                },
+                "url": {
+                  "type": "string",
+                  "format": "uri"
+                },
+                "identifier": {
+                  "type": "string"
+                }
+              }
             },
             "strict": false
           },
@@ -989,7 +1047,19 @@
                   "http://purl.obolibrary.org/obo/cido.owl",
                   "http://purl.obolibrary.org/obo/epo",
                   "https://bioportal.bioontology.org/ontologies/COVID19"
-                ]
+                ],
+                "property": {
+                  "name": {
+                    "type" : "string"
+                  },
+                  "url": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "identifier": {
+                    "type": "string"
+                  }
+                }
               }
           },
           "datadownload": {
@@ -1061,6 +1131,11 @@
                       }
                     }
                   ]
+                },
+                "curationDate":{
+                  "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
+                  "type": "string",
+                  "format": "date"
                 }
               },
               "required": [
@@ -1128,6 +1203,11 @@
                       }
                     }
                   ]
+              },
+              "curationDate":{
+                "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
+                "type": "string",
+                "format": "date"
               }
             },
             "required": [
@@ -1217,6 +1297,11 @@
               "citeText": {
                 "description": "The bibliographic citation for the referenced resource as is provided",
                 "type": "string"
+              },
+              "curationDate":{
+                "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
+                "type": "string",
+                "format": "date"
               }
             },
             "required": [
@@ -1898,6 +1983,11 @@
                       }
                     }
                   ]
+                },
+                "curationDate":{
+                  "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
+                  "type": "string",
+                  "format": "date"
                 }
               },
               "required": [
@@ -1965,6 +2055,11 @@
                       }
                     }
                   ]
+              },
+              "curationDate":{
+                "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
+                "type": "string",
+                "format": "date"
               }
             },
             "required": [
@@ -2095,6 +2190,11 @@
               "citeText": {
                 "description": "The bibliographic citation for the referenced resource as is provided",
                 "type": "string"
+              },
+              "curationDate":{
+                "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
+                "type": "string",
+                "format": "date"
               }
             },
             "required": [
@@ -2726,8 +2826,20 @@
                   "https://bioportal.bioontology.org/ontologies/COVID19",
                   "http://purl.obolibrary.org/obo/cido.owl",
                   "http://purl.obolibrary.org/obo/epo"
-                ]
+                ],
+                "property": {
+                  "name": {
+                    "type" : "string"
+                  },
+                  "url": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "identifier": {
+                    "type": "string"
+                  }
                 }
+              }
             },
             "miscControlledVocabulary": {
               "description": "collection of vocabulary terms defined in ontologies",
@@ -2736,8 +2848,20 @@
               "strict": false,
               "vocabulary": {
                   "ontology": ["ncbitaxon"],
-                  "children_of": ["http://purl.obolibrary.org/obo/NCBITaxon_10239"]
-                }
+                  "children_of": ["http://purl.obolibrary.org/obo/NCBITaxon_10239"],
+                  "property": {
+                    "name": {
+                      "type" : "string"
+                    },
+                    "url": {
+                      "type": "string",
+                      "format": "uri"
+                    },
+                    "identifier": {
+                      "type": "string"
+                    }
+                  }
+              }
             },
             "moreControlledVocabulary": {
               "definition": "collection of vocabulary terms defined in ontologies",
@@ -2750,8 +2874,20 @@
                   ],
                   "children_of": [
                     "http://identifiers.org/mamo/MAMO_0000037"
-                  ]
-                }
+                  ],
+                  "property": {
+                    "name": {
+                      "type" : "string"
+                    },
+                    "url": {
+                      "type": "string",
+                      "format": "uri"
+                    },
+                    "identifier": {
+                      "type": "string"
+                    }
+                  }
+              }
             },
             "diseaseVocabulary": {
               "description": "collection of vocabulary terms defined in ontologies",
@@ -2760,7 +2896,19 @@
               "strict": false,
               "vocabulary": {
                 "ontology": ["mondo"],
-                "children_of": ["http://purl.obolibrary.org/obo/MONDO_0000001"]              
+                "children_of": ["http://purl.obolibrary.org/obo/MONDO_0000001"],
+                "property": {
+                  "name": {
+                    "type" : "string"
+                  },
+                  "url": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "identifier": {
+                    "type": "string"
+                  }
+                }              
               }
             },
             "baseOrgObject":{
@@ -2810,6 +2958,11 @@
                       }
                     }
                   ]
+                },
+                "curationDate":{
+                  "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
+                  "type": "string",
+                  "format": "date"
                 }
               },
               "required": [
@@ -2877,6 +3030,11 @@
                       }
                     }
                   ]
+              },
+              "curationDate":{
+                "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
+                "type": "string",
+                "format": "date"
               }
             },
             "required": [
@@ -2966,6 +3124,11 @@
               "citeText": {
                 "description": "The bibliographic citation for the referenced resource as is provided",
                 "type": "string"
+              },
+              "curationDate":{
+                "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
+                "type": "string",
+                "format": "date"
               }
             },
             "required": [
@@ -3758,7 +3921,19 @@
                   "https://www.ebi.ac.uk/efo/EFO_0002694",
                   "http://purl.obolibrary.org/obo/ECO_0000000",
                   "http://purl.obolibrary.org/obo/OBI_0000011"
-                ]
+                ],
+                "property": {
+                  "name": {
+                    "type" : "string"
+                  },
+                  "url": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "identifier": {
+                    "type": "string"
+                  }
+                }
               }
           },
           "miscControlledVocabulary": {
@@ -3772,7 +3947,19 @@
                 ],
                 "children_of": [
                   "http://purl.obolibrary.org/obo/ECO_0000000"
-                ]
+                ],
+                "property": {
+                  "name": {
+                    "type" : "string"
+                  },
+                  "url": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "identifier": {
+                    "type": "string"
+                  }
+                }
               }
           },
           "product": {
@@ -3893,6 +4080,11 @@
                       }
                     }
                   ]
+                },
+                "curationDate":{
+                  "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
+                  "type": "string",
+                  "format": "date"
                 }
               },
               "required": [
@@ -3960,6 +4152,11 @@
                       }
                     }
                   ]
+              },
+              "curationDate":{
+                "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
+                "type": "string",
+                "format": "date"
               }
             },
             "required": [
@@ -4049,6 +4246,11 @@
               "citeText": {
                 "description": "The bibliographic citation for the referenced resource as is provided",
                 "type": "string"
+              },
+              "curationDate":{
+                "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
+                "type": "string",
+                "format": "date"
               }
             },
             "required": [
@@ -6016,6 +6218,11 @@
                             }
                         }
                     ]
+                },
+                "curationDate":{
+                  "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
+                  "type": "string",
+                  "format": "date"
                 }
               },
               "required": [
@@ -6114,6 +6321,11 @@
                       }
                     }
                   ]
+              },
+              "curationDate":{
+                "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
+                "type": "string",
+                "format": "date"
               }
             },
             "required": [
@@ -6674,6 +6886,11 @@
               "citeText": {
                 "description": "The bibliographic citation for the referenced resource as is provided",
                 "type": "string"
+              },
+              "curationDate":{
+                "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
+                "type": "string",
+                "format": "date"
               }
             },
             "required": [
@@ -7365,6 +7582,9 @@
       "rdfs:comment": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
       "rdfs:label": "curationDate",
       "schema:domainIncludes": [
+        {"@id": "outbreak:Person"},
+        {"@id": "outbreak:Organization"},
+        {"@id": "outbreak:CitationObject"},
         {"@id": "outbreak:Dataset"},
         {"@id": "outbreak:Publication"},
         {"@id": "outbreak:Analysis"},

--- a/yaml/outbreak_Analysis.json
+++ b/yaml/outbreak_Analysis.json
@@ -65,6 +65,11 @@
                 }
               }
             ]
+          },
+          "curationDate":{
+            "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
+            "type": "string",
+            "format": "date"
           }
         },
         "required": [
@@ -168,6 +173,11 @@
                 }
               }
             ]
+          },
+          "curationDate":{
+            "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
+            "type": "string",
+            "format": "date"
           }
         },
         "required": [
@@ -496,6 +506,11 @@
               "SoftwareApplication",
               "CreativeWork"
             ]
+          },
+          "curationDate":{
+            "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
+            "type": "string",
+            "format": "date"
           }
         },
         "required": [
@@ -1036,7 +1051,19 @@
                   "https://bioportal.bioontology.org/ontologies/COVID19",
                   "http://purl.obolibrary.org/obo/cido.owl",
                   "http://purl.obolibrary.org/obo/epo"
-                ]
+                ],
+                  "property": {
+                    "name": {
+                      "type" : "string"
+                    },
+                    "url": {
+                      "type": "string",
+                      "format": "uri"
+                    },
+                    "identifier": {
+                      "type": "string"
+                    }
+                  }
                 }
             },
             "miscControlledVocabulary": {
@@ -1046,8 +1073,20 @@
               "strict": false,
               "vocabulary": {
                   "ontology": ["ncbitaxon"],
-                  "children_of": ["http://purl.obolibrary.org/obo/NCBITaxon_10239"]
-                }
+                  "children_of": ["http://purl.obolibrary.org/obo/NCBITaxon_10239"],
+                  "property": {
+                    "name": {
+                      "type" : "string"
+                    },
+                    "url": {
+                      "type": "string",
+                      "format": "uri"
+                    },
+                    "identifier": {
+                      "type": "string"
+                    }
+                  }
+              }
             },
             "moreControlledVocabulary": {
               "definition": "collection of vocabulary terms defined in ontologies",
@@ -1060,8 +1099,20 @@
                   ],
                   "children_of": [
                     "http://identifiers.org/mamo/MAMO_0000037"
-                  ]
-                }
+                  ],
+                  "property": {
+                    "name": {
+                      "type" : "string"
+                    },
+                    "url": {
+                      "type": "string",
+                      "format": "uri"
+                    },
+                    "identifier": {
+                      "type": "string"
+                    }
+                  }
+              }
             },
             "diseaseVocabulary": {
               "description": "collection of vocabulary terms defined in ontologies",
@@ -1070,7 +1121,19 @@
               "strict": false,
               "vocabulary": {
                 "ontology": ["mondo"],
-                "children_of": ["http://purl.obolibrary.org/obo/MONDO_0000001"]              
+                "children_of": ["http://purl.obolibrary.org/obo/MONDO_0000001"],
+                "property": {
+                  "name": {
+                    "type" : "string"
+                  },
+                  "url": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "identifier": {
+                    "type": "string"
+                  }
+                }              
               }
             },
             "baseOrgObject":{
@@ -1120,6 +1183,11 @@
                       }
                     }
                   ]
+                },
+                "curationDate":{
+                  "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
+                  "type": "string",
+                  "format": "date"
                 }
               },
               "required": [
@@ -1175,23 +1243,28 @@
                   "affiliation": {
                     "$ref": "#/definitions/baseOrgObject"
                   },
-              "members": {
-                 "oneOf": [
-                    {
-                      "$ref": "#/definitions/memberObject"
-                    },
-                    {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/definitions/memberObject"
-                      }
-                    }
-                  ]
-              }
-            },
-            "required": [
-              "name"
-            ]
+                  "members": {
+                     "oneOf": [
+                        {
+                          "$ref": "#/definitions/memberObject"
+                        },
+                        {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/definitions/memberObject"
+                          }
+                        }
+                      ]
+                  },
+                  "curationDate":{
+                    "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
+                    "type": "string",
+                    "format": "date"
+                  }
+                },
+                "required": [
+                  "name"
+                ]
           },
             "funding": {
             "type": "object",
@@ -1276,6 +1349,11 @@
               "citeText": {
                 "description": "The bibliographic citation for the referenced resource as is provided",
                 "type": "string"
+              },
+              "curationDate":{
+                "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
+                "type": "string",
+                "format": "date"
               }
             },
             "required": [
@@ -2753,6 +2831,9 @@
       "rdfs:comment": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
       "rdfs:label": "curationDate",
       "schema:domainIncludes": [
+        {"@id": "outbreak:Person"},
+        {"@id": "outbreak:Organization"},
+        {"@id": "outbreak:CitationObject"},
         {"@id": "outbreak:Dataset"},
         {"@id": "outbreak:Publication"},
         {"@id": "outbreak:Analysis"},

--- a/yaml/outbreak_Analysis.json
+++ b/yaml/outbreak_Analysis.json
@@ -995,11 +995,6 @@
               }
             ]
           },
-          "curationDate":{
-            "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
-            "type": "string",
-            "format": "date"
-          },
           "license": {
             "description": "A license document that applies to this content, typically indicated by URL.",
             "type": "string"
@@ -1401,14 +1396,9 @@
                         "type": "array",
                         "items": {
                           "$ref": "#/definitions/organization"
+                        }
                       }
-                }
-              ]
-            },
-                "curationDate":{
-                    "description": "The date this evaluation was added into outbreak.info, or was updated in outbreak.info.",
-                    "type": "string",
-                    "format": "date"
+                    ]
                 }
               },
               "required": [
@@ -1454,14 +1444,9 @@
                         "type": "array",
                         "items": {
                           "$ref": "#/definitions/organization"
+                        }
                       }
-                }
-              ]
-            },
-                  "curationDate":{
-                    "description": "The date this evaluation was added into outbreak.info, or was updated in outbreak.info.",
-                    "type": "string",
-                    "format": "date"
+                    ]
                   }
                 },
                 "required": [
@@ -1503,15 +1488,10 @@
                         "type": "array",
                         "items": {
                           "$ref": "#/definitions/organization"
+                        }
                       }
-                }
-              ]
-            },
-                "curationDate": {
-                    "description": "The date this evaluation was added into outbreak.info, or was updated in outbreak.info.",
-                    "type": "string",
-                    "format": "date"
-                  },
+                    ]
+                },
                 "reviews": {
                   "anyOf": [
                       {
@@ -2834,11 +2814,7 @@
         {"@id": "outbreak:Person"},
         {"@id": "outbreak:Organization"},
         {"@id": "outbreak:CitationObject"},
-        {"@id": "outbreak:Dataset"},
-        {"@id": "outbreak:Publication"},
-        {"@id": "outbreak:Analysis"},
-        {"@id": "outbreak:Protocol"},
-        {"@id": "outbreak:ClinicalTrial"}
+        {"@id": "schema:CreativeWork"}
       ],
       "schema:rangeIncludes": [
         {"@id": "schema:Date"}

--- a/yaml/outbreak_ClinicalTrial.json
+++ b/yaml/outbreak_ClinicalTrial.json
@@ -3873,7 +3873,7 @@
         {"@id": "outbreak:Person"},
         {"@id": "outbreak:Organization"},
         {"@id": "outbreak:CitationObject"},
-        {"@id": "schema:CreativeWork}
+        {"@id": "schema:CreativeWork"}
       ],
       "schema:rangeIncludes": [
         {"@id": "schema:Date"}

--- a/yaml/outbreak_ClinicalTrial.json
+++ b/yaml/outbreak_ClinicalTrial.json
@@ -2420,11 +2420,6 @@
               }
             ]
           },
-          "curationDate":{
-            "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
-            "type": "string",
-            "format": "date"
-          },
           "evaluations":{
               "description": "Reviews, Ratings, or other types of evaluations on this resource",
               "anyOf":[
@@ -3258,15 +3253,10 @@
                         "items": {
                           "$ref": "#/definitions/organization"
                       }
+                    }
+                  ]
                 }
-              ]
-            },
-              "curationDate":{
-                    "description": "The date this evaluation was added into outbreak.info, or was updated in outbreak.info.",
-                    "type": "string",
-                    "format": "date"
-                  }
-                },
+              },
               "required": [
               ]
             },
@@ -3310,16 +3300,11 @@
                         "type": "array",
                         "items": {
                           "$ref": "#/definitions/organization"
-                      }
+                          }
+                    }
+                  ]
                 }
-              ]
             },
-                  "curationDate":{
-                    "description": "The date this evaluation was added into outbreak.info, or was updated in outbreak.info.",
-                    "type": "string",
-                    "format": "date"
-                  }
-                },
             "required": [
             ]
           },
@@ -3359,33 +3344,17 @@
                         "type": "array",
                         "items": {
                           "$ref": "#/definitions/organization"
-                      }
-                }
-              ]
-            },
-                "curationDate": {
-                    "description": "The date this evaluation was added into outbreak.info, or was updated in outbreak.info.",
-                    "type": "string",
-                    "format": "date"
-                  },
+                          }
+                    }
+                  ]
+                },
                 "reviews": {
-                  "oneOf": [
-                      {
-                        "$ref": "#/definitions/reviewObject"
-                      },
+                  "anyOf": [
                       {
                         "type": "array",
                         "items": {
                           "$ref": "#/definitions/reviewObject"
                         }
-                      }
-                      
-                  ]
-                },
-                "ratings": {
-                  "oneOf": [
-                      {
-                        "$ref": "#/definitions/ratingObject"
                       },
                       {
                         "type": "array",
@@ -3396,7 +3365,7 @@
                       
                   ]
                 }
-                },
+            },
             "required": [
             ]
           }
@@ -3904,11 +3873,7 @@
         {"@id": "outbreak:Person"},
         {"@id": "outbreak:Organization"},
         {"@id": "outbreak:CitationObject"},
-        {"@id": "outbreak:Dataset"},
-        {"@id": "outbreak:Publication"},
-        {"@id": "outbreak:Analysis"},
-        {"@id": "outbreak:Protocol"},
-        {"@id": "outbreak:ClinicalTrial"}
+        {"@id": "schema:CreativeWork}
       ],
       "schema:rangeIncludes": [
         {"@id": "schema:Date"}

--- a/yaml/outbreak_ClinicalTrial.json
+++ b/yaml/outbreak_ClinicalTrial.json
@@ -65,6 +65,11 @@
                 }
               }
             ]
+          },
+          "curationDate":{
+            "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
+            "type": "string",
+            "format": "date"
           }
         },
         "required": [
@@ -168,6 +173,11 @@
                 }
               }
             ]
+          },
+          "curationDate":{
+            "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
+            "type": "string",
+            "format": "date"
           }
         },
         "required": [
@@ -496,6 +506,11 @@
               "SoftwareApplication",
               "CreativeWork"
             ]
+          },
+          "curationDate":{
+            "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
+            "type": "string",
+            "format": "date"
           }
         },
         "required": [
@@ -2522,6 +2537,11 @@
                             }
                         }
                     ]
+                },
+                "curationDate":{
+                  "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
+                  "type": "string",
+                  "format": "date"
                 }
               },
               "required": [
@@ -2620,6 +2640,11 @@
                       }
                     }
                   ]
+              },
+              "curationDate":{
+                "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
+                "type": "string",
+                "format": "date"
               }
             },
             "required": [
@@ -3180,6 +3205,11 @@
               "citeText": {
                 "description": "The bibliographic citation for the referenced resource as is provided",
                 "type": "string"
+              },
+              "curationDate":{
+                "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
+                "type": "string",
+                "format": "date"
               }
             },
             "required": [
@@ -3871,6 +3901,9 @@
       "rdfs:comment": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
       "rdfs:label": "curationDate",
       "schema:domainIncludes": [
+        {"@id": "outbreak:Person"},
+        {"@id": "outbreak:Organization"},
+        {"@id": "outbreak:CitationObject"},
         {"@id": "outbreak:Dataset"},
         {"@id": "outbreak:Publication"},
         {"@id": "outbreak:Analysis"},

--- a/yaml/outbreak_Dataset.json
+++ b/yaml/outbreak_Dataset.json
@@ -530,6 +530,11 @@
               "SoftwareApplication",
               "CreativeWork"
             ]
+          },
+          "curationDate":{
+            "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
+            "type": "string",
+            "format": "date"
           }
         },
         "required": [
@@ -900,11 +905,6 @@
                 }
               }
             ]
-          },
-          "curationDate":{
-            "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
-            "type": "string",
-            "format": "date"
           },
           "license": {
             "description": "A license document that applies to this content, typically indicated by URL.",
@@ -1349,16 +1349,11 @@
                         "type": "array",
                         "items": {
                           "$ref": "#/definitions/organization"
-                      }
+                          }
+                    }
+                  ]
                 }
-              ]
-            },
-              "curationDate":{
-                    "description": "The date this evaluation was added into outbreak.info, or was updated in outbreak.info.",
-                    "type": "string",
-                    "format": "date"
-                  }
-                },
+              },
               "required": [
               ]
             },
@@ -1402,14 +1397,9 @@
                         "type": "array",
                         "items": {
                           "$ref": "#/definitions/organization"
+                          }
                       }
-                }
-              ]
-            },
-                  "curationDate":{
-                    "description": "The date this evaluation was added into outbreak.info, or was updated in outbreak.info.",
-                    "type": "string",
-                    "format": "date"
+                    ]
                   }
                 },
                 "required": [
@@ -1455,11 +1445,6 @@
                 }
               ]
             },
-                "curationDate": {
-                    "description": "The date this evaluation was added into outbreak.info, or was updated in outbreak.info.",
-                    "type": "string",
-                    "format": "date"
-                  },
                 "reviews": {
                   "anyOf": [
                       {
@@ -2879,11 +2864,7 @@
         {"@id": "outbreak:Person"},
         {"@id": "outbreak:Organization"},
         {"@id": "outbreak:CitationObject"},
-        {"@id": "outbreak:Dataset"},
-        {"@id": "outbreak:Publication"},
-        {"@id": "outbreak:Analysis"},
-        {"@id": "outbreak:Protocol"},
-        {"@id": "outbreak:ClinicalTrial"}
+        {"@id": "schema:CreativeWork"}
       ],
       "schema:rangeIncludes": [
         {"@id": "schema:Date"}

--- a/yaml/outbreak_Dataset.json
+++ b/yaml/outbreak_Dataset.json
@@ -938,7 +938,19 @@
             "vocabulary": {
               "ontology": ["efo", "ncit","obi"],
               "children_of": ["https://www.ebi.ac.uk/efo/EFO_0002694", "http://purl.obolibrary.org/obo/NCIT_C20368",
-                             "http://purl.obolibrary.org/obo/OBI_0000011"]
+                             "http://purl.obolibrary.org/obo/OBI_0000011"],
+              "property": {
+                "name": {
+                  "type" : "string"
+                },
+                "url": {
+                  "type": "string",
+                  "format": "uri"
+                },
+                "identifier": {
+                  "type": "string"
+                }
+              }
             },
             "strict": false
           },

--- a/yaml/outbreak_Dataset.json
+++ b/yaml/outbreak_Dataset.json
@@ -65,6 +65,11 @@
                 }
               }
             ]
+          },
+          "curationDate":{
+            "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
+            "type": "string",
+            "format": "date"
           }
         },
         "required": [
@@ -168,6 +173,11 @@
                 }
               }
             ]
+          },
+          "curationDate":{
+            "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
+            "type": "string",
+            "format": "date"
           }
         },
         "required": [
@@ -960,7 +970,19 @@
             "type": "string",
             "vocabulary": {
               "ontology": ["ncbitaxon"],
-              "children_of": ["http://purl.obolibrary.org/obo/NCBITaxon_10239"]
+              "children_of": ["http://purl.obolibrary.org/obo/NCBITaxon_10239"],
+              "property": {
+                "name": {
+                  "type" : "string"
+                },
+                "url": {
+                  "type": "string",
+                  "format": "uri"
+                },
+                "identifier": {
+                  "type": "string"
+                }
+              }
             },
             "strict": false
           },
@@ -970,7 +992,19 @@
             "type": "string",
             "vocabulary": {
               "ontology": ["ncbitaxon"],
-              "children_of": ["http://purl.obolibrary.org/obo/NCBITaxon_131567"]
+              "children_of": ["http://purl.obolibrary.org/obo/NCBITaxon_131567"],
+              "property": {
+                "name": {
+                  "type" : "string"
+                },
+                "url": {
+                  "type": "string",
+                  "format": "uri"
+                },
+                "identifier": {
+                  "type": "string"
+                }
+              }
             },
               "strict": false
           },
@@ -980,7 +1014,19 @@
             "type": "string",
             "vocabulary": {
               "ontology": ["mondo"],
-              "children_of": ["http://purl.obolibrary.org/obo/MONDO_0000001"]
+              "children_of": ["http://purl.obolibrary.org/obo/MONDO_0000001"],
+              "property": {
+                "name": {
+                  "type" : "string"
+                },
+                "url": {
+                  "type": "string",
+                  "format": "uri"
+                },
+                "identifier": {
+                  "type": "string"
+                }
+              }
             },
             "strict": false
           },
@@ -1001,7 +1047,19 @@
                   "http://purl.obolibrary.org/obo/cido.owl",
                   "http://purl.obolibrary.org/obo/epo",
                   "https://bioportal.bioontology.org/ontologies/COVID19"
-                ]
+                ],
+                "property": {
+                  "name": {
+                    "type" : "string"
+                  },
+                  "url": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "identifier": {
+                    "type": "string"
+                  }
+                }
               }
           },
           "datadownload": {
@@ -1073,6 +1131,11 @@
                       }
                     }
                   ]
+                },
+                "curationDate":{
+                  "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
+                  "type": "string",
+                  "format": "date"
                 }
               },
               "required": [
@@ -1140,6 +1203,11 @@
                       }
                     }
                   ]
+              },
+              "curationDate":{
+                "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
+                "type": "string",
+                "format": "date"
               }
             },
             "required": [
@@ -1229,6 +1297,11 @@
               "citeText": {
                 "description": "The bibliographic citation for the referenced resource as is provided",
                 "type": "string"
+              },
+              "curationDate":{
+                "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
+                "type": "string",
+                "format": "date"
               }
             },
             "required": [
@@ -2803,6 +2876,9 @@
       "rdfs:comment": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
       "rdfs:label": "curationDate",
       "schema:domainIncludes": [
+        {"@id": "outbreak:Person"},
+        {"@id": "outbreak:Organization"},
+        {"@id": "outbreak:CitationObject"},
         {"@id": "outbreak:Dataset"},
         {"@id": "outbreak:Publication"},
         {"@id": "outbreak:Analysis"},

--- a/yaml/outbreak_Protocol.json
+++ b/yaml/outbreak_Protocol.json
@@ -1225,11 +1225,6 @@
               }
             ]
           },
-          "curationDate":{
-            "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
-            "type": "string",
-            "format": "date"
-          },
           "evaluations":{
               "description": "Reviews, Ratings, or other types of evaluations on this resource",
               "anyOf":[
@@ -1602,6 +1597,11 @@
               "citeText": {
                 "description": "The bibliographic citation for the referenced resource as is provided",
                 "type": "string"
+              },
+              "curationDate":{
+                "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
+                "type": "string",
+                "format": "date"
               }
             },
             "required": [
@@ -1649,16 +1649,11 @@
                         "type": "array",
                         "items": {
                           "$ref": "#/definitions/organization"
-                      }
+                          }
+                    }
+                  ]
                 }
-              ]
-            },
-              "curationDate":{
-                    "description": "The date this evaluation was added into outbreak.info, or was updated in outbreak.info.",
-                    "type": "string",
-                    "format": "date"
-                  }
-                },
+              },
               "required": [
               ]
             },
@@ -1702,16 +1697,11 @@
                         "type": "array",
                         "items": {
                           "$ref": "#/definitions/organization"
-                      }
+                          }
+                    }
+                  ]
                 }
-              ]
             },
-                  "curationDate":{
-                    "description": "The date this evaluation was added into outbreak.info, or was updated in outbreak.info.",
-                    "type": "string",
-                    "format": "date"
-                  }
-                },
             "required": [
             ]
           },
@@ -1751,15 +1741,10 @@
                         "type": "array",
                         "items": {
                           "$ref": "#/definitions/organization"
-                      }
-                }
-              ]
-            },
-                "curationDate": {
-                    "description": "The date this evaluation was added into outbreak.info, or was updated in outbreak.info.",
-                    "type": "string",
-                    "format": "date"
-                  },
+                          }
+                    }
+                  ]
+                },
                 "reviews": {
                   "anyOf": [
                       {
@@ -2997,11 +2982,7 @@
         {"@id": "outbreak:Person"},
         {"@id": "outbreak:Organization"},
         {"@id": "outbreak:CitationObject"},
-        {"@id": "outbreak:Dataset"},
-        {"@id": "outbreak:Publication"},
-        {"@id": "outbreak:Analysis"},
-        {"@id": "outbreak:Protocol"},
-        {"@id": "outbreak:ClinicalTrial"}
+        {"@id": "schema:CreativeWork"}
       ],
       "schema:rangeIncludes": [
         {"@id": "schema:Date"}

--- a/yaml/outbreak_Protocol.json
+++ b/yaml/outbreak_Protocol.json
@@ -65,6 +65,11 @@
                 }
               }
             ]
+          },
+          "curationDate":{
+            "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
+            "type": "string",
+            "format": "date"
           }
         },
         "required": [
@@ -168,6 +173,11 @@
                 }
               }
             ]
+          },
+          "curationDate":{
+            "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
+            "type": "string",
+            "format": "date"
           }
         },
         "required": [
@@ -496,6 +506,11 @@
               "SoftwareApplication",
               "CreativeWork"
             ]
+          },
+          "curationDate":{
+            "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
+            "type": "string",
+            "format": "date"
           }
         },
         "required": [
@@ -1262,7 +1277,19 @@
                   "https://www.ebi.ac.uk/efo/EFO_0002694",
                   "http://purl.obolibrary.org/obo/ECO_0000000",
                   "http://purl.obolibrary.org/obo/OBI_0000011"
-                ]
+                ],
+                "property": {
+                  "name": {
+                    "type" : "string"
+                  },
+                  "url": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "identifier": {
+                    "type": "string"
+                  }
+                }
               }
           },
           "miscControlledVocabulary": {
@@ -1276,7 +1303,19 @@
                 ],
                 "children_of": [
                   "http://purl.obolibrary.org/obo/ECO_0000000"
-                ]
+                ],
+                "property": {
+                  "name": {
+                    "type" : "string"
+                  },
+                  "url": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "identifier": {
+                    "type": "string"
+                  }
+                }
               }
           },
           "product": {
@@ -1397,7 +1436,12 @@
                       }
                     }
                   ]
-                }
+                },
+              "curationDate":{
+                "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
+                "type": "string",
+                "format": "date"
+              }
               },
               "required": [
                 "name"
@@ -1464,6 +1508,11 @@
                       }
                     }
                   ]
+              },
+              "curationDate":{
+                "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
+                "type": "string",
+                "format": "date"
               }
             },
             "required": [
@@ -2945,6 +2994,9 @@
       "rdfs:comment": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
       "rdfs:label": "curationDate",
       "schema:domainIncludes": [
+        {"@id": "outbreak:Person"},
+        {"@id": "outbreak:Organization"},
+        {"@id": "outbreak:CitationObject"},
         {"@id": "outbreak:Dataset"},
         {"@id": "outbreak:Publication"},
         {"@id": "outbreak:Analysis"},

--- a/yaml/outbreak_Publication.json
+++ b/yaml/outbreak_Publication.json
@@ -980,11 +980,6 @@
               }
             ]
           },
-          "curationDate":{
-            "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
-            "type": "string",
-            "format": "date"
-          },
           "license": {
             "description": "Licensing that applies to this content, typically indicated by URL.",
             "type": "string"
@@ -1328,16 +1323,11 @@
                         "type": "array",
                         "items": {
                           "$ref": "#/definitions/organization"
-                      }
+                          }
+                    }
+                  ]
                 }
-              ]
-            },
-              "curationDate":{
-                    "description": "The date this evaluation was added into outbreak.info, or was updated in outbreak.info.",
-                    "type": "string",
-                    "format": "date"
-                  }
-                },
+              },
               "required": [
               ]
             },
@@ -1381,14 +1371,9 @@
                         "type": "array",
                         "items": {
                           "$ref": "#/definitions/organization"
+                          }
                       }
-                }
-              ]
-            },
-                  "curationDate":{
-                    "description": "The date this evaluation was added into outbreak.info, or was updated in outbreak.info.",
-                    "type": "string",
-                    "format": "date"
+                    ]
                   }
                 },
                 "required": [
@@ -1430,15 +1415,10 @@
                         "type": "array",
                         "items": {
                           "$ref": "#/definitions/organization"
-                      }
-                }
-              ]
-            },
-                "curationDate": {
-                    "description": "The date this evaluation was added into outbreak.info, or was updated in outbreak.info.",
-                    "type": "string",
-                    "format": "date"
-                  },
+                          }
+                    }
+                  ]
+                },
                 "reviews": {
                   "anyOf": [
                       {
@@ -2898,11 +2878,7 @@
         {"@id": "outbreak:Person"},
         {"@id": "outbreak:Organization"},
         {"@id": "outbreak:CitationObject"},
-        {"@id": "outbreak:Dataset"},
-        {"@id": "outbreak:Publication"},
-        {"@id": "outbreak:Analysis"},
-        {"@id": "outbreak:Protocol"},
-        {"@id": "outbreak:ClinicalTrial"}
+        {"@id": "schema:Thing"}
       ],
       "schema:rangeIncludes": [
         {"@id": "schema:Date"}

--- a/yaml/outbreak_Publication.json
+++ b/yaml/outbreak_Publication.json
@@ -65,6 +65,11 @@
                 }
               }
             ]
+          },
+          "curationDate":{
+            "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
+            "type": "string",
+            "format": "date"
           }
         },
         "required": [
@@ -168,6 +173,11 @@
                 }
               }
             ]
+          },
+          "curationDate":{
+            "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
+            "type": "string",
+            "format": "date"
           }
         },
         "required": [
@@ -496,6 +506,11 @@
               "SoftwareApplication",
               "CreativeWork"
             ]
+          },
+          "curationDate":{
+            "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
+            "type": "string",
+            "format": "date"
           }
         },
         "required": [
@@ -1054,6 +1069,11 @@
                       }
                     }
                   ]
+                },
+                "curationDate":{
+                  "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
+                  "type": "string",
+                  "format": "date"
                 }
               },
               "required": [
@@ -1121,6 +1141,11 @@
                       }
                     }
                   ]
+              },
+              "curationDate":{
+                "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
+                "type": "string",
+                "format": "date"
               }
             },
             "required": [
@@ -1251,6 +1276,11 @@
               "citeText": {
                 "description": "The bibliographic citation for the referenced resource as is provided",
                 "type": "string"
+              },
+              "curationDate":{
+                "description": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
+                "type": "string",
+                "format": "date"
               }
             },
             "required": [
@@ -2865,6 +2895,9 @@
       "rdfs:comment": "The date this resource was added into outbreak.info, or was updated in outbreak.info.",
       "rdfs:label": "curationDate",
       "schema:domainIncludes": [
+        {"@id": "outbreak:Person"},
+        {"@id": "outbreak:Organization"},
+        {"@id": "outbreak:CitationObject"},
         {"@id": "outbreak:Dataset"},
         {"@id": "outbreak:Publication"},
         {"@id": "outbreak:Analysis"},


### PR DESCRIPTION
These schema changes include:

- Nesting 'name', 'url', and 'identifier' under 'vocabulary' for any DefinedTerms, so that user's are not asked for these details, but the data can be stored as requested.
- nesting 'curationDate' into CitationObject, Person, or Organization so that the `curatedBy` structure matches how it is actually presented in the data